### PR TITLE
feat(observability): logging, redaction, breadcrumbs, and feedback-report foundation

### DIFF
--- a/packages/core/observability/analysis_options.yaml
+++ b/packages/core/observability/analysis_options.yaml
@@ -1,0 +1,6 @@
+# Static analysis configuration for `package:observability`.
+#
+# Mirrors the sibling core packages (`models`, `interfaces`): the
+# 'recommended' lint set from `package:lints`.
+
+include: package:lints/recommended.yaml

--- a/packages/core/observability/build.yaml
+++ b/packages/core/observability/build.yaml
@@ -1,0 +1,19 @@
+# Build configuration for `package:observability`.
+#
+# `explicit_to_json: true` tells json_serializable to recursively call
+# `.toJson()` on nested objects when serialising a containing class.
+# Without it, a Freezed/json_serializable class with another Freezed
+# class as a field passes the nested object through to the output map
+# *as a Dart instance* rather than a `Map<String, dynamic>`.
+#
+# Affected here: `FeedbackReport` nests a `List<Breadcrumb>`. Without
+# this option, `report.toJson()['breadcrumbs']` would contain
+# `_Breadcrumb` instances instead of maps, silently breaking offline
+# persistence and HTTP bodies. Same rationale (and same setting) as
+# `packages/core/models/build.yaml`.
+targets:
+  $default:
+    builders:
+      json_serializable:
+        options:
+          explicit_to_json: true

--- a/packages/core/observability/lib/observability.dart
+++ b/packages/core/observability/lib/observability.dart
@@ -1,0 +1,19 @@
+/// Observability foundation for Board Games Empire (issue #8):
+/// five-level logging over `package:logging`, shared PII redaction,
+/// breadcrumb capture, and the feedback-report domain mirroring the
+/// backend's FeedbackReport contract.
+library;
+
+export 'src/breadcrumbs/breadcrumb.dart';
+export 'src/breadcrumbs/breadcrumb_buffer.dart';
+export 'src/feedback/feedback_category.dart';
+export 'src/feedback/feedback_constants.dart';
+export 'src/feedback/feedback_context.dart';
+export 'src/feedback/feedback_report.dart';
+export 'src/feedback/feedback_report_preview.dart';
+export 'src/feedback/feedback_service.dart';
+export 'src/feedback/feedback_severity.dart';
+export 'src/logging/bge_log_level.dart';
+export 'src/logging/bge_logger.dart';
+export 'src/logging/context_log_message.dart';
+export 'src/redaction/redaction.dart';

--- a/packages/core/observability/lib/src/breadcrumbs/breadcrumb.dart
+++ b/packages/core/observability/lib/src/breadcrumbs/breadcrumb.dart
@@ -1,0 +1,44 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../logging/bge_log_level.dart';
+
+part 'breadcrumb.freezed.dart';
+part 'breadcrumb.g.dart';
+
+/// A captured log record, sanitised and frozen for inclusion in a
+/// feedback report (issue #8).
+///
+/// Produced by the BreadcrumbBuffer from `LogRecord`s; never constructed
+/// from raw user input. By the time a record becomes a [Breadcrumb] its
+/// [message] has been through email-pattern masking and its
+/// [sanitizedContext] through key-based field redaction — PII can't sneak
+/// into a buffered crumb via a forgotten `info` call.
+///
+/// JSON shape is client-internal (offline persistence of draft reports);
+/// the backend FeedbackReport model has no breadcrumb field yet, so the
+/// transport mapping is decided by the concrete FeedbackService
+/// implementations (separate issue).
+@freezed
+abstract class Breadcrumb with _$Breadcrumb {
+  const factory Breadcrumb({
+    /// When the underlying record was emitted.
+    required DateTime timestamp,
+
+    /// The record's level, collapsed onto the BGE five-level scheme.
+    required BgeLogLevel level,
+
+    /// Hierarchical name of the emitting logger (e.g.
+    /// `bge.storage.sync_queue`).
+    required String loggerName,
+
+    /// The log message, post email-pattern masking.
+    required String message,
+
+    /// The structured context map, post key-based redaction. Null when
+    /// the record carried no context.
+    Map<String, dynamic>? sanitizedContext,
+  }) = _Breadcrumb;
+
+  factory Breadcrumb.fromJson(Map<String, dynamic> json) =>
+      _$BreadcrumbFromJson(json);
+}

--- a/packages/core/observability/lib/src/breadcrumbs/breadcrumb_buffer.dart
+++ b/packages/core/observability/lib/src/breadcrumbs/breadcrumb_buffer.dart
@@ -1,0 +1,122 @@
+import 'dart:async';
+import 'dart:collection';
+
+import 'package:logging/logging.dart';
+
+import '../logging/bge_log_level.dart';
+import '../logging/context_log_message.dart';
+import '../redaction/redaction.dart';
+import 'breadcrumb.dart';
+
+/// Bounded ring buffer of sanitised [Breadcrumb]s captured from
+/// `Logger.root` (issue #8).
+///
+/// When a crash or bug report is assembled, [snapshot] supplies the last
+/// [capacity] log records as context. Sanitisation happens at capture —
+/// not at emit — so local dev consoles keep full fidelity while anything
+/// that could leave the device is scrubbed:
+///
+/// - Messages run through [Redaction.redactEmailsIn].
+/// - Context maps (from [ContextLogMessage] payloads, or a raw `Map`
+///   logged directly) run through [Redaction.redactJsonFields] against
+///   [redactedContextFields].
+/// - Stack traces are NOT buffered: `LogRecord.error` / `stackTrace` stay
+///   on the live record for console handlers. Error text reaches the
+///   buffer only if the caller put it in the message, where the email
+///   masking applies.
+///
+/// Capture is level-gated by `Logger.root.level` like any other root
+/// listener — records filtered out by the root level never reach the
+/// buffer.
+class BreadcrumbBuffer {
+  /// Creates a buffer holding at most [capacity] crumbs.
+  ///
+  /// [redactedContextFields] REPLACES (not extends) the defaults when
+  /// supplied; callers wanting both spread them:
+  /// `{...BreadcrumbBuffer.defaultRedactedContextFields, 'extra'}`.
+  BreadcrumbBuffer({
+    int capacity = defaultCapacity,
+    Set<String> redactedContextFields = defaultRedactedContextFields,
+  }) : assert(capacity > 0, 'capacity must be positive'),
+       _capacity = capacity,
+       _redactedContextFields = Set.unmodifiable(redactedContextFields);
+
+  /// Default ring size per issue #8.
+  static const int defaultCapacity = 100;
+
+  /// Context keys scrubbed by default. Key-based (exact, case-sensitive)
+  /// because context values aren't pattern-scanned — only messages are.
+  static const Set<String> defaultRedactedContextFields = {
+    'accessToken',
+    'apiKey',
+    'authorization',
+    'cookie',
+    'email',
+    'password',
+    'refreshToken',
+    'secret',
+    'sessionToken',
+    'token',
+  };
+
+  final int _capacity;
+  final Set<String> _redactedContextFields;
+  final Queue<Breadcrumb> _buffer = Queue<Breadcrumb>();
+  StreamSubscription<LogRecord>? _subscription;
+
+  /// Maximum number of crumbs retained.
+  int get capacity => _capacity;
+
+  /// Current number of buffered crumbs.
+  int get length => _buffer.length;
+
+  /// Whether the buffer is currently subscribed to `Logger.root`.
+  bool get isAttached => _subscription != null;
+
+  /// Starts capturing from `Logger.root.onRecord`. Idempotent — calling
+  /// while attached is a no-op (no duplicate subscription).
+  void attach() {
+    if (_subscription != null) return;
+    _subscription = Logger.root.onRecord.listen(add);
+  }
+
+  /// Stops capturing. Buffered crumbs are retained; call [clear] to drop
+  /// them.
+  Future<void> detach() async {
+    await _subscription?.cancel();
+    _subscription = null;
+  }
+
+  /// Sanitises [record] into a [Breadcrumb] and appends it, evicting the
+  /// oldest entries beyond [capacity]. Public so tests and synthetic
+  /// capture paths can feed records without going through `Logger.root`.
+  void add(LogRecord record) {
+    _buffer.add(_toBreadcrumb(record));
+    while (_buffer.length > _capacity) {
+      _buffer.removeFirst();
+    }
+  }
+
+  /// A point-in-time, unmodifiable copy of the buffer, oldest first.
+  List<Breadcrumb> snapshot() => List.unmodifiable(_buffer);
+
+  /// Drops all buffered crumbs without detaching.
+  void clear() => _buffer.clear();
+
+  Breadcrumb _toBreadcrumb(LogRecord record) {
+    final context = switch (record.object) {
+      ContextLogMessage(:final context) => context,
+      final Map<String, dynamic> map => map,
+      _ => null,
+    };
+    return Breadcrumb(
+      timestamp: record.time,
+      level: BgeLogLevel.fromLevel(record.level),
+      loggerName: record.loggerName,
+      message: Redaction.redactEmailsIn(record.message),
+      sanitizedContext: context == null
+          ? null
+          : Redaction.redactJsonFields(context, _redactedContextFields),
+    );
+  }
+}

--- a/packages/core/observability/lib/src/breadcrumbs/breadcrumb_buffer.dart
+++ b/packages/core/observability/lib/src/breadcrumbs/breadcrumb_buffer.dart
@@ -104,9 +104,18 @@ class BreadcrumbBuffer {
   void clear() => _buffer.clear();
 
   Breadcrumb _toBreadcrumb(LogRecord record) {
+    // `Map<String, dynamic>` matches any covariant subtype of itself, so
+    // a `Map<String, String>` etc. from a BgeLogger call lands here.
+    // The raw-`Map` fallback covers a record logged directly through
+    // `Logger.root` with a non-String key type — uncommon, but cheap to
+    // defend against rather than silently drop. Same pattern as
+    // `Redaction._redactValue`.
     final context = switch (record.object) {
       ContextLogMessage(:final context) => context,
       final Map<String, dynamic> map => map,
+      final Map<dynamic, dynamic> map => map.map(
+        (key, value) => MapEntry(key.toString(), value),
+      ),
       _ => null,
     };
     return Breadcrumb(

--- a/packages/core/observability/lib/src/breadcrumbs/breadcrumb_buffer.dart
+++ b/packages/core/observability/lib/src/breadcrumbs/breadcrumb_buffer.dart
@@ -103,26 +103,32 @@ class BreadcrumbBuffer {
   /// Drops all buffered crumbs without detaching.
   void clear() => _buffer.clear();
 
+  /// Substituted for [Breadcrumb.message] when a raw `Map` is the log
+  /// payload — `record.message` derives from `map.toString()`, which
+  /// only the email pattern masks. The structured map is still
+  /// captured (and redacted) in [Breadcrumb.sanitizedContext].
+  static const String rawMapMessagePlaceholder = '<context map>';
+
   Breadcrumb _toBreadcrumb(LogRecord record) {
-    // `Map<String, dynamic>` matches any covariant subtype of itself, so
-    // a `Map<String, String>` etc. from a BgeLogger call lands here.
-    // The raw-`Map` fallback covers a record logged directly through
-    // `Logger.root` with a non-String key type — uncommon, but cheap to
-    // defend against rather than silently drop. Same pattern as
-    // `Redaction._redactValue`.
-    final context = switch (record.object) {
-      ContextLogMessage(:final context) => context,
-      final Map<String, dynamic> map => map,
-      final Map<dynamic, dynamic> map => map.map(
-        (key, value) => MapEntry(key.toString(), value),
-      ),
-      _ => null,
-    };
+    final object = record.object;
+    Map<String, dynamic>? context;
+    var rawMapPayload = false;
+    if (object is ContextLogMessage) {
+      context = object.context;
+    } else if (object is Map<String, dynamic>) {
+      context = object;
+      rawMapPayload = true;
+    } else if (object is Map) {
+      context = object.map((key, value) => MapEntry(key.toString(), value));
+      rawMapPayload = true;
+    }
     return Breadcrumb(
       timestamp: record.time,
       level: BgeLogLevel.fromLevel(record.level),
       loggerName: record.loggerName,
-      message: Redaction.redactEmailsIn(record.message),
+      message: rawMapPayload
+          ? rawMapMessagePlaceholder
+          : Redaction.redactEmailsIn(record.message),
       sanitizedContext: context == null
           ? null
           : Redaction.redactJsonFields(context, _redactedContextFields),

--- a/packages/core/observability/lib/src/feedback/_placeholder_remove.dart
+++ b/packages/core/observability/lib/src/feedback/_placeholder_remove.dart
@@ -1,1 +1,0 @@
-import 'breadcrumbs/feedback_imports.dart';

--- a/packages/core/observability/lib/src/feedback/_placeholder_remove.dart
+++ b/packages/core/observability/lib/src/feedback/_placeholder_remove.dart
@@ -1,0 +1,1 @@
+import 'breadcrumbs/feedback_imports.dart';

--- a/packages/core/observability/lib/src/feedback/feedback_category.dart
+++ b/packages/core/observability/lib/src/feedback/feedback_category.dart
@@ -1,0 +1,39 @@
+import 'package:json_annotation/json_annotation.dart';
+
+/// What kind of report this is.
+///
+/// Wire format mirrors the server `FeedbackCategory` enum (PascalCase)
+/// via `@JsonValue` annotations. [fromWire] / [toWire] exist for direct
+/// String<->enum conversion (offline persistence); they MUST agree with
+/// the `@JsonValue` mappings — `feedback_enums_test.dart` guards drift.
+///
+/// [fromWire] is strict: these values are client-authored, so an
+/// unrecognised string indicates corruption rather than a server enum
+/// extension and throws [StateError] (contrast `ContentType`'s lenient
+/// fallback for server-authored payloads).
+///
+/// See: `prisma/models/feedback/feedback-report.prisma` in
+/// `board-games-empire-backend`.
+enum FeedbackCategory {
+  @JsonValue('Bug')
+  bug,
+  @JsonValue('Crash')
+  crash,
+  @JsonValue('FeatureRequest')
+  featureRequest;
+
+  /// Parses a wire-format string. Strict — see class doc.
+  static FeedbackCategory fromWire(String value) => switch (value) {
+    'Bug' => bug,
+    'Crash' => crash,
+    'FeatureRequest' => featureRequest,
+    _ => throw StateError('Unknown FeedbackCategory wire value: $value'),
+  };
+
+  /// The wire-format string for this category.
+  String toWire() => switch (this) {
+    bug => 'Bug',
+    crash => 'Crash',
+    featureRequest => 'FeatureRequest',
+  };
+}

--- a/packages/core/observability/lib/src/feedback/feedback_constants.dart
+++ b/packages/core/observability/lib/src/feedback/feedback_constants.dart
@@ -1,0 +1,34 @@
+/// Client-side mirrors of the backend feedback transport/protocol caps.
+///
+/// Source of truth:
+/// `libs/api/feedback/src/lib/constants/feedback.constants.ts` in
+/// `board-games-empire-backend`. These are compile-time protocol limits
+/// (runtime-tunable policy like retention lives in the backend's
+/// SystemSetting); the client validates against them BEFORE submission so
+/// over-cap reports fail fast and offline-queued reports are never
+/// rejected hours later on sync.
+abstract final class FeedbackConstants {
+  /// 256 KB transport-layer body cap (backend body-parser limit).
+  static const int maxBodyBytes = 256 * 1024;
+
+  /// Field-level cap on `message`.
+  static const int maxMessageLength = 10000;
+
+  /// Field-level cap on `title`.
+  static const int maxTitleLength = 200;
+
+  /// Field-level cap on `appVersion`.
+  static const int maxAppVersionLength = 64;
+
+  /// Field-level cap on `platform`.
+  static const int maxPlatformLength = 32;
+
+  /// Field-level cap on `locale`.
+  static const int maxLocaleLength = 32;
+
+  /// Field-level cap on `correlationKey`.
+  static const int maxCorrelationKeyLength = 128;
+
+  /// Cap on the `userRedactedFields` array length.
+  static const int maxRedactedFields = 64;
+}

--- a/packages/core/observability/lib/src/feedback/feedback_context.dart
+++ b/packages/core/observability/lib/src/feedback/feedback_context.dart
@@ -1,0 +1,32 @@
+import 'package:json_annotation/json_annotation.dart';
+
+/// Client- vs server-side scope of a feedback report. Drives sink
+/// routing on the backend once external drivers exist.
+///
+/// Wire format and strictness rationale as for `FeedbackCategory`.
+///
+/// See: `prisma/models/feedback/feedback-report.prisma` in
+/// `board-games-empire-backend`.
+enum FeedbackContext {
+  @JsonValue('Client')
+  client,
+  @JsonValue('Server')
+  server,
+  @JsonValue('Unknown')
+  unknown;
+
+  /// Parses a wire-format string. Strict — see class doc.
+  static FeedbackContext fromWire(String value) => switch (value) {
+    'Client' => client,
+    'Server' => server,
+    'Unknown' => unknown,
+    _ => throw StateError('Unknown FeedbackContext wire value: $value'),
+  };
+
+  /// The wire-format string for this context.
+  String toWire() => switch (this) {
+    client => 'Client',
+    server => 'Server',
+    unknown => 'Unknown',
+  };
+}

--- a/packages/core/observability/lib/src/feedback/feedback_report.dart
+++ b/packages/core/observability/lib/src/feedback/feedback_report.dart
@@ -40,7 +40,11 @@ abstract class FeedbackReport with _$FeedbackReport {
         'category == FeedbackCategory.bug) || severity != null',
     'severity is required when category is crash or bug',
   )
-  @Assert('message.isNotEmpty', 'message must not be empty')
+  // `message != ""` rather than `message.isNotEmpty`: const constructor
+  // asserts only admit potentially-constant expressions, and property
+  // access on a parameter (`.isNotEmpty`) is not one — `==`/`!=` against
+  // a String literal is.
+  @Assert("message != ''", 'message must not be empty')
   const factory FeedbackReport({
     /// What kind of report this is.
     required FeedbackCategory category,

--- a/packages/core/observability/lib/src/feedback/feedback_report.dart
+++ b/packages/core/observability/lib/src/feedback/feedback_report.dart
@@ -1,0 +1,130 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import '../breadcrumbs/breadcrumb.dart';
+import 'feedback_category.dart';
+import 'feedback_constants.dart';
+import 'feedback_context.dart';
+import 'feedback_severity.dart';
+
+part 'feedback_report.freezed.dart';
+part 'feedback_report.g.dart';
+
+/// A client-assembled feedback report (issue #8; "BugReport" in the
+/// original issue text, renamed to match the backend's generalised
+/// FeedbackReport domain from backend PR #77).
+///
+/// Field set mirrors `CreateFeedbackReportDto`
+/// (`libs/api/feedback/src/lib/dto/create-feedback-report.dto.ts` in
+/// `board-games-empire-backend`) with one client-side extension:
+///
+/// - [breadcrumbs] has NO backend counterpart yet. It serialises here so
+///   offline-queued draft reports persist their context, but the
+///   transport mapping (dedicated DTO field vs embedding) is decided by
+///   the concrete FeedbackService implementations once the backend grows
+///   a breadcrumb field. Noted for backend follow-up.
+///
+/// Invariants enforced at construction (mirroring the DTO's ValidateIf
+/// and IsNotEmpty rules):
+///
+/// - [severity] is required when [category] is [FeedbackCategory.crash]
+///   or [FeedbackCategory.bug]; feature requests carry none.
+/// - [message] must be non-empty.
+///
+/// Length caps are NOT construction-time asserts — a user typing past a
+/// cap is expected input, not a programming error. [validate] reports
+/// cap violations for the submission UI to surface.
+@freezed
+abstract class FeedbackReport with _$FeedbackReport {
+  @Assert(
+    '!(category == FeedbackCategory.crash || '
+        'category == FeedbackCategory.bug) || severity != null',
+    'severity is required when category is crash or bug',
+  )
+  @Assert('message.isNotEmpty', 'message must not be empty')
+  const factory FeedbackReport({
+    /// What kind of report this is.
+    required FeedbackCategory category,
+
+    /// Free-form report body. Capped at
+    /// [FeedbackConstants.maxMessageLength]; see [validate].
+    required String message,
+
+    /// Short title; surfaced as the GitHub issue title when forwarded
+    /// by a backend sink.
+    String? title,
+
+    /// Client- vs server-side scope.
+    @Default(FeedbackContext.unknown) FeedbackContext context,
+
+    /// Severity. Required for crash/bug categories (constructor assert).
+    FeedbackSeverity? severity,
+
+    /// Submitting client app version (e.g. `0.4.1`).
+    String? appVersion,
+
+    /// Submitting platform (e.g. `android`, `macos`, `web`).
+    String? platform,
+
+    /// BCP-47 locale (e.g. `en-US`).
+    String? locale,
+
+    /// Free-form device/environment context. Keys here are user-
+    /// redactable via dot-paths on FeedbackReportPreview.
+    Map<String, dynamic>? deviceInfo,
+
+    /// Idempotency token — unique per (user, report) on the backend, so
+    /// offline-queue retries don't create duplicates.
+    String? correlationKey,
+
+    /// Field paths redacted before submission. Sets
+    /// `redactionApplied=true` server-side.
+    @Default(<String>[]) List<String> userRedactedFields,
+
+    /// Sanitised log trail captured at build time. Client-side
+    /// extension — see class doc.
+    @Default(<Breadcrumb>[]) List<Breadcrumb> breadcrumbs,
+  }) = _FeedbackReport;
+
+  const FeedbackReport._();
+
+  factory FeedbackReport.fromJson(Map<String, dynamic> json) =>
+      _$FeedbackReportFromJson(json);
+
+  /// Checks every backend protocol cap from [FeedbackConstants] and
+  /// returns human-readable violations (empty when submittable). Each
+  /// violation names the offending field, so the submission UI can map
+  /// messages onto inputs.
+  List<String> validate() {
+    final violations = <String>[];
+
+    void cap(String field, String? value, int max) {
+      if (value != null && value.length > max) {
+        violations.add('$field exceeds $max characters (${value.length})');
+      }
+    }
+
+    cap('message', message, FeedbackConstants.maxMessageLength);
+    cap('title', title, FeedbackConstants.maxTitleLength);
+    cap('appVersion', appVersion, FeedbackConstants.maxAppVersionLength);
+    cap('platform', platform, FeedbackConstants.maxPlatformLength);
+    cap('locale', locale, FeedbackConstants.maxLocaleLength);
+    cap(
+      'correlationKey',
+      correlationKey,
+      FeedbackConstants.maxCorrelationKeyLength,
+    );
+
+    if (userRedactedFields.length > FeedbackConstants.maxRedactedFields) {
+      violations.add(
+        'userRedactedFields exceeds '
+        '${FeedbackConstants.maxRedactedFields} entries '
+        '(${userRedactedFields.length})',
+      );
+    }
+
+    return violations;
+  }
+
+  /// Whether [validate] reports no violations.
+  bool get isValid => validate().isEmpty;
+}

--- a/packages/core/observability/lib/src/feedback/feedback_report.dart
+++ b/packages/core/observability/lib/src/feedback/feedback_report.dart
@@ -101,6 +101,25 @@ abstract class FeedbackReport with _$FeedbackReport {
   List<String> validate() {
     final violations = <String>[];
 
+    // The constructor asserts re-stated as runtime checks: asserts are
+    // stripped in release builds, so an invalid report — e.g. a
+    // corrupted offline-persisted draft rehydrated via [fromJson] —
+    // can exist there. Re-checking here lets submit() implementations
+    // reject it reliably in every build mode. (Under `dart test`
+    // asserts are active, so these branches are unreachable in the
+    // suite — the construction-time AssertionError specs cover the
+    // debug path.)
+    if (message.isEmpty) {
+      violations.add('message must not be empty');
+    }
+    if ((category == FeedbackCategory.crash ||
+            category == FeedbackCategory.bug) &&
+        severity == null) {
+      violations.add(
+        'severity is required when category is ${category.toWire()}',
+      );
+    }
+
     void cap(String field, String? value, int max) {
       if (value != null && value.length > max) {
         violations.add('$field exceeds $max characters (${value.length})');

--- a/packages/core/observability/lib/src/feedback/feedback_report_preview.dart
+++ b/packages/core/observability/lib/src/feedback/feedback_report_preview.dart
@@ -105,8 +105,8 @@ abstract class FeedbackReportPreview with _$FeedbackReportPreview {
 
   /// The report's JSON with this preview's redactions visibly applied —
   /// what the consent screen renders. Only non-null values are marked;
-  /// a redacted-but-absent field stays absent rather than gaining a
-  /// phantom marker.
+  /// a redacted-but-absent (or null) field stays absent rather than
+  /// gaining a phantom marker.
   Map<String, dynamic> displayJson() {
     final out = {...report.toJson()};
     // Lazily cloned once on the first deviceInfo.<key> redaction, then
@@ -121,7 +121,7 @@ abstract class FeedbackReportPreview with _$FeedbackReportPreview {
         };
         if (device == null) continue;
         final key = path.substring(deviceInfoPrefix.length);
-        if (device.containsKey(key)) {
+        if (device[key] != null) {
           device[key] = redactedMarker;
         }
       } else if (out[path] != null) {
@@ -143,6 +143,10 @@ abstract class FeedbackReportPreview with _$FeedbackReportPreview {
   /// [FeedbackReport.userRedactedFields] so the backend sets
   /// `redactionApplied`. The report's own `userRedactedFields` is NOT
   /// unioned in — see the "Seeding from a persisted draft" class doc.
+  ///
+  /// Null values aren't marked (matches `displayJson`'s non-null rule):
+  /// a redacted-but-null field stays null rather than gaining a phantom
+  /// marker.
   ///
   /// Returns [report] unchanged when both the preview's set and the
   /// report's own `userRedactedFields` are empty.
@@ -168,7 +172,7 @@ abstract class FeedbackReportPreview with _$FeedbackReportPreview {
       deviceInfo = {...deviceInfo};
       for (final path in devicePaths) {
         final key = path.substring(deviceInfoPrefix.length);
-        if (deviceInfo.containsKey(key)) {
+        if (deviceInfo[key] != null) {
           deviceInfo[key] = redactedMarker;
         }
       }

--- a/packages/core/observability/lib/src/feedback/feedback_report_preview.dart
+++ b/packages/core/observability/lib/src/feedback/feedback_report_preview.dart
@@ -84,18 +84,27 @@ abstract class FeedbackReportPreview with _$FeedbackReportPreview {
   /// phantom marker.
   Map<String, dynamic> displayJson() {
     final out = {...report.toJson()};
+    // Lazily cloned once on the first deviceInfo.<key> redaction, then
+    // mutated in place — re-spreading the map per redacted key would
+    // allocate a fresh copy for every path.
+    Map<String, dynamic>? device;
     for (final path in userRedactedFields) {
       if (path.startsWith(deviceInfoPrefix)) {
-        final device = out['deviceInfo'];
-        if (device is Map<String, dynamic>) {
-          final key = path.substring(deviceInfoPrefix.length);
-          if (device.containsKey(key)) {
-            out['deviceInfo'] = {...device, key: redactedMarker};
-          }
+        device ??= switch (out['deviceInfo']) {
+          final Map<String, dynamic> map => {...map},
+          _ => null,
+        };
+        if (device == null) continue;
+        final key = path.substring(deviceInfoPrefix.length);
+        if (device.containsKey(key)) {
+          device[key] = redactedMarker;
         }
       } else if (out[path] != null) {
         out[path] = redactedMarker;
       }
+    }
+    if (device != null) {
+      out['deviceInfo'] = device;
     }
     return out;
   }

--- a/packages/core/observability/lib/src/feedback/feedback_report_preview.dart
+++ b/packages/core/observability/lib/src/feedback/feedback_report_preview.dart
@@ -131,6 +131,9 @@ abstract class FeedbackReportPreview with _$FeedbackReportPreview {
     if (device != null) {
       out['deviceInfo'] = device;
     }
+    // Preview's set is authoritative; the report's own list (carried in
+    // by report.toJson()) would otherwise diverge from toSubmittableReport().
+    out['userRedactedFields'] = userRedactedFields.toList()..sort();
     return out;
   }
 

--- a/packages/core/observability/lib/src/feedback/feedback_report_preview.dart
+++ b/packages/core/observability/lib/src/feedback/feedback_report_preview.dart
@@ -22,6 +22,16 @@ part 'feedback_report_preview.freezed.dart';
 /// are already sanitised at capture; per-crumb redaction is a future
 /// UI-layer concern, not part of this model.
 ///
+/// ## Seeding from a persisted draft
+///
+/// The bare constructor's [userRedactedFields] defaults to the empty
+/// set, NOT the report's — it's an explicit-set entry point.
+/// [FeedbackReportPreview.fromReport] is the right call for the common
+/// case (previewing a draft whose own `userRedactedFields` already
+/// carries prior marks): it seeds the preview's set from the report so
+/// [unredactField] can toggle those off and [toSubmittableReport]
+/// reflects the final intent.
+///
 /// The preview is immutable: [redactField] / [unredactField] return new
 /// instances, so the consent screen can treat it as ordinary bloc state.
 @freezed
@@ -31,10 +41,25 @@ abstract class FeedbackReportPreview with _$FeedbackReportPreview {
     required FeedbackReport report,
 
     /// Field paths the user has redacted in this preview session.
-    /// Merged with any paths already on [FeedbackReport.userRedactedFields]
-    /// at submission time.
+    /// THIS is the authoritative final set used by
+    /// [toSubmittableReport]; the report's own `userRedactedFields`
+    /// is NOT unioned in at submit time. Seed via
+    /// [FeedbackReportPreview.fromReport] when previewing a draft
+    /// whose paths should be carried forward.
     @Default(<String>{}) Set<String> userRedactedFields,
   }) = _FeedbackReportPreview;
+
+  /// Creates a preview seeded with the redactions already on [report].
+  ///
+  /// Equivalent to passing `userRedactedFields: {...report.userRedactedFields}`
+  /// — the named factory exists so call sites that preview a persisted
+  /// draft read at a glance, and so callers can't accidentally drop
+  /// prior marks by forgetting to seed manually.
+  factory FeedbackReportPreview.fromReport(FeedbackReport report) =>
+      FeedbackReportPreview(
+        report: report,
+        userRedactedFields: {...report.userRedactedFields},
+      );
 
   const FeedbackReportPreview._();
 
@@ -111,14 +136,21 @@ abstract class FeedbackReportPreview with _$FeedbackReportPreview {
 
   /// Materialises the preview into the report that should actually be
   /// submitted: redacted values replaced with [redactedMarker], and the
-  /// redacted paths merged (sorted) into
+  /// preview's sorted [userRedactedFields] copied into
   /// [FeedbackReport.userRedactedFields] so the backend sets
-  /// `redactionApplied`.
+  /// `redactionApplied`. The report's own `userRedactedFields` is NOT
+  /// unioned in — see the "Seeding from a persisted draft" class doc.
   ///
-  /// With no preview-session redactions the underlying report is
-  /// returned as-is.
+  /// Returns [report] unchanged when both the preview's set and the
+  /// report's own `userRedactedFields` are empty.
   FeedbackReport toSubmittableReport() {
-    if (userRedactedFields.isEmpty) return report;
+    // Early-out only when the preview AND the report both carry no
+    // marks — otherwise the preview's set is the authoritative final
+    // intent (incl. an explicit "unredact everything" override), so
+    // we re-materialise even when our own set is empty.
+    if (userRedactedFields.isEmpty && report.userRedactedFields.isEmpty) {
+      return report;
+    }
 
     String? maskIf(String field, String? value) =>
         userRedactedFields.contains(field) && value != null
@@ -139,9 +171,10 @@ abstract class FeedbackReportPreview with _$FeedbackReportPreview {
       }
     }
 
-    final mergedPaths =
-        {...report.userRedactedFields, ...userRedactedFields}.toList()..sort();
-
+    // The preview's set IS the final intent — no union with
+    // `report.userRedactedFields`. Seeding (when desired) happens
+    // upfront via [FeedbackReportPreview.fromReport], which lets
+    // [unredactField] genuinely toggle a seeded path off.
     return report.copyWith(
       title: maskIf('title', report.title),
       message: userRedactedFields.contains('message')
@@ -151,7 +184,7 @@ abstract class FeedbackReportPreview with _$FeedbackReportPreview {
       platform: maskIf('platform', report.platform),
       locale: maskIf('locale', report.locale),
       deviceInfo: deviceInfo,
-      userRedactedFields: mergedPaths,
+      userRedactedFields: userRedactedFields.toList()..sort(),
     );
   }
 }

--- a/packages/core/observability/lib/src/feedback/feedback_report_preview.dart
+++ b/packages/core/observability/lib/src/feedback/feedback_report_preview.dart
@@ -1,0 +1,148 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+import 'feedback_report.dart';
+
+part 'feedback_report_preview.freezed.dart';
+
+/// The consent-screen model for a [FeedbackReport] (issue #8): shows the
+/// user exactly what would be submitted and lets them redact additional
+/// fields before sending.
+///
+/// Redacted fields are visibly marked with [redactedMarker] rather than
+/// removed — the reviewer (and the backend triager) can see that a value
+/// existed and was withheld, which is materially different from the value
+/// never having been collected.
+///
+/// ## What is redactable
+///
+/// Only string-valued payload fields and `deviceInfo.<key>` dot-paths
+/// (see [redactableTopLevelFields]). Structural fields — category,
+/// severity, context — are not: a `<redacted>` enum can't round-trip,
+/// and stripping them would make the report untriageable. Breadcrumbs
+/// are already sanitised at capture; per-crumb redaction is a future
+/// UI-layer concern, not part of this model.
+///
+/// The preview is immutable: [redactField] / [unredactField] return new
+/// instances, so the consent screen can treat it as ordinary bloc state.
+@freezed
+abstract class FeedbackReportPreview with _$FeedbackReportPreview {
+  const factory FeedbackReportPreview({
+    /// The underlying report being previewed.
+    required FeedbackReport report,
+
+    /// Field paths the user has redacted in this preview session.
+    /// Merged with any paths already on [FeedbackReport.userRedactedFields]
+    /// at submission time.
+    @Default(<String>{}) Set<String> userRedactedFields,
+  }) = _FeedbackReportPreview;
+
+  const FeedbackReportPreview._();
+
+  /// Marker substituted for redacted values. Matches
+  /// `Redaction.defaultReplacement` by convention.
+  static const String redactedMarker = '<redacted>';
+
+  /// Top-level fields the user may redact. String-valued payload fields
+  /// only — see class doc for why structural fields are excluded.
+  static const Set<String> redactableTopLevelFields = {
+    'title',
+    'message',
+    'appVersion',
+    'platform',
+    'locale',
+  };
+
+  /// Prefix for `deviceInfo` key dot-paths (e.g. `deviceInfo.model`).
+  static const String deviceInfoPrefix = 'deviceInfo.';
+
+  /// Whether [path] is a field the user may redact.
+  bool isRedactable(String path) =>
+      redactableTopLevelFields.contains(path) ||
+      (path.startsWith(deviceInfoPrefix) &&
+          path.length > deviceInfoPrefix.length);
+
+  /// Returns a new preview with [path] redacted.
+  ///
+  /// Throws [ArgumentError] when [path] is not redactable — the consent
+  /// UI should only offer redaction affordances for [isRedactable]
+  /// fields, so a bad path here is a programming error worth surfacing.
+  FeedbackReportPreview redactField(String path) {
+    if (!isRedactable(path)) {
+      throw ArgumentError.value(path, 'path', 'not a redactable field');
+    }
+    return copyWith(userRedactedFields: {...userRedactedFields, path});
+  }
+
+  /// Returns a new preview with [path] no longer redacted. Unknown paths
+  /// are a no-op.
+  FeedbackReportPreview unredactField(String path) =>
+      copyWith(userRedactedFields: {...userRedactedFields}..remove(path));
+
+  /// The report's JSON with this preview's redactions visibly applied —
+  /// what the consent screen renders. Only non-null values are marked;
+  /// a redacted-but-absent field stays absent rather than gaining a
+  /// phantom marker.
+  Map<String, dynamic> displayJson() {
+    final out = {...report.toJson()};
+    for (final path in userRedactedFields) {
+      if (path.startsWith(deviceInfoPrefix)) {
+        final device = out['deviceInfo'];
+        if (device is Map<String, dynamic>) {
+          final key = path.substring(deviceInfoPrefix.length);
+          if (device.containsKey(key)) {
+            out['deviceInfo'] = {...device, key: redactedMarker};
+          }
+        }
+      } else if (out[path] != null) {
+        out[path] = redactedMarker;
+      }
+    }
+    return out;
+  }
+
+  /// Materialises the preview into the report that should actually be
+  /// submitted: redacted values replaced with [redactedMarker], and the
+  /// redacted paths merged (sorted) into
+  /// [FeedbackReport.userRedactedFields] so the backend sets
+  /// `redactionApplied`.
+  ///
+  /// With no preview-session redactions the underlying report is
+  /// returned as-is.
+  FeedbackReport toSubmittableReport() {
+    if (userRedactedFields.isEmpty) return report;
+
+    String? maskIf(String field, String? value) =>
+        userRedactedFields.contains(field) && value != null
+        ? redactedMarker
+        : value;
+
+    var deviceInfo = report.deviceInfo;
+    final devicePaths = userRedactedFields
+        .where((path) => path.startsWith(deviceInfoPrefix))
+        .toList();
+    if (deviceInfo != null && devicePaths.isNotEmpty) {
+      deviceInfo = {...deviceInfo};
+      for (final path in devicePaths) {
+        final key = path.substring(deviceInfoPrefix.length);
+        if (deviceInfo.containsKey(key)) {
+          deviceInfo[key] = redactedMarker;
+        }
+      }
+    }
+
+    final mergedPaths =
+        {...report.userRedactedFields, ...userRedactedFields}.toList()..sort();
+
+    return report.copyWith(
+      title: maskIf('title', report.title),
+      message: userRedactedFields.contains('message')
+          ? redactedMarker
+          : report.message,
+      appVersion: maskIf('appVersion', report.appVersion),
+      platform: maskIf('platform', report.platform),
+      locale: maskIf('locale', report.locale),
+      deviceInfo: deviceInfo,
+      userRedactedFields: mergedPaths,
+    );
+  }
+}

--- a/packages/core/observability/lib/src/feedback/feedback_service.dart
+++ b/packages/core/observability/lib/src/feedback/feedback_service.dart
@@ -67,5 +67,7 @@ class FeedbackSubmissionException implements Exception {
   final Object? cause;
 
   @override
-  String toString() => 'FeedbackSubmissionException: $message';
+  String toString() => cause == null
+      ? 'FeedbackSubmissionException: $message'
+      : 'FeedbackSubmissionException: $message (cause: $cause)';
 }

--- a/packages/core/observability/lib/src/feedback/feedback_service.dart
+++ b/packages/core/observability/lib/src/feedback/feedback_service.dart
@@ -1,0 +1,71 @@
+import 'feedback_category.dart';
+import 'feedback_report.dart';
+import 'feedback_severity.dart';
+
+/// Assembles and submits [FeedbackReport]s (issue #8; "BugReportService"
+/// in the original issue text, renamed alongside the model to match the
+/// backend's generalised feedback domain).
+///
+/// Interface only — concrete implementations (network submission via the
+/// DioFactory stack, offline queueing, the always-available local-file
+/// sink) are a separate issue. The contract below is what those
+/// implementations must honour.
+abstract class FeedbackService {
+  /// Composes a submittable [FeedbackReport] from the pieces a caller
+  /// has at hand when something goes wrong.
+  ///
+  /// Implementations are responsible for:
+  ///
+  /// - **Message composition**: weaving [errorMessage], [stackTrace],
+  ///   and [userComment] into [FeedbackReport.message] (truncating
+  ///   against the protocol caps as needed — the stack trace is the
+  ///   piece to trim first, tail-preserved, since the throw site is at
+  ///   the top).
+  /// - **Environment stamping**: filling `appVersion`, `platform`,
+  ///   `locale`, and `deviceInfo` from platform info providers.
+  /// - **Context capture**: snapshotting the BreadcrumbBuffer into
+  ///   [FeedbackReport.breadcrumbs] at build time — not at submit time,
+  ///   which for an offline-queued report could be hours later with the
+  ///   relevant crumbs long since evicted.
+  ///
+  /// [severity] must be supplied when [category] is crash or bug
+  /// (constructor assert on the model).
+  ///
+  /// [correlationKey] is the idempotency token for the offline queue;
+  /// implementations should generate one (cuid2, matching the repo's id
+  /// convention) when the caller doesn't supply it.
+  FeedbackReport buildReport({
+    required FeedbackCategory category,
+    FeedbackSeverity? severity,
+    String? title,
+    String? errorMessage,
+    String? stackTrace,
+    String? userComment,
+    String? correlationKey,
+  });
+
+  /// Submits [report] to the active server's feedback endpoint.
+  ///
+  /// Implementations should run [FeedbackReport.validate] first and
+  /// throw [FeedbackSubmissionException] on violations rather than
+  /// letting the backend reject the payload. Network-layer failures
+  /// surface as [FeedbackSubmissionException] with the underlying error
+  /// as [FeedbackSubmissionException.cause]; offline-queueing
+  /// implementations resolve once the report is durably enqueued.
+  Future<void> submit(FeedbackReport report);
+}
+
+/// Thrown by [FeedbackService.submit] when a report cannot be submitted
+/// (validation failure, transport failure, or queue persistence failure).
+class FeedbackSubmissionException implements Exception {
+  const FeedbackSubmissionException(this.message, {this.cause});
+
+  /// Human-readable description of the failure.
+  final String message;
+
+  /// The underlying error, when one exists (e.g. a DioException).
+  final Object? cause;
+
+  @override
+  String toString() => 'FeedbackSubmissionException: $message';
+}

--- a/packages/core/observability/lib/src/feedback/feedback_severity.dart
+++ b/packages/core/observability/lib/src/feedback/feedback_severity.dart
@@ -1,0 +1,37 @@
+import 'package:json_annotation/json_annotation.dart';
+
+/// Severity of a feedback report. Required (backend-validated, and
+/// constructor-asserted client-side on `FeedbackReport`) when the
+/// category is `Bug` or `Crash`; not applicable to feature requests.
+///
+/// Wire format and strictness rationale as for `FeedbackCategory`.
+///
+/// See: `prisma/models/feedback/feedback-report.prisma` in
+/// `board-games-empire-backend`.
+enum FeedbackSeverity {
+  @JsonValue('Low')
+  low,
+  @JsonValue('Medium')
+  medium,
+  @JsonValue('High')
+  high,
+  @JsonValue('Critical')
+  critical;
+
+  /// Parses a wire-format string. Strict — see class doc.
+  static FeedbackSeverity fromWire(String value) => switch (value) {
+    'Low' => low,
+    'Medium' => medium,
+    'High' => high,
+    'Critical' => critical,
+    _ => throw StateError('Unknown FeedbackSeverity wire value: $value'),
+  };
+
+  /// The wire-format string for this severity.
+  String toWire() => switch (this) {
+    low => 'Low',
+    medium => 'Medium',
+    high => 'High',
+    critical => 'Critical',
+  };
+}

--- a/packages/core/observability/lib/src/logging/bge_log_level.dart
+++ b/packages/core/observability/lib/src/logging/bge_log_level.dart
@@ -1,0 +1,77 @@
+import 'package:json_annotation/json_annotation.dart';
+import 'package:logging/logging.dart';
+
+/// The five-level BGE logging scheme, collapsed from `package:logging`'s
+/// java.util.logging-style defaults (issue #8 design):
+///
+/// | BGE       | package:logging |
+/// |-----------|-----------------|
+/// | [verbose] | FINEST (300)    |
+/// | [debug]   | FINE (500)      |
+/// | [info]    | INFO (800)      |
+/// | [warn]    | WARNING (900)   |
+/// | [error]   | SEVERE (1000)   |
+///
+/// Mapping back from arbitrary [Level]s (including FINER, CONFIG, SHOUT,
+/// and custom values) is threshold-based via [fromLevel]: a record maps to
+/// the highest BGE level whose underlying value it meets.
+///
+/// The wire form (used when a [Level] is persisted inside a Breadcrumb) is
+/// the camelCase enum name. Unlike the feedback enums, this is a
+/// client-internal shape with no server counterpart, so camelCase rather
+/// than the backend's PascalCase convention. [fromWire] is strict: these
+/// strings are client-authored, so an unrecognised value indicates
+/// corruption and throws [StateError] rather than coercing.
+enum BgeLogLevel {
+  @JsonValue('verbose')
+  verbose,
+  @JsonValue('debug')
+  debug,
+  @JsonValue('info')
+  info,
+  @JsonValue('warn')
+  warn,
+  @JsonValue('error')
+  error;
+
+  /// The `package:logging` [Level] this BGE level emits at.
+  Level get level => switch (this) {
+    verbose => Level.FINEST,
+    debug => Level.FINE,
+    info => Level.INFO,
+    warn => Level.WARNING,
+    error => Level.SEVERE,
+  };
+
+  /// Collapses any `package:logging` [Level] onto the five-level scheme
+  /// by numeric threshold.
+  static BgeLogLevel fromLevel(Level level) {
+    if (level.value >= Level.SEVERE.value) return error;
+    if (level.value >= Level.WARNING.value) return warn;
+    if (level.value >= Level.INFO.value) return info;
+    if (level.value >= Level.FINE.value) return debug;
+    return verbose;
+  }
+
+  /// Parses a wire-format string. Strict: unknown values throw
+  /// [StateError] (see class doc).
+  static BgeLogLevel fromWire(String value) => switch (value) {
+    'verbose' => verbose,
+    'debug' => debug,
+    'info' => info,
+    'warn' => warn,
+    'error' => error,
+    _ => throw StateError('Unknown BgeLogLevel wire value: $value'),
+  };
+
+  /// The wire-format string for this level. MUST agree with the
+  /// `@JsonValue` annotations; a test in `bge_log_level_test.dart`
+  /// guards against drift.
+  String toWire() => switch (this) {
+    verbose => 'verbose',
+    debug => 'debug',
+    info => 'info',
+    warn => 'warn',
+    error => 'error',
+  };
+}

--- a/packages/core/observability/lib/src/logging/bge_logger.dart
+++ b/packages/core/observability/lib/src/logging/bge_logger.dart
@@ -1,0 +1,92 @@
+import 'package:logging/logging.dart';
+
+import 'bge_log_level.dart';
+import 'context_log_message.dart';
+
+/// Thin wrapper around `package:logging`'s [Logger] exposing the BGE
+/// five-level scheme (issue #8).
+///
+/// ## Naming
+///
+/// Logger names are hierarchical and align with package structure:
+/// `bge.storage.sync_queue`, `bge.network.dio`, `bge.auth.bloc`, etc.
+/// `package:logging` canonicalises by name, so two `BgeLogger`s with the
+/// same name share the same underlying logger.
+///
+/// ## Configuration
+///
+/// Level filtering and sink wiring are app-shell concerns: each app's
+/// `main.dart` sets `Logger.root.level` and attaches its platform sink
+/// (Logcat on Android, stdout/rotating file on macOS, console on web) to
+/// `Logger.root.onRecord`. This package only emits.
+///
+/// ## Context
+///
+/// Every method takes an optional `context` map. Non-empty contexts are
+/// wrapped in [ContextLogMessage] so structured consumers (the
+/// BreadcrumbBuffer, future JSON sinks) can read them off
+/// `LogRecord.object`, while `LogRecord.message` stays the plain text.
+/// Context values are NOT redacted here — see [ContextLogMessage] for the
+/// capture-time sanitisation rationale.
+class BgeLogger {
+  /// Creates (or retrieves) the logger named [name].
+  BgeLogger(String name) : _logger = Logger(name);
+
+  final Logger _logger;
+
+  /// The hierarchical logger name.
+  String get name => _logger.fullName;
+
+  /// Logs at [BgeLogLevel.verbose] (≈ FINEST). High-volume tracing.
+  void verbose(
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+    Map<String, dynamic>? context,
+  }) => _log(BgeLogLevel.verbose, message, error, stackTrace, context);
+
+  /// Logs at [BgeLogLevel.debug] (≈ FINE). Developer diagnostics.
+  void debug(
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+    Map<String, dynamic>? context,
+  }) => _log(BgeLogLevel.debug, message, error, stackTrace, context);
+
+  /// Logs at [BgeLogLevel.info]. Notable application events.
+  void info(
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+    Map<String, dynamic>? context,
+  }) => _log(BgeLogLevel.info, message, error, stackTrace, context);
+
+  /// Logs at [BgeLogLevel.warn] (= WARNING). Recoverable problems.
+  void warn(
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+    Map<String, dynamic>? context,
+  }) => _log(BgeLogLevel.warn, message, error, stackTrace, context);
+
+  /// Logs at [BgeLogLevel.error] (≈ SEVERE). Failures needing attention.
+  void error(
+    String message, {
+    Object? error,
+    StackTrace? stackTrace,
+    Map<String, dynamic>? context,
+  }) => _log(BgeLogLevel.error, message, error, stackTrace, context);
+
+  void _log(
+    BgeLogLevel level,
+    String message,
+    Object? error,
+    StackTrace? stackTrace,
+    Map<String, dynamic>? context,
+  ) {
+    final Object payload = (context == null || context.isEmpty)
+        ? message
+        : ContextLogMessage(message, context);
+    _logger.log(level.level, payload, error, stackTrace);
+  }
+}

--- a/packages/core/observability/lib/src/logging/context_log_message.dart
+++ b/packages/core/observability/lib/src/logging/context_log_message.dart
@@ -1,0 +1,27 @@
+/// Structured log payload: a plain message plus a context map.
+///
+/// [BgeLogger] wraps `(message, context)` pairs in this class before
+/// handing them to `package:logging`, which stores non-String payloads on
+/// `LogRecord.object` while deriving `LogRecord.message` from [toString].
+///
+/// [toString] deliberately returns [text] alone: handlers that only print
+/// `record.message` (Logcat bridges, stdout formatters, test matchers)
+/// behave exactly as if a plain String had been logged, while structured
+/// consumers — the BreadcrumbBuffer's sanitised-context capture, future
+/// JSON sinks — read [context] off `record.object`.
+final class ContextLogMessage {
+  const ContextLogMessage(this.text, this.context);
+
+  /// The human-readable log line.
+  final String text;
+
+  /// Structured key/value context attached to the line.
+  ///
+  /// NOT redacted at this layer — sanitisation happens at capture time
+  /// (BreadcrumbBuffer) so that local dev consoles keep full fidelity
+  /// while anything buffered for potential submission is scrubbed.
+  final Map<String, dynamic> context;
+
+  @override
+  String toString() => text;
+}

--- a/packages/core/observability/lib/src/redaction/redaction.dart
+++ b/packages/core/observability/lib/src/redaction/redaction.dart
@@ -1,0 +1,149 @@
+/// Shared redaction utilities (issue #8).
+///
+/// Promoted from the helpers formerly private to
+/// `packages/features/auth/lib/src/bloc/auth_event.dart` so that any code
+/// needing to redact before logging — event `toString`s, the
+/// BreadcrumbBuffer, future analytics sinks — has one consistent place to
+/// reach. [redactName] and [redactEmail] are behaviour-identical to the
+/// originals; `redaction_test.dart` pins the exact output shapes.
+///
+/// ## Threat-model caveat
+///
+/// Partial redaction is incidental-exposure mitigation, not strong
+/// anonymisation. The patterns are deterministic so debug readers can
+/// correlate events for the same user, which equally means a determined
+/// attacker combining multiple lines with external context can narrow
+/// identity for short values. Deployments needing GDPR-grade anonymisation
+/// should mask fully or suppress at the sink layer.
+abstract final class Redaction {
+  /// The replacement string used by [redactJsonFields] by default, and the
+  /// conventional marker for "a value was here and was removed".
+  static const String defaultReplacement = '<redacted>';
+
+  static final RegExp _emailPattern = RegExp(
+    r'[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}',
+  );
+
+  /// Partial name redaction.
+  ///
+  /// - empty → empty
+  /// - 1–2 chars → all `*`
+  /// - 3+ chars → first + `*` × (length − 2) + last
+  ///
+  /// Examples: `John` → `J**n`; `Bob` → `B*b`; `Al` → `**`; `X` → `*`.
+  static String redactName(String name) => maskMiddle(name);
+
+  /// Partial email redaction.
+  ///
+  /// Splits the local part on `.`, applies [redactName] to each segment,
+  /// rejoins, and preserves the domain intact — the domain is useful debug
+  /// context (gmail vs corporate vs SSO) and isn't uniquely identifying
+  /// without the local part. Strings without `@` are treated as a name.
+  ///
+  /// Examples: `john.doe@email.com` → `j**n.d*e@email.com`;
+  /// `alice@example.com` → `a***e@example.com`; `j@gmail.com` →
+  /// `*@gmail.com`.
+  static String redactEmail(String email) {
+    final atIndex = email.indexOf('@');
+    if (atIndex < 0) return redactName(email);
+    final local = email.substring(0, atIndex);
+    final domain = email.substring(atIndex);
+    // Empty segments (consecutive/leading/trailing dots) map to '' via
+    // redactName's empty branch, preserving the local part's shape.
+    final maskedLocal = local.split('.').map(redactName).join('.');
+    return '$maskedLocal$domain';
+  }
+
+  /// Masks every email-shaped token embedded in [text] via [redactEmail].
+  ///
+  /// Used by the BreadcrumbBuffer to sanitise log messages: a forgotten
+  /// `info('failed for $email')` can't leak a full address into a buffered
+  /// breadcrumb. Returns [text] itself (same instance) when no email is
+  /// present.
+  static String redactEmailsIn(String text) {
+    if (!_emailPattern.hasMatch(text)) return text;
+    return text.replaceAllMapped(
+      _emailPattern,
+      (match) => redactEmail(match[0]!),
+    );
+  }
+
+  /// Generic middle-mask: keeps [keepStart] leading and [keepEnd] trailing
+  /// characters, masks the rest with [maskChar]. Inputs no longer than
+  /// `keepStart + keepEnd` are fully masked — keeping both ends of a
+  /// too-short value would reveal it entirely.
+  static String maskMiddle(
+    String input, {
+    int keepStart = 1,
+    int keepEnd = 1,
+    String maskChar = '*',
+  }) {
+    assert(keepStart >= 0, 'keepStart must be >= 0');
+    assert(keepEnd >= 0, 'keepEnd must be >= 0');
+    if (input.length <= keepStart + keepEnd) {
+      return maskChar * input.length;
+    }
+    final masked = maskChar * (input.length - keepStart - keepEnd);
+    return '${input.substring(0, keepStart)}'
+        '$masked'
+        '${input.substring(input.length - keepEnd)}';
+  }
+
+  /// Caps [input] at [maxLength] total characters, replacing the overflow
+  /// tail with [ellipsis]. Inputs within the cap are returned unchanged
+  /// (same instance).
+  static String truncate(String input, int maxLength, {String ellipsis = '…'}) {
+    assert(
+      maxLength >= ellipsis.length,
+      'maxLength must fit the ellipsis itself',
+    );
+    if (input.length <= maxLength) return input;
+    return '${input.substring(0, maxLength - ellipsis.length)}$ellipsis';
+  }
+
+  /// Returns a copy of [json] with every key in [fields] replaced by
+  /// [replacement]. With [recursive] (the default), nested maps — including
+  /// maps inside lists — are scrubbed too. Matching is exact and
+  /// case-sensitive. The input map is never mutated.
+  static Map<String, dynamic> redactJsonFields(
+    Map<String, dynamic> json,
+    Set<String> fields, {
+    String replacement = defaultReplacement,
+    bool recursive = true,
+  }) {
+    final out = <String, dynamic>{};
+    json.forEach((key, value) {
+      if (fields.contains(key)) {
+        out[key] = replacement;
+      } else {
+        out[key] = recursive ? _redactValue(value, fields, replacement) : value;
+      }
+    });
+    return out;
+  }
+
+  static dynamic _redactValue(
+    dynamic value,
+    Set<String> fields,
+    String replacement,
+  ) {
+    if (value is Map<String, dynamic>) {
+      return redactJsonFields(value, fields, replacement: replacement);
+    }
+    if (value is Map) {
+      // Non-String-keyed maps shouldn't appear in JSON-shaped data, but
+      // degrade gracefully by stringifying keys rather than throwing.
+      return redactJsonFields(
+        value.map((key, nested) => MapEntry(key.toString(), nested)),
+        fields,
+        replacement: replacement,
+      );
+    }
+    if (value is List) {
+      return value
+          .map((element) => _redactValue(element, fields, replacement))
+          .toList();
+    }
+    return value;
+  }
+}

--- a/packages/core/observability/lib/src/redaction/redaction.dart
+++ b/packages/core/observability/lib/src/redaction/redaction.dart
@@ -73,11 +73,12 @@ abstract final class Redaction {
   /// `keepStart + keepEnd` are fully masked — keeping both ends of a
   /// too-short value would reveal it entirely.
   ///
-  /// Throws [ArgumentError] when [keepStart] or [keepEnd] is negative.
-  /// Runtime checks rather than asserts: this is a public redaction
-  /// utility, and in a release build (asserts stripped) a negative
-  /// value would otherwise surface as a cryptic substring [RangeError]
-  /// far from the bad call site.
+  /// Throws [ArgumentError] when [keepStart] or [keepEnd] is negative,
+  /// or when [maskChar] is empty (an empty mask would leave the input
+  /// effectively unmasked). Runtime checks rather than asserts: this is
+  /// a public redaction utility, and in a release build (asserts
+  /// stripped) a bad argument would otherwise surface as a cryptic
+  /// downstream error — or, in the case of an empty mask, silently leak.
   static String maskMiddle(
     String input, {
     int keepStart = 1,
@@ -89,6 +90,9 @@ abstract final class Redaction {
     }
     if (keepEnd < 0) {
       throw ArgumentError.value(keepEnd, 'keepEnd', 'must be >= 0');
+    }
+    if (maskChar.isEmpty) {
+      throw ArgumentError.value(maskChar, 'maskChar', 'must not be empty');
     }
     if (input.length <= keepStart + keepEnd) {
       return maskChar * input.length;

--- a/packages/core/observability/lib/src/redaction/redaction.dart
+++ b/packages/core/observability/lib/src/redaction/redaction.dart
@@ -72,14 +72,24 @@ abstract final class Redaction {
   /// characters, masks the rest with [maskChar]. Inputs no longer than
   /// `keepStart + keepEnd` are fully masked — keeping both ends of a
   /// too-short value would reveal it entirely.
+  ///
+  /// Throws [ArgumentError] when [keepStart] or [keepEnd] is negative.
+  /// Runtime checks rather than asserts: this is a public redaction
+  /// utility, and in a release build (asserts stripped) a negative
+  /// value would otherwise surface as a cryptic substring [RangeError]
+  /// far from the bad call site.
   static String maskMiddle(
     String input, {
     int keepStart = 1,
     int keepEnd = 1,
     String maskChar = '*',
   }) {
-    assert(keepStart >= 0, 'keepStart must be >= 0');
-    assert(keepEnd >= 0, 'keepEnd must be >= 0');
+    if (keepStart < 0) {
+      throw ArgumentError.value(keepStart, 'keepStart', 'must be >= 0');
+    }
+    if (keepEnd < 0) {
+      throw ArgumentError.value(keepEnd, 'keepEnd', 'must be >= 0');
+    }
     if (input.length <= keepStart + keepEnd) {
       return maskChar * input.length;
     }
@@ -92,11 +102,18 @@ abstract final class Redaction {
   /// Caps [input] at [maxLength] total characters, replacing the overflow
   /// tail with [ellipsis]. Inputs within the cap are returned unchanged
   /// (same instance).
+  ///
+  /// Throws [ArgumentError] when [maxLength] can't fit [ellipsis] —
+  /// runtime check rather than assert, for the same release-build
+  /// rationale as [maskMiddle].
   static String truncate(String input, int maxLength, {String ellipsis = '…'}) {
-    assert(
-      maxLength >= ellipsis.length,
-      'maxLength must fit the ellipsis itself',
-    );
+    if (maxLength < ellipsis.length) {
+      throw ArgumentError.value(
+        maxLength,
+        'maxLength',
+        'must be >= the ellipsis length (${ellipsis.length})',
+      );
+    }
     if (input.length <= maxLength) return input;
     return '${input.substring(0, maxLength - ellipsis.length)}$ellipsis';
   }

--- a/packages/core/observability/pubspec.yaml
+++ b/packages/core/observability/pubspec.yaml
@@ -1,0 +1,20 @@
+name: observability
+description: "Logging, redaction, breadcrumbs, and feedback-report foundation"
+publish_to: none
+
+environment:
+  sdk: ">=3.9.0 <4.0.0"
+resolution: workspace
+
+dependencies:
+  freezed_annotation: ^3.1.0
+  json_annotation: ^4.9.0
+  logging: ^1.3.0
+
+dev_dependencies:
+  build_runner: ^2.4.12
+  freezed: ^3.0.6
+  json_serializable: ^6.8.0
+  lints: ^6.1.0
+  test: ^1.25.6
+  very_good_analysis: ^10.2.0

--- a/packages/core/observability/test/breadcrumbs/breadcrumb_buffer_test.dart
+++ b/packages/core/observability/test/breadcrumbs/breadcrumb_buffer_test.dart
@@ -171,6 +171,30 @@ void main() {
       BgeLogger('bge.test.noctx').info('plain');
       expect(buffer.snapshot().single.sanitizedContext, isNull);
     });
+
+    test('raw Map payload uses a placeholder message, not toString()', () {
+      final buffer = BreadcrumbBuffer(capacity: 5)..attach();
+      addTearDown(buffer.detach);
+      Logger('bge.test.rawmap').log(
+        Level.INFO,
+        <String, dynamic>{'password': 'hunter2', 'note': 'visible'},
+      );
+      final crumb = buffer.snapshot().single;
+      expect(crumb.message, BreadcrumbBuffer.rawMapMessagePlaceholder);
+      expect(crumb.sanitizedContext, {
+        'password': '<redacted>',
+        'note': 'visible',
+      });
+    });
+
+    test('non-String-keyed Map payload is stringified and placeheld', () {
+      final buffer = BreadcrumbBuffer(capacity: 5)..attach();
+      addTearDown(buffer.detach);
+      Logger('bge.test.weirdkey').log(Level.INFO, <int, String>{1: 'a'});
+      final crumb = buffer.snapshot().single;
+      expect(crumb.message, BreadcrumbBuffer.rawMapMessagePlaceholder);
+      expect(crumb.sanitizedContext, {'1': 'a'});
+    });
   });
 
   group('Breadcrumb JSON', () {

--- a/packages/core/observability/test/breadcrumbs/breadcrumb_buffer_test.dart
+++ b/packages/core/observability/test/breadcrumbs/breadcrumb_buffer_test.dart
@@ -1,0 +1,198 @@
+import 'package:logging/logging.dart';
+import 'package:observability/observability.dart';
+import 'package:test/test.dart';
+
+void main() {
+  setUp(() {
+    Logger.root.level = Level.ALL;
+  });
+
+  tearDown(() {
+    Logger.root.level = Level.INFO;
+  });
+
+  group('BreadcrumbBuffer ring semantics', () {
+    test('capacity must be positive', () {
+      expect(() => BreadcrumbBuffer(capacity: 0), throwsA(isA<AssertionError>()));
+    });
+
+    test('captures records in order up to capacity', () {
+      final buffer = BreadcrumbBuffer(capacity: 5)..attach();
+      addTearDown(buffer.detach);
+      final logger = BgeLogger('bge.test.order');
+      logger
+        ..info('one')
+        ..info('two')
+        ..info('three');
+      expect(buffer.length, 3);
+      expect(buffer.snapshot().map((b) => b.message).toList(), [
+        'one',
+        'two',
+        'three',
+      ]);
+    });
+
+    test('evicts oldest entries beyond capacity', () {
+      final buffer = BreadcrumbBuffer(capacity: 3)..attach();
+      addTearDown(buffer.detach);
+      final logger = BgeLogger('bge.test.evict');
+      for (var i = 1; i <= 5; i++) {
+        logger.info('msg $i');
+      }
+      expect(buffer.length, 3);
+      expect(buffer.snapshot().map((b) => b.message).toList(), [
+        'msg 3',
+        'msg 4',
+        'msg 5',
+      ]);
+    });
+
+    test('clear empties the buffer without detaching', () {
+      final buffer = BreadcrumbBuffer(capacity: 3)..attach();
+      addTearDown(buffer.detach);
+      final logger = BgeLogger('bge.test.clear');
+      logger.info('before');
+      buffer.clear();
+      expect(buffer.length, 0);
+      logger.info('after');
+      expect(buffer.snapshot().single.message, 'after');
+    });
+
+    test('snapshot is an unmodifiable copy', () {
+      final buffer = BreadcrumbBuffer(capacity: 3)..attach();
+      addTearDown(buffer.detach);
+      BgeLogger('bge.test.snapshot').info('only');
+      final snap = buffer.snapshot();
+      expect(() => snap.clear(), throwsUnsupportedError);
+      // A later record does not retroactively appear in the old snapshot.
+      BgeLogger('bge.test.snapshot').info('later');
+      expect(snap, hasLength(1));
+    });
+  });
+
+  group('BreadcrumbBuffer attach/detach', () {
+    test('records are not captured before attach or after detach', () async {
+      final buffer = BreadcrumbBuffer(capacity: 5);
+      final logger = BgeLogger('bge.test.lifecycle');
+      logger.info('pre-attach');
+      expect(buffer.length, 0);
+
+      buffer.attach();
+      logger.info('attached');
+      expect(buffer.length, 1);
+
+      await buffer.detach();
+      logger.info('post-detach');
+      expect(buffer.length, 1);
+    });
+
+    test('attach is idempotent (no double capture)', () {
+      final buffer = BreadcrumbBuffer(capacity: 5)
+        ..attach()
+        ..attach();
+      addTearDown(buffer.detach);
+      BgeLogger('bge.test.idempotent').info('once');
+      expect(buffer.length, 1);
+    });
+  });
+
+  group('BreadcrumbBuffer record mapping', () {
+    test('captures timestamp, level, and logger name', () {
+      final buffer = BreadcrumbBuffer(capacity: 5)..attach();
+      addTearDown(buffer.detach);
+      final before = DateTime.now();
+      BgeLogger('bge.test.mapping').warn('careful');
+      final crumb = buffer.snapshot().single;
+      expect(crumb.level, BgeLogLevel.warn);
+      expect(crumb.loggerName, 'bge.test.mapping');
+      expect(
+        crumb.timestamp.isBefore(before.subtract(const Duration(seconds: 5))),
+        isFalse,
+      );
+    });
+
+    test('masks emails embedded in the message', () {
+      final buffer = BreadcrumbBuffer(capacity: 5)..attach();
+      addTearDown(buffer.detach);
+      BgeLogger('bge.test.pii').info('sign-in failed for john.doe@email.com');
+      expect(
+        buffer.snapshot().single.message,
+        'sign-in failed for j**n.d*e@email.com',
+      );
+    });
+
+    test('sanitizes default-redacted keys from a context map', () {
+      final buffer = BreadcrumbBuffer(capacity: 5)..attach();
+      addTearDown(buffer.detach);
+      BgeLogger('bge.test.ctx').info(
+        'auth attempt',
+        context: {'password': 'hunter2', 'attempt': 2},
+      );
+      final crumb = buffer.snapshot().single;
+      expect(crumb.sanitizedContext, {
+        'password': '<redacted>',
+        'attempt': 2,
+      });
+    });
+
+    test('sanitizes nested context maps', () {
+      final buffer = BreadcrumbBuffer(capacity: 5)..attach();
+      addTearDown(buffer.detach);
+      BgeLogger('bge.test.nested').info(
+        'request',
+        context: {
+          'headers': {'authorization': 'Bearer abc', 'accept': 'json'},
+        },
+      );
+      expect(buffer.snapshot().single.sanitizedContext, {
+        'headers': {'authorization': '<redacted>', 'accept': 'json'},
+      });
+    });
+
+    test('custom redactedContextFields override the defaults', () {
+      final buffer = BreadcrumbBuffer(
+        capacity: 5,
+        redactedContextFields: {'shoeSize'},
+      )..attach();
+      addTearDown(buffer.detach);
+      BgeLogger('bge.test.custom').info(
+        'profile',
+        context: {'shoeSize': 44, 'password': 'visible-now'},
+      );
+      expect(buffer.snapshot().single.sanitizedContext, {
+        'shoeSize': '<redacted>',
+        'password': 'visible-now',
+      });
+    });
+
+    test('records without context have a null sanitizedContext', () {
+      final buffer = BreadcrumbBuffer(capacity: 5)..attach();
+      addTearDown(buffer.detach);
+      BgeLogger('bge.test.noctx').info('plain');
+      expect(buffer.snapshot().single.sanitizedContext, isNull);
+    });
+  });
+
+  group('Breadcrumb JSON', () {
+    test('round-trips through toJson/fromJson', () {
+      final crumb = Breadcrumb(
+        timestamp: DateTime.utc(2026, 6, 12, 10, 30),
+        level: BgeLogLevel.debug,
+        loggerName: 'bge.test.json',
+        message: 'hello',
+        sanitizedContext: const {'k': 'v'},
+      );
+      expect(Breadcrumb.fromJson(crumb.toJson()), crumb);
+    });
+
+    test('level serialises to its camelCase wire string', () {
+      final crumb = Breadcrumb(
+        timestamp: DateTime.utc(2026),
+        level: BgeLogLevel.warn,
+        loggerName: 'bge.test.wire',
+        message: 'm',
+      );
+      expect(crumb.toJson()['level'], 'warn');
+    });
+  });
+}

--- a/packages/core/observability/test/feedback/feedback_enums_test.dart
+++ b/packages/core/observability/test/feedback/feedback_enums_test.dart
@@ -1,0 +1,86 @@
+import 'package:observability/observability.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FeedbackCategory wire helpers', () {
+    const expectations = {
+      FeedbackCategory.bug: 'Bug',
+      FeedbackCategory.crash: 'Crash',
+      FeedbackCategory.featureRequest: 'FeatureRequest',
+    };
+
+    test('toWire covers every variant with the PascalCase server string', () {
+      expect(expectations.keys.toSet(), FeedbackCategory.values.toSet());
+      expectations.forEach((category, wire) {
+        expect(category.toWire(), wire);
+      });
+    });
+
+    test('fromWire parses every wire string', () {
+      expectations.forEach((category, wire) {
+        expect(FeedbackCategory.fromWire(wire), category);
+      });
+    });
+
+    test('round-trip', () {
+      for (final category in FeedbackCategory.values) {
+        expect(FeedbackCategory.fromWire(category.toWire()), category);
+      }
+    });
+
+    test('fromWire throws on an unrecognised value', () {
+      expect(() => FeedbackCategory.fromWire('Praise'), throwsStateError);
+    });
+  });
+
+  group('FeedbackContext wire helpers', () {
+    const expectations = {
+      FeedbackContext.client: 'Client',
+      FeedbackContext.server: 'Server',
+      FeedbackContext.unknown: 'Unknown',
+    };
+
+    test('toWire covers every variant', () {
+      expect(expectations.keys.toSet(), FeedbackContext.values.toSet());
+      expectations.forEach((context, wire) {
+        expect(context.toWire(), wire);
+      });
+    });
+
+    test('round-trip', () {
+      for (final context in FeedbackContext.values) {
+        expect(FeedbackContext.fromWire(context.toWire()), context);
+      }
+    });
+
+    test('fromWire throws on an unrecognised value', () {
+      expect(() => FeedbackContext.fromWire('Edge'), throwsStateError);
+    });
+  });
+
+  group('FeedbackSeverity wire helpers', () {
+    const expectations = {
+      FeedbackSeverity.low: 'Low',
+      FeedbackSeverity.medium: 'Medium',
+      FeedbackSeverity.high: 'High',
+      FeedbackSeverity.critical: 'Critical',
+    };
+
+    test('toWire covers every variant', () {
+      expect(expectations.keys.toSet(), FeedbackSeverity.values.toSet());
+      expectations.forEach((severity, wire) {
+        expect(severity.toWire(), wire);
+      });
+    });
+
+    test('round-trip', () {
+      for (final severity in FeedbackSeverity.values) {
+        expect(FeedbackSeverity.fromWire(severity.toWire()), severity);
+      }
+    });
+
+    test('fromWire throws on an unrecognised value', () {
+      expect(() => FeedbackSeverity.fromWire('Blocker'), throwsStateError);
+    });
+  });
+}

--- a/packages/core/observability/test/feedback/feedback_report_preview_test.dart
+++ b/packages/core/observability/test/feedback/feedback_report_preview_test.dart
@@ -1,0 +1,131 @@
+import 'package:observability/observability.dart';
+import 'package:test/test.dart';
+
+FeedbackReport _report() => FeedbackReport(
+  category: FeedbackCategory.bug,
+  severity: FeedbackSeverity.high,
+  message: 'crash on add-to-collection',
+  title: 'Add crash',
+  appVersion: '0.1.0',
+  platform: 'android',
+  locale: 'en-US',
+  deviceInfo: const {'model': 'Pixel 9', 'osVersion': '16'},
+);
+
+void main() {
+  group('FeedbackReportPreview.isRedactable', () {
+    test('accepts the redactable top-level string fields', () {
+      final preview = FeedbackReportPreview(report: _report());
+      for (final field in const [
+        'title',
+        'message',
+        'appVersion',
+        'platform',
+        'locale',
+      ]) {
+        expect(preview.isRedactable(field), isTrue, reason: field);
+      }
+    });
+
+    test('accepts deviceInfo dot-paths', () {
+      final preview = FeedbackReportPreview(report: _report());
+      expect(preview.isRedactable('deviceInfo.model'), isTrue);
+    });
+
+    test('rejects structural and unknown fields', () {
+      final preview = FeedbackReportPreview(report: _report());
+      expect(preview.isRedactable('category'), isFalse);
+      expect(preview.isRedactable('severity'), isFalse);
+      expect(preview.isRedactable('breadcrumbs'), isFalse);
+      expect(preview.isRedactable('deviceInfo.'), isFalse);
+      expect(preview.isRedactable('nonsense'), isFalse);
+    });
+  });
+
+  group('redactField / unredactField', () {
+    test('redactField records the path immutably', () {
+      final preview = FeedbackReportPreview(report: _report());
+      final redacted = preview.redactField('platform');
+      expect(redacted.userRedactedFields, {'platform'});
+      expect(preview.userRedactedFields, isEmpty);
+    });
+
+    test('redactField throws on a non-redactable path', () {
+      final preview = FeedbackReportPreview(report: _report());
+      expect(() => preview.redactField('category'), throwsArgumentError);
+    });
+
+    test('unredactField removes a previously redacted path', () {
+      final preview = FeedbackReportPreview(
+        report: _report(),
+      ).redactField('platform').redactField('locale').unredactField('platform');
+      expect(preview.userRedactedFields, {'locale'});
+    });
+  });
+
+  group('displayJson', () {
+    test('marks redacted fields visibly instead of removing them', () {
+      final json = FeedbackReportPreview(report: _report())
+          .redactField('platform')
+          .redactField('deviceInfo.model')
+          .displayJson();
+      expect(json['platform'], FeedbackReportPreview.redactedMarker);
+      expect(
+        (json['deviceInfo'] as Map<String, dynamic>)['model'],
+        FeedbackReportPreview.redactedMarker,
+      );
+      // Untouched fields stay visible.
+      expect(json['title'], 'Add crash');
+      expect((json['deviceInfo'] as Map<String, dynamic>)['osVersion'], '16');
+    });
+  });
+
+  group('toSubmittableReport', () {
+    test('replaces redacted values and carries the paths', () {
+      final submittable = FeedbackReportPreview(report: _report())
+          .redactField('locale')
+          .redactField('deviceInfo.model')
+          .toSubmittableReport();
+      expect(submittable.locale, FeedbackReportPreview.redactedMarker);
+      expect(
+        submittable.deviceInfo!['model'],
+        FeedbackReportPreview.redactedMarker,
+      );
+      expect(submittable.deviceInfo!['osVersion'], '16');
+      expect(
+        submittable.userRedactedFields,
+        containsAll(['locale', 'deviceInfo.model']),
+      );
+    });
+
+    test('merges with paths already on the underlying report', () {
+      final report = _report().copyWith(userRedactedFields: ['title']);
+      final submittable = FeedbackReportPreview(
+        report: report,
+      ).redactField('platform').toSubmittableReport();
+      expect(
+        submittable.userRedactedFields.toSet(),
+        {'title', 'platform'},
+      );
+    });
+
+    test('no user redactions returns an equivalent report', () {
+      final report = _report();
+      final submittable = FeedbackReportPreview(
+        report: report,
+      ).toSubmittableReport();
+      expect(submittable, report);
+    });
+
+    test('redacting a null field leaves it null', () {
+      final report = FeedbackReport(
+        category: FeedbackCategory.featureRequest,
+        message: 'm',
+      );
+      final submittable = FeedbackReportPreview(
+        report: report,
+      ).redactField('title').toSubmittableReport();
+      expect(submittable.title, isNull);
+    });
+  });
+}

--- a/packages/core/observability/test/feedback/feedback_report_preview_test.dart
+++ b/packages/core/observability/test/feedback/feedback_report_preview_test.dart
@@ -89,6 +89,20 @@ void main() {
         expect(json['userRedactedFields'], equals(['platform']));
       },
     );
+
+    test('null deviceInfo key is not marked', () {
+      final report = FeedbackReport(
+        category: FeedbackCategory.featureRequest,
+        message: 'm',
+        deviceInfo: const {'model': null, 'osVersion': '16'},
+      );
+      final json = FeedbackReportPreview(report: report)
+          .redactField('deviceInfo.model')
+          .displayJson();
+      final device = json['deviceInfo'] as Map<String, dynamic>;
+      expect(device['model'], isNull);
+      expect(device['osVersion'], '16');
+    });
   });
 
   group('toSubmittableReport', () {
@@ -160,6 +174,19 @@ void main() {
         report: report,
       ).redactField('title').toSubmittableReport();
       expect(submittable.title, isNull);
+    });
+
+    test('redacting a null deviceInfo key leaves it null', () {
+      final report = FeedbackReport(
+        category: FeedbackCategory.featureRequest,
+        message: 'm',
+        deviceInfo: const {'model': null, 'osVersion': '16'},
+      );
+      final submittable = FeedbackReportPreview(report: report)
+          .redactField('deviceInfo.model')
+          .toSubmittableReport();
+      expect(submittable.deviceInfo!['model'], isNull);
+      expect(submittable.deviceInfo!['osVersion'], '16');
     });
   });
 }

--- a/packages/core/observability/test/feedback/feedback_report_preview_test.dart
+++ b/packages/core/observability/test/feedback/feedback_report_preview_test.dart
@@ -78,6 +78,17 @@ void main() {
       expect(json['title'], 'Add crash');
       expect((json['deviceInfo'] as Map<String, dynamic>)['osVersion'], '16');
     });
+
+    test(
+      'userRedactedFields reflects the preview, not the underlying report',
+      () {
+        final report = _report().copyWith(userRedactedFields: ['title']);
+        final json = FeedbackReportPreview(report: report)
+            .redactField('platform')
+            .displayJson();
+        expect(json['userRedactedFields'], equals(['platform']));
+      },
+    );
   });
 
   group('toSubmittableReport', () {
@@ -117,16 +128,12 @@ void main() {
         report,
       ).unredactField('title').toSubmittableReport();
       expect(submittable.userRedactedFields, isEmpty);
-      // Value is preserved because no marker was applied.
       expect(submittable.title, equals('Add crash'));
     });
 
     test(
       'bare constructor with a marked report overrides the report\'s marks',
       () {
-        // The bare constructor is for explicit-set construction; a
-        // caller who passes a report with prior marks but does NOT
-        // seed via fromReport is saying "ignore the report's marks".
         final report = _report().copyWith(userRedactedFields: ['title']);
         final submittable = FeedbackReportPreview(
           report: report,

--- a/packages/core/observability/test/feedback/feedback_report_preview_test.dart
+++ b/packages/core/observability/test/feedback/feedback_report_preview_test.dart
@@ -98,16 +98,43 @@ void main() {
       );
     });
 
-    test('merges with paths already on the underlying report', () {
+    test(
+      'fromReport seeds userRedactedFields so seeded paths survive submit',
+      () {
+        final report = _report().copyWith(userRedactedFields: ['title']);
+        final submittable = FeedbackReportPreview.fromReport(
+          report,
+        ).redactField('platform').toSubmittableReport();
+        expect(submittable.userRedactedFields.toSet(), {'title', 'platform'});
+        // Seeded path's value is also masked at submit time.
+        expect(submittable.title, FeedbackReportPreview.redactedMarker);
+      },
+    );
+
+    test('unredactField undoes a path seeded from the report', () {
       final report = _report().copyWith(userRedactedFields: ['title']);
-      final submittable = FeedbackReportPreview(
-        report: report,
-      ).redactField('platform').toSubmittableReport();
-      expect(
-        submittable.userRedactedFields.toSet(),
-        {'title', 'platform'},
-      );
+      final submittable = FeedbackReportPreview.fromReport(
+        report,
+      ).unredactField('title').toSubmittableReport();
+      expect(submittable.userRedactedFields, isEmpty);
+      // Value is preserved because no marker was applied.
+      expect(submittable.title, equals('Add crash'));
     });
+
+    test(
+      'bare constructor with a marked report overrides the report\'s marks',
+      () {
+        // The bare constructor is for explicit-set construction; a
+        // caller who passes a report with prior marks but does NOT
+        // seed via fromReport is saying "ignore the report's marks".
+        final report = _report().copyWith(userRedactedFields: ['title']);
+        final submittable = FeedbackReportPreview(
+          report: report,
+        ).toSubmittableReport();
+        expect(submittable.userRedactedFields, isEmpty);
+        expect(submittable.title, equals('Add crash'));
+      },
+    );
 
     test('no user redactions returns an equivalent report', () {
       final report = _report();

--- a/packages/core/observability/test/feedback/feedback_report_test.dart
+++ b/packages/core/observability/test/feedback/feedback_report_test.dart
@@ -1,0 +1,152 @@
+import 'package:observability/observability.dart';
+import 'package:test/test.dart';
+
+FeedbackReport _validBugReport() => FeedbackReport(
+  category: FeedbackCategory.bug,
+  severity: FeedbackSeverity.medium,
+  message: 'the collection list flickers on resync',
+  title: 'Collection flicker',
+  appVersion: '0.1.0',
+  platform: 'android',
+  locale: 'en-US',
+  deviceInfo: const {'model': 'Pixel 9'},
+  correlationKey: 'ck-001',
+);
+
+void main() {
+  group('FeedbackReport construction', () {
+    test('severity is required when category is bug', () {
+      expect(
+        () => FeedbackReport(category: FeedbackCategory.bug, message: 'm'),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('severity is required when category is crash', () {
+      expect(
+        () => FeedbackReport(category: FeedbackCategory.crash, message: 'm'),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('feature requests do not require a severity', () {
+      final report = FeedbackReport(
+        category: FeedbackCategory.featureRequest,
+        message: 'dark mode for the kitchen table please',
+      );
+      expect(report.severity, isNull);
+    });
+
+    test('message must not be empty', () {
+      expect(
+        () => FeedbackReport(
+          category: FeedbackCategory.featureRequest,
+          message: '',
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+
+    test('context defaults to unknown, list fields default empty', () {
+      final report = FeedbackReport(
+        category: FeedbackCategory.featureRequest,
+        message: 'm',
+      );
+      expect(report.context, FeedbackContext.unknown);
+      expect(report.userRedactedFields, isEmpty);
+      expect(report.breadcrumbs, isEmpty);
+    });
+  });
+
+  group('FeedbackReport JSON', () {
+    test('round-trips through toJson/fromJson', () {
+      final report = _validBugReport().copyWith(
+        breadcrumbs: [
+          Breadcrumb(
+            timestamp: DateTime.utc(2026, 6, 12),
+            level: BgeLogLevel.info,
+            loggerName: 'bge.test',
+            message: 'crumb',
+          ),
+        ],
+      );
+      expect(FeedbackReport.fromJson(report.toJson()), report);
+    });
+
+    test('enums serialise to PascalCase wire strings matching the backend', () {
+      final json = _validBugReport().toJson();
+      expect(json['category'], 'Bug');
+      expect(json['severity'], 'Medium');
+      expect(json['context'], 'Unknown');
+    });
+
+    test('breadcrumbs serialise to maps, not Dart instances', () {
+      final report = _validBugReport().copyWith(
+        breadcrumbs: [
+          Breadcrumb(
+            timestamp: DateTime.utc(2026),
+            level: BgeLogLevel.error,
+            loggerName: 'bge.test',
+            message: 'boom',
+          ),
+        ],
+      );
+      final crumbs = report.toJson()['breadcrumbs'] as List;
+      expect(crumbs.single, isA<Map<String, dynamic>>());
+    });
+  });
+
+  group('FeedbackReport.validate', () {
+    test('a well-formed report has no violations', () {
+      expect(_validBugReport().validate(), isEmpty);
+      expect(_validBugReport().isValid, isTrue);
+    });
+
+    test('flags message over the backend cap', () {
+      final report = _validBugReport().copyWith(
+        message: 'x' * (FeedbackConstants.maxMessageLength + 1),
+      );
+      expect(report.validate(), contains(contains('message')));
+      expect(report.isValid, isFalse);
+    });
+
+    test('flags title over the backend cap', () {
+      final report = _validBugReport().copyWith(
+        title: 't' * (FeedbackConstants.maxTitleLength + 1),
+      );
+      expect(report.validate(), contains(contains('title')));
+    });
+
+    test('flags metadata strings over their caps', () {
+      final report = _validBugReport().copyWith(
+        appVersion: 'v' * (FeedbackConstants.maxAppVersionLength + 1),
+        platform: 'p' * (FeedbackConstants.maxPlatformLength + 1),
+        locale: 'l' * (FeedbackConstants.maxLocaleLength + 1),
+        correlationKey: 'c' * (FeedbackConstants.maxCorrelationKeyLength + 1),
+      );
+      final violations = report.validate();
+      expect(violations, contains(contains('appVersion')));
+      expect(violations, contains(contains('platform')));
+      expect(violations, contains(contains('locale')));
+      expect(violations, contains(contains('correlationKey')));
+    });
+
+    test('flags userRedactedFields over the backend array cap', () {
+      final report = _validBugReport().copyWith(
+        userRedactedFields: List.generate(
+          FeedbackConstants.maxRedactedFields + 1,
+          (i) => 'deviceInfo.k$i',
+        ),
+      );
+      expect(report.validate(), contains(contains('userRedactedFields')));
+    });
+
+    test('values exactly at the caps pass', () {
+      final report = _validBugReport().copyWith(
+        message: 'x' * FeedbackConstants.maxMessageLength,
+        title: 't' * FeedbackConstants.maxTitleLength,
+      );
+      expect(report.validate(), isEmpty);
+    });
+  });
+}

--- a/packages/core/observability/test/feedback/feedback_service_test.dart
+++ b/packages/core/observability/test/feedback/feedback_service_test.dart
@@ -1,0 +1,26 @@
+import 'package:observability/observability.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('FeedbackSubmissionException', () {
+    test('toString without a cause is the message alone', () {
+      const exception = FeedbackSubmissionException('queue full');
+      expect(
+        exception.toString(),
+        'FeedbackSubmissionException: queue full',
+      );
+    });
+
+    test('toString includes the cause when present', () {
+      final exception = FeedbackSubmissionException(
+        'transport failed',
+        cause: StateError('socket closed'),
+      );
+      expect(
+        exception.toString(),
+        'FeedbackSubmissionException: transport failed '
+        '(cause: Bad state: socket closed)',
+      );
+    });
+  });
+}

--- a/packages/core/observability/test/logging/bge_log_level_test.dart
+++ b/packages/core/observability/test/logging/bge_log_level_test.dart
@@ -1,0 +1,78 @@
+import 'package:logging/logging.dart';
+import 'package:observability/observability.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('BgeLogLevel.level', () {
+    test('maps the five BGE levels onto package:logging levels', () {
+      expect(BgeLogLevel.verbose.level, Level.FINEST);
+      expect(BgeLogLevel.debug.level, Level.FINE);
+      expect(BgeLogLevel.info.level, Level.INFO);
+      expect(BgeLogLevel.warn.level, Level.WARNING);
+      expect(BgeLogLevel.error.level, Level.SEVERE);
+    });
+  });
+
+  group('BgeLogLevel.fromLevel', () {
+    test('round-trips every BGE level', () {
+      for (final level in BgeLogLevel.values) {
+        expect(BgeLogLevel.fromLevel(level.level), level);
+      }
+    });
+
+    test('collapses package:logging levels without a direct peer', () {
+      // FINER sits between FINEST (verbose) and FINE (debug).
+      expect(BgeLogLevel.fromLevel(Level.FINER), BgeLogLevel.verbose);
+      // CONFIG sits between FINE (debug) and INFO.
+      expect(BgeLogLevel.fromLevel(Level.CONFIG), BgeLogLevel.debug);
+      // SHOUT is above SEVERE.
+      expect(BgeLogLevel.fromLevel(Level.SHOUT), BgeLogLevel.error);
+    });
+
+    test('handles custom levels by threshold', () {
+      expect(
+        BgeLogLevel.fromLevel(const Level('CUSTOM', 850)),
+        BgeLogLevel.info,
+      );
+      expect(
+        BgeLogLevel.fromLevel(const Level('CUSTOM', 950)),
+        BgeLogLevel.warn,
+      );
+    });
+  });
+
+  group('wire helpers', () {
+    const expectations = {
+      BgeLogLevel.verbose: 'verbose',
+      BgeLogLevel.debug: 'debug',
+      BgeLogLevel.info: 'info',
+      BgeLogLevel.warn: 'warn',
+      BgeLogLevel.error: 'error',
+    };
+
+    test('toWire covers every variant', () {
+      expect(expectations.keys.toSet(), BgeLogLevel.values.toSet());
+      expectations.forEach((level, wire) {
+        expect(level.toWire(), wire);
+      });
+    });
+
+    test('fromWire parses every wire string', () {
+      expectations.forEach((level, wire) {
+        expect(BgeLogLevel.fromWire(wire), level);
+      });
+    });
+
+    test('round-trip', () {
+      for (final level in BgeLogLevel.values) {
+        expect(BgeLogLevel.fromWire(level.toWire()), level);
+      }
+    });
+
+    test('fromWire throws on an unrecognised value', () {
+      // Strict — these strings are client-authored; an unknown value is
+      // corruption, not a server enum extension.
+      expect(() => BgeLogLevel.fromWire('TRACE'), throwsStateError);
+    });
+  });
+}

--- a/packages/core/observability/test/logging/bge_logger_test.dart
+++ b/packages/core/observability/test/logging/bge_logger_test.dart
@@ -1,0 +1,88 @@
+import 'dart:async';
+
+import 'package:logging/logging.dart';
+import 'package:observability/observability.dart';
+import 'package:test/test.dart';
+
+void main() {
+  late List<LogRecord> records;
+  late StreamSubscription<LogRecord> subscription;
+
+  setUp(() {
+    Logger.root.level = Level.ALL;
+    records = [];
+    subscription = Logger.root.onRecord.listen(records.add);
+  });
+
+  tearDown(() async {
+    await subscription.cancel();
+    Logger.root.level = Level.INFO;
+  });
+
+  group('BgeLogger', () {
+    test('exposes its hierarchical name', () {
+      final logger = BgeLogger('bge.storage.sync_queue');
+      expect(logger.name, 'bge.storage.sync_queue');
+    });
+
+    test('records propagate to the root logger with the logger name', () {
+      BgeLogger('bge.test.propagation').info('hello');
+      expect(records, hasLength(1));
+      expect(records.single.loggerName, 'bge.test.propagation');
+      expect(records.single.message, 'hello');
+    });
+
+    test('each method emits at its mapped package:logging level', () {
+      final logger = BgeLogger('bge.test.levels');
+      logger
+        ..verbose('v')
+        ..debug('d')
+        ..info('i')
+        ..warn('w')
+        ..error('e');
+      expect(records.map((r) => r.level).toList(), [
+        Level.FINEST,
+        Level.FINE,
+        Level.INFO,
+        Level.WARNING,
+        Level.SEVERE,
+      ]);
+    });
+
+    test('error and stackTrace pass through to the record', () {
+      final logger = BgeLogger('bge.test.error');
+      final boom = StateError('boom');
+      final trace = StackTrace.current;
+      logger.error('failed', error: boom, stackTrace: trace);
+      expect(records.single.error, same(boom));
+      expect(records.single.stackTrace, same(trace));
+    });
+
+    test('context map travels on record.object as a ContextLogMessage', () {
+      final logger = BgeLogger('bge.test.context');
+      logger.info('with ctx', context: {'requestId': 'r-1'});
+      final object = records.single.object;
+      expect(object, isA<ContextLogMessage>());
+      expect((object! as ContextLogMessage).context, {'requestId': 'r-1'});
+      // The record message stays the plain text — handlers that only
+      // print record.message are unaffected by the context payload.
+      expect(records.single.message, 'with ctx');
+    });
+
+    test('omitted or empty context emits a plain String message', () {
+      final logger = BgeLogger('bge.test.nocontext');
+      logger
+        ..info('plain')
+        ..info('empty', context: {});
+      expect(records[0].object, isNull);
+      expect(records[1].object, isNull);
+    });
+  });
+
+  group('ContextLogMessage', () {
+    test('toString returns the text only', () {
+      const message = ContextLogMessage('text', {'k': 'v'});
+      expect(message.toString(), 'text');
+    });
+  });
+}

--- a/packages/core/observability/test/redaction/redaction_test.dart
+++ b/packages/core/observability/test/redaction/redaction_test.dart
@@ -97,6 +97,20 @@ void main() {
     test('empty input stays empty', () {
       expect(Redaction.maskMiddle(''), '');
     });
+
+    test('negative keepStart throws ArgumentError', () {
+      expect(
+        () => Redaction.maskMiddle('abc', keepStart: -1),
+        throwsArgumentError,
+      );
+    });
+
+    test('negative keepEnd throws ArgumentError', () {
+      expect(
+        () => Redaction.maskMiddle('abc', keepEnd: -1),
+        throwsArgumentError,
+      );
+    });
   });
 
   group('Redaction.truncate', () {
@@ -121,6 +135,10 @@ void main() {
 
     test('empty ellipsis produces a plain cut', () {
       expect(Redaction.truncate('hello world', 5, ellipsis: ''), 'hello');
+    });
+
+    test('maxLength smaller than the ellipsis throws ArgumentError', () {
+      expect(() => Redaction.truncate('hello', 0), throwsArgumentError);
     });
   });
 

--- a/packages/core/observability/test/redaction/redaction_test.dart
+++ b/packages/core/observability/test/redaction/redaction_test.dart
@@ -1,0 +1,203 @@
+import 'package:observability/observability.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Redaction.redactName', () {
+    // Behaviour pinned to the original helpers promoted out of
+    // packages/features/auth/lib/src/bloc/auth_event.dart. Any change
+    // here is a behavioural change for auth event logging too.
+    test('empty string stays empty', () {
+      expect(Redaction.redactName(''), '');
+    });
+
+    test('1-char name is fully masked', () {
+      expect(Redaction.redactName('X'), '*');
+    });
+
+    test('2-char name is fully masked', () {
+      expect(Redaction.redactName('Al'), '**');
+    });
+
+    test('3-char name keeps first and last char', () {
+      expect(Redaction.redactName('Bob'), 'B*b');
+    });
+
+    test('4-char name keeps first and last char', () {
+      expect(Redaction.redactName('John'), 'J**n');
+    });
+
+    test('mask length matches input length', () {
+      expect(Redaction.redactName('Alexander').length, 'Alexander'.length);
+    });
+  });
+
+  group('Redaction.redactEmail', () {
+    test('redacts each dot-separated local segment, preserves domain', () {
+      expect(Redaction.redactEmail('john.doe@email.com'), 'j**n.d*e@email.com');
+    });
+
+    test('single-segment local part', () {
+      expect(Redaction.redactEmail('alice@example.com'), 'a***e@example.com');
+    });
+
+    test('1-char local part is fully masked', () {
+      expect(Redaction.redactEmail('j@gmail.com'), '*@gmail.com');
+    });
+
+    test('string without @ is treated as a name', () {
+      expect(Redaction.redactEmail('bare'), 'b**e');
+    });
+
+    test('consecutive dots preserve structural shape', () {
+      expect(Redaction.redactEmail('a..b@x.com'), '*..*@x.com');
+    });
+  });
+
+  group('Redaction.redactEmailsIn', () {
+    test('masks an email embedded in free text', () {
+      expect(
+        Redaction.redactEmailsIn('sign-in failed for john.doe@email.com today'),
+        'sign-in failed for j**n.d*e@email.com today',
+      );
+    });
+
+    test('masks multiple emails independently', () {
+      expect(
+        Redaction.redactEmailsIn('from alice@example.com to bob.r@x.io'),
+        'from a***e@example.com to b*b.*@x.io',
+      );
+    });
+
+    test('text without emails is returned unchanged', () {
+      const text = 'no addresses here, just words';
+      expect(Redaction.redactEmailsIn(text), same(text));
+    });
+  });
+
+  group('Redaction.maskMiddle', () {
+    test('defaults keep one char on each end', () {
+      expect(Redaction.maskMiddle('secret'), 's****t');
+    });
+
+    test('input shorter than keepStart+keepEnd is fully masked', () {
+      expect(Redaction.maskMiddle('ab', keepStart: 2, keepEnd: 2), '**');
+    });
+
+    test('input exactly keepStart+keepEnd is fully masked', () {
+      expect(Redaction.maskMiddle('abcd', keepStart: 2, keepEnd: 2), '****');
+    });
+
+    test('custom keep counts and mask char', () {
+      expect(
+        Redaction.maskMiddle('1234567890', keepStart: 2, keepEnd: 3, maskChar: '#'),
+        '12#####890',
+      );
+    });
+
+    test('empty input stays empty', () {
+      expect(Redaction.maskMiddle(''), '');
+    });
+  });
+
+  group('Redaction.truncate', () {
+    test('input within limit is returned unchanged', () {
+      const text = 'short';
+      expect(Redaction.truncate(text, 10), same(text));
+    });
+
+    test('input at exactly the limit is returned unchanged', () {
+      expect(Redaction.truncate('12345', 5), '12345');
+    });
+
+    test('over-limit input is cut and suffixed with the ellipsis', () {
+      final out = Redaction.truncate('hello world', 8);
+      expect(out, 'hello w…');
+      expect(out.length, 8);
+    });
+
+    test('custom ellipsis', () {
+      expect(Redaction.truncate('hello world', 8, ellipsis: '...'), 'hello...');
+    });
+
+    test('empty ellipsis produces a plain cut', () {
+      expect(Redaction.truncate('hello world', 5, ellipsis: ''), 'hello');
+    });
+  });
+
+  group('Redaction.redactJsonFields', () {
+    test('replaces matching top-level keys', () {
+      final out = Redaction.redactJsonFields(
+        {'email': 'a@b.com', 'count': 3},
+        {'email'},
+      );
+      expect(out, {'email': '<redacted>', 'count': 3});
+    });
+
+    test('recurses into nested maps by default', () {
+      final out = Redaction.redactJsonFields(
+        {
+          'user': {'password': 'hunter2', 'name': 'Ada'},
+        },
+        {'password'},
+      );
+      expect(out, {
+        'user': {'password': '<redacted>', 'name': 'Ada'},
+      });
+    });
+
+    test('recurses into maps inside lists', () {
+      final out = Redaction.redactJsonFields(
+        {
+          'items': [
+            {'token': 't1'},
+            {'token': 't2', 'keep': true},
+          ],
+        },
+        {'token'},
+      );
+      expect(out, {
+        'items': [
+          {'token': '<redacted>'},
+          {'token': '<redacted>', 'keep': true},
+        ],
+      });
+    });
+
+    test('recursive: false leaves nested maps untouched', () {
+      final out = Redaction.redactJsonFields(
+        {
+          'password': 'top',
+          'nested': {'password': 'inner'},
+        },
+        {'password'},
+        recursive: false,
+      );
+      expect(out['password'], '<redacted>');
+      expect(out['nested'], {'password': 'inner'});
+    });
+
+    test('keys not present are a no-op', () {
+      final out = Redaction.redactJsonFields({'a': 1}, {'missing'});
+      expect(out, {'a': 1});
+    });
+
+    test('custom replacement string', () {
+      final out = Redaction.redactJsonFields(
+        {'secret': 'x'},
+        {'secret'},
+        replacement: '[GONE]',
+      );
+      expect(out['secret'], '[GONE]');
+    });
+
+    test('does not mutate the input map', () {
+      final input = {
+        'email': 'a@b.com',
+        'nested': {'email': 'c@d.com'},
+      };
+      Redaction.redactJsonFields(input, {'email'});
+      expect(input['email'], 'a@b.com');
+      expect((input['nested']! as Map)['email'], 'c@d.com');
+    });
+  });
+}

--- a/packages/core/observability/test/redaction/redaction_test.dart
+++ b/packages/core/observability/test/redaction/redaction_test.dart
@@ -111,6 +111,15 @@ void main() {
         throwsArgumentError,
       );
     });
+
+    test('empty maskChar throws ArgumentError', () {
+      // Empty mask would produce unmasked output via `'' * n`, defeating
+      // the redaction guarantee.
+      expect(
+        () => Redaction.maskMiddle('secret', maskChar: ''),
+        throwsArgumentError,
+      );
+    });
   });
 
   group('Redaction.truncate', () {

--- a/packages/features/auth/lib/src/bloc/auth_event.dart
+++ b/packages/features/auth/lib/src/bloc/auth_event.dart
@@ -1,5 +1,6 @@
 import 'package:equatable/equatable.dart';
 import 'package:interfaces/repositories.dart';
+import 'package:observability/observability.dart';
 
 sealed class AuthEvent extends Equatable {
   const AuthEvent();
@@ -30,7 +31,7 @@ final class AuthSignInRequested extends AuthEvent {
   /// matcher diffs. Overriding [toString] here makes the leak
   /// impossible regardless of EquatableConfig.
   ///
-  /// [email] is partially redacted via [_redactEmail] — first and
+  /// [email] is partially redacted via [Redaction.redactEmail] — first and
   /// last char of each dot-separated local-part segment is kept,
   /// middle is masked, domain is preserved. A debug reader can
   /// still correlate sign-in attempts by the same user (the
@@ -39,7 +40,7 @@ final class AuthSignInRequested extends AuthEvent {
   @override
   String toString() =>
       'AuthSignInRequested('
-      'email: ${_redactEmail(email)}, '
+      'email: ${Redaction.redactEmail(email)}, '
       'password: <redacted>)';
 }
 
@@ -64,7 +65,7 @@ final class AuthRegisterRequested extends AuthEvent {
   /// for the rationale on the password and email redactions.
   ///
   /// [username], [firstName], and [lastName] are partially redacted
-  /// via [_redactName] — first and last char preserved, middle
+  /// via [Redaction.redactName] — first and last char preserved, middle
   /// masked. Null name fields render as the literal `null` so a
   /// debug reader can tell at a glance which optional fields were
   /// supplied. As with the email, the redaction is a debug-readability
@@ -78,11 +79,11 @@ final class AuthRegisterRequested extends AuthEvent {
     final fn = firstName;
     final ln = lastName;
     return 'AuthRegisterRequested('
-        'email: ${_redactEmail(email)}, '
+        'email: ${Redaction.redactEmail(email)}, '
         'password: <redacted>, '
-        'username: ${_redactName(username)}, '
-        'firstName: ${fn == null ? 'null' : _redactName(fn)}, '
-        'lastName: ${ln == null ? 'null' : _redactName(ln)})';
+        'username: ${Redaction.redactName(username)}, '
+        'firstName: ${fn == null ? 'null' : Redaction.redactName(fn)}, '
+        'lastName: ${ln == null ? 'null' : Redaction.redactName(ln)})';
   }
 }
 
@@ -110,75 +111,4 @@ final class AuthRepositoryStateChanged extends AuthEvent {
   /// reader of the trail actually needs.
   @override
   String toString() => 'AuthRepositoryStateChanged(${repoState.runtimeType})';
-}
-
-// ── PII redaction helpers ────────────────────────────────────────────────────
-
-/// Partial PII redaction for log/debug stringification.
-///
-/// Preserves the first and last character of [name] and masks the
-/// middle with `*` of the original-length minus 2.
-///
-/// - Empty string → empty string.
-/// - 1 char → `'*'`.
-/// - 2 chars → `'**'`.
-/// - 3+ chars → first + `'*' * (length - 2)` + last.
-///
-/// Examples:
-/// - `John` → `J**n`
-/// - `Bob` → `B*b`
-/// - `Al` → `**`
-/// - `X` → `*`
-///
-/// This is a debug-readability vs incidental-exposure compromise,
-/// not strong anonymisation. The redaction is deterministic, so:
-///
-/// - A reader of multiple log lines for the same user sees the
-///   same pattern repeatedly and can correlate events without
-///   needing the full name.
-/// - A determined attacker correlating multiple log lines, or
-///   combining with other context (length-based guessing, known
-///   user lists, etc.), can reverse most short names. If GDPR-
-///   grade anonymisation is required for a particular deployment,
-///   the redaction should be tightened to full mask or the
-///   logging suppressed entirely at the observer layer.
-String _redactName(String name) {
-  if (name.isEmpty) return '';
-  if (name.length <= 2) return '*' * name.length;
-  return '${name[0]}${'*' * (name.length - 2)}${name[name.length - 1]}';
-}
-
-/// Partial email redaction for log/debug stringification.
-///
-/// Splits the local part of [email] on `.`, applies [_redactName]
-/// to each segment, rejoins with `.`, and leaves the domain (the
-/// `@…` suffix) entirely intact. Examples:
-///
-/// - `john.doe@email.com` → `j**n.d*e@email.com`
-/// - `alice@example.com` → `a***e@example.com`
-/// - `j@gmail.com` → `*@gmail.com`
-/// - `bare-string-no-at` → treated as a name, redacted whole.
-///
-/// The domain is preserved because:
-///
-/// - It's commonly useful for debug context — at a glance,
-///   distinguishing gmail vs corporate vs SSO providers helps
-///   triage auth issues.
-/// - It isn't itself uniquely identifying without the local part;
-///   thousands of users typically share a domain.
-///
-/// Same caveats as [_redactName]: this is incidental-exposure
-/// mitigation, not strong anonymisation. Determined correlation
-/// across logs can still narrow identity.
-String _redactEmail(String email) {
-  final atIndex = email.indexOf('@');
-  if (atIndex < 0) return _redactName(email);
-  final local = email.substring(0, atIndex);
-  final domain = email.substring(atIndex);
-  // Split-map-join over '.'-separated local-part segments. An
-  // empty segment (consecutive dots, leading dot, trailing dot)
-  // maps to '' via [_redactName]'s empty-string branch, preserving
-  // the structural shape of the local part.
-  final maskedLocal = local.split('.').map(_redactName).join('.');
-  return '$maskedLocal$domain';
 }

--- a/packages/features/auth/pubspec.yaml
+++ b/packages/features/auth/pubspec.yaml
@@ -17,6 +17,8 @@ dependencies:
     path: ../../core/interfaces
   models:
     path: ../../core/models
+  observability:
+    path: ../../core/observability
   ui:
     path: ../../ui
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ workspace:
   - packages/core/interfaces
   - packages/core/models
   - packages/core/di
+  - packages/core/observability
   - packages/features/auth
   - packages/storage/drift_storage
   - packages/storage/storage_interface


### PR DESCRIPTION
Implements the observability foundation from #8 as a new pure-Dart `packages/core/observability` package, plus the auth refactor that adopts the promoted redaction utilities.

## What's in the package

**Logging** — `BgeLogger` wrapping `package:logging` with the five-level scheme (`verbose/debug/info/warn/error` ≈ FINEST/FINE/INFO/WARNING/SEVERE), hierarchical names (`bge.storage.sync_queue`), and structured context via `ContextLogMessage` riding on `LogRecord.object` while `record.message` stays plain text. Level filtering and sink wiring remain app-shell concerns.

**Redaction** — `Redaction.redactName` / `redactEmail` promoted from `auth_event.dart` (behaviour pinned byte-for-byte by tests), plus new generic helpers: `maskMiddle`, `truncate`, `redactEmailsIn` (pattern-scan for breadcrumb messages), and `redactJsonFields` (deep, list-aware, non-mutating).

**Breadcrumbs** — `BreadcrumbBuffer`: bounded ring (default 100) subscribed to `Logger.root`, sanitising **at capture time**: email-pattern masking over messages, key-based context redaction (documented default sensitive-key set, overridable). Stack traces are deliberately not buffered. Local consoles keep full fidelity; only the buffered trail is scrubbed.

**Feedback domain** — `FeedbackReport` mirroring the backend `CreateFeedbackReportDto` (backend PR #77): severity-required-for-Bug/Crash constructor assert, non-empty message assert, `validate()` against `FeedbackConstants` (mirrors `feedback.constants.ts` caps so offline-queued reports fail fast client-side). `FeedbackCategory/Context/Severity` enums with PascalCase `@JsonValue` + strict `fromWire/toWire`. `FeedbackReportPreview` = the consent-screen model: visible `<redacted>` markers, immutable redact/unredact over a whitelisted field surface (string payload fields + `deviceInfo.<key>` dot-paths), `toSubmittableReport()` merging paths into `userRedactedFields`. `FeedbackService` interface only — concrete impls (network, offline queue, local-file sink) are a follow-up issue.

## Naming note vs issue #8

Issue #8 says `BugReport` / `BugReportService`; backend #44 evolved into the generalised **FeedbackReport** domain (landed in backend PR #77), so the client models follow the backend naming.

## ⚠️ Backend gaps noted (per design discussion — to be added backend-side)

1. **No breadcrumb field on `CreateFeedbackReportDto` / the Prisma model.** The client model carries `breadcrumbs` as a first-class field (serialised for offline draft persistence), but there is nowhere to send them. Suggest `breadcrumbs Json? @map("breadcrumbs")` on `FeedbackReport` + a size-capped DTO field.
2. **No dedicated stack-trace field.** Crash stack traces currently have to be composed into `message` (the `FeedbackService.buildReport` contract documents tail-preserving truncation). Acceptable for alpha, but a dedicated `stackTrace` column would keep `message` human-readable.

## Verification (no Dart SDK in my environment — code is unexecuted)

```
melos bootstrap
melos run generate     # breadcrumb/feedback_report freezed + g.dart, preview freezed
melos run analyze:dart
melos run test:core    # observability suite
melos run test         # auth still green (refactor is behaviour-preserving)
```

The commit history follows the red→green discipline: scaffold → failing specs (2 commits) → implementations (3 commits) → auth refactor. One stray placeholder file slipped into the 2/2b batch and was removed in the immediately following commit.

Partially closes #8 — the FeedbackService **interface** lands here; concrete implementations are intentionally deferred to their own issue per the issue text.

## Summary by Sourcery

Add a new core observability module with logging, sanitised breadcrumb buffering, and feedback-report modeling, and update auth to use the shared redaction utilities.

New Features:
- Introduce core observability package providing BGE-aligned logging, redaction utilities, breadcrumb capture, and feedback-report domain models and service interface

Enhancements:
- Refactor auth feature to consume shared redaction utilities from the observability package instead of local helpers

Build:
- Register the new observability package in the workspace and wire it as a dependency of the auth feature package

Tests:
- Add comprehensive unit tests covering redaction helpers, breadcrumb buffering and JSON shape, logging level mappings and context handling, feedback enums, feedback report validation, and feedback preview redaction flows