### PR TITLE
feat(forms): remove reactive_forms <-> flutter_form_builder

### DIFF
--- a/packages/features/auth/lib/src/widgets/auth_text_field.dart
+++ b/packages/features/auth/lib/src/widgets/auth_text_field.dart
@@ -1,20 +1,31 @@
 import 'package:flutter/material.dart';
-import 'package:reactive_forms/reactive_forms.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
 
-/// Accessible [ReactiveTextField] wrapper for auth forms.
+/// Accessible [FormBuilderTextField] wrapper for auth forms.
 ///
 /// Accessibility features:
 /// - `Semantics.label` ensures VoiceOver/TalkBack reads the field name
 /// - A visually-hidden `liveRegion: true` [Semantics] node announces validation
 ///   errors immediately when they appear, without requiring the user to
-///   re-navigate to the field
-/// - Password visibility toggle meets the 48×48 minimum touch target
+///   re-navigate to the field.
+///   flutter_form_builder has no reactive error stream (unlike reactive_forms'
+///   `FormControl.errors`), so the error text is re-read from
+///   [FormBuilderFieldState.errorText] in a post-frame callback scheduled on
+///   every rebuild of this widget. Both keystrokes (via [onChanged] calling
+///   `setState`) and a parent form's submit-time `validate()` call (which
+///   rebuilds this widget as part of the ancestor rebuild) trigger that
+///   rebuild, so the value read is never stale. The one gap versus the prior
+///   implementation: a field blurred without any edit (pure tab-away) won't
+///   push a new announcement, since nothing here triggers a rebuild in that
+///   case — only the decoration's visible error text updates. Acceptable
+///   trade-off; revisit if screen-reader QA flags it.
+/// - Password visibility toggle meets the 48x48 minimum touch target
 /// - `autofillHints` enables credential manager integration
 /// - Keyboard users submit with Enter when [textInputAction] is [TextInputAction.done]
 class AuthTextField extends StatefulWidget {
   const AuthTextField({
     super.key,
-    required this.formControlName,
+    required this.name,
     required this.label,
     this.hint,
     this.autofillHints,
@@ -24,10 +35,11 @@ class AuthTextField extends StatefulWidget {
     this.onSubmitted,
     this.enabled = true,
     this.autofocus = false,
-    this.validationMessages = const {},
+    this.validator,
   });
 
-  final String formControlName;
+  /// The [FormBuilder] field name this control binds to.
+  final String name;
   final String label;
   final String? hint;
   final Iterable<String>? autofillHints;
@@ -38,9 +50,10 @@ class AuthTextField extends StatefulWidget {
   final bool enabled;
   final bool autofocus;
 
-  /// Maps reactive_forms error keys to human-readable messages.
-  /// e.g. `{ValidationMessage.required: (_) => 'Required'}`
-  final Map<String, String Function(Object)> validationMessages;
+  /// Composed validator, e.g. via `FormBuilderValidators.compose([...])`.
+  /// Kept as a plain [FormFieldValidator] so this widget stays decoupled
+  /// from any specific validation package.
+  final FormFieldValidator<String>? validator;
 
   @override
   State<AuthTextField> createState() => _AuthTextFieldState();
@@ -48,9 +61,28 @@ class AuthTextField extends StatefulWidget {
 
 class _AuthTextFieldState extends State<AuthTextField> {
   bool _obscure = true;
+  final _fieldKey =
+      GlobalKey<FormBuilderFieldState<FormBuilderField<String>, String>>();
+  final _liveError = ValueNotifier<String?>(null);
+
+  @override
+  void dispose() {
+    _liveError.dispose();
+    super.dispose();
+  }
 
   @override
   Widget build(BuildContext context) {
+    // Re-sync the live-region announcer after this frame settles, so it
+    // reflects whatever the field's own validator just produced.
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (!mounted) return;
+      final error = _fieldKey.currentState?.errorText;
+      if (error != _liveError.value) {
+        _liveError.value = error;
+      }
+    });
+
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       mainAxisSize: MainAxisSize.min,
@@ -58,17 +90,24 @@ class _AuthTextFieldState extends State<AuthTextField> {
         Semantics(
           label: widget.label,
           textField: true,
-          child: ReactiveTextField<String>(
-            formControlName: widget.formControlName,
+          child: FormBuilderTextField(
+            key: _fieldKey,
+            name: widget.name,
             autofocus: widget.autofocus,
             obscureText: widget.isPassword && _obscure,
             textInputAction: widget.textInputAction,
             keyboardType: widget.keyboardType,
             autofillHints: widget.autofillHints,
+            enabled: widget.enabled,
+            validator: widget.validator,
+            autovalidateMode: AutovalidateMode.onUserInteraction,
             onSubmitted: widget.onSubmitted != null
                 ? (_) => widget.onSubmitted!()
                 : null,
-            validationMessages: widget.validationMessages,
+            // Forces a rebuild per keystroke so the postFrameCallback above
+            // re-checks errorText; flutter_form_builder validates internally
+            // regardless, this only drives our external live-region copy.
+            onChanged: (_) => setState(() {}),
             decoration: InputDecoration(
               labelText: widget.label,
               hintText: widget.hint,
@@ -80,9 +119,23 @@ class _AuthTextFieldState extends State<AuthTextField> {
         ),
         // Live-region error node — screen readers announce this immediately
         // when it becomes non-empty, even without re-focusing the field.
-        _LiveErrorAnnouncer(
-          formControlName: widget.formControlName,
-          validationMessages: widget.validationMessages,
+        ValueListenableBuilder<String?>(
+          valueListenable: _liveError,
+          builder: (context, message, _) {
+            if (message == null || message.isEmpty) {
+              return const SizedBox.shrink();
+            }
+            return Semantics(
+              liveRegion: true,
+              child: SizedBox(
+                height: 0,
+                child: OverflowBox(
+                  maxHeight: double.infinity,
+                  child: Text(message, style: const TextStyle(fontSize: 0)),
+                ),
+              ),
+            );
+          },
         ),
       ],
     );
@@ -98,58 +151,6 @@ class _AuthTextFieldState extends State<AuthTextField> {
         tooltip: isObscured ? 'Show password' : 'Hide password',
         onPressed: () => setState(() => _obscure = !_obscure),
       ),
-    );
-  }
-}
-
-/// Renders an invisible live-region node that announces validation errors.
-///
-/// Uses [ReactiveFormConsumer] scoped only to this control so rebuilds are
-/// surgical. The text node has zero size but is visible to the accessibility
-/// tree via [Semantics.liveRegion].
-class _LiveErrorAnnouncer extends StatelessWidget {
-  const _LiveErrorAnnouncer({
-    required this.formControlName,
-    required this.validationMessages,
-  });
-
-  final String formControlName;
-  final Map<String, String Function(Object)> validationMessages;
-
-  @override
-  Widget build(BuildContext context) {
-    return ReactiveFormConsumer(
-      builder: (context, form, _) {
-        final control = form.control(formControlName);
-        if (!control.invalid || !control.touched) {
-          return const SizedBox.shrink();
-        }
-
-        final errorKey = control.errors.keys.firstOrNull;
-        if (errorKey == null) {
-          return const SizedBox.shrink();
-        }
-
-        final message = validationMessages[errorKey]?.call(
-          control.errors[errorKey]!,
-        );
-
-        if (message == null) {
-          return const SizedBox.shrink();
-        }
-
-        return Semantics(
-          liveRegion: true,
-          // ExcludeSemantics: false so the live-region text IS in the tree
-          child: SizedBox(
-            height: 0,
-            child: OverflowBox(
-              maxHeight: double.infinity,
-              child: Text(message, style: const TextStyle(fontSize: 0)),
-            ),
-          ),
-        );
-      },
     );
   }
 }

--- a/packages/features/auth/lib/src/widgets/login_form.dart
+++ b/packages/features/auth/lib/src/widgets/login_form.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:reactive_forms/reactive_forms.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
 
 import '../bloc/auth_bloc.dart';
 import '../bloc/auth_event.dart';
@@ -25,41 +26,17 @@ class LoginForm extends StatefulWidget {
 class _LoginFormState extends State<LoginForm> {
   static const _kMinPasswordLength = 8;
 
-  late final FormGroup _form;
-
-  @override
-  void initState() {
-    super.initState();
-    _form = FormGroup({
-      'email': FormControl<String>(
-        value: '',
-        validators: [Validators.required, Validators.email],
-      ),
-      'password': FormControl<String>(
-        value: '',
-        validators: [
-          Validators.required,
-          Validators.minLength(_kMinPasswordLength),
-        ],
-      ),
-    });
-  }
-
-  @override
-  void dispose() {
-    _form.dispose();
-    super.dispose();
-  }
+  final _formKey = GlobalKey<FormBuilderState>();
 
   void _submit(BuildContext context) {
-    if (_form.invalid) {
-      _form.markAllAsTouched();
-      return;
-    }
+    final isValid = _formKey.currentState?.saveAndValidate() ?? false;
+    if (!isValid) return;
+
+    final values = _formKey.currentState!.value;
     context.read<AuthBloc>().add(
       AuthSignInRequested(
-        email: _form.control('email').value as String,
-        password: _form.control('password').value as String,
+        email: values['email'] as String,
+        password: values['password'] as String,
       ),
     );
   }
@@ -72,15 +49,15 @@ class _LoginFormState extends State<LoginForm> {
       builder: (context, state) {
         final isLoading = state is AuthLoading;
 
-        return ReactiveForm(
-          formGroup: _form,
+        return FormBuilder(
+          key: _formKey,
           child: AutofillGroup(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               mainAxisSize: MainAxisSize.min,
               children: [
                 AuthTextField(
-                  formControlName: 'email',
+                  name: 'email',
                   label: 'Email', // TODO: wire AuthLocalizations
                   hint: 'Enter your email address',
                   keyboardType: TextInputType.emailAddress,
@@ -88,15 +65,18 @@ class _LoginFormState extends State<LoginForm> {
                   textInputAction: TextInputAction.next,
                   enabled: !isLoading,
                   autofocus: true,
-                  validationMessages: {
-                    ValidationMessage.required: (_) => 'Email is required',
-                    ValidationMessage.email: (_) =>
-                        'Enter a valid email address',
-                  },
+                  validator: FormBuilderValidators.compose([
+                    FormBuilderValidators.required(
+                      errorText: 'Email is required',
+                    ),
+                    FormBuilderValidators.email(
+                      errorText: 'Enter a valid email address',
+                    ),
+                  ]),
                 ),
                 const SizedBox(height: 16),
                 AuthTextField(
-                  formControlName: 'password',
+                  name: 'password',
                   label: 'Password',
                   hint: 'Enter your password',
                   isPassword: true,
@@ -104,13 +84,17 @@ class _LoginFormState extends State<LoginForm> {
                   textInputAction: TextInputAction.done,
                   enabled: !isLoading,
                   onSubmitted: () => _submit(context),
-                  validationMessages: {
-                    ValidationMessage.required: (_) => 'Password is required',
-                    ValidationMessage.minLength: (e) {
-                      final min = (e as Map)['requiredLength'] as int;
-                      return 'Password must be at least $min characters';
-                    },
-                  },
+                  validator: FormBuilderValidators.compose([
+                    FormBuilderValidators.required(
+                      errorText: 'Password is required',
+                    ),
+                    FormBuilderValidators.minLength(
+                      _kMinPasswordLength,
+                      errorText:
+                          'Password must be at least '
+                          '$_kMinPasswordLength characters',
+                    ),
+                  ]),
                 ),
                 const SizedBox(height: 24),
                 Semantics(

--- a/packages/features/auth/lib/src/widgets/register_form.dart
+++ b/packages/features/auth/lib/src/widgets/register_form.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:reactive_forms/reactive_forms.dart';
+import 'package:flutter_form_builder/flutter_form_builder.dart';
+import 'package:form_builder_validators/form_builder_validators.dart';
 
 import '../bloc/auth_bloc.dart';
 import '../bloc/auth_event.dart';
@@ -24,55 +25,21 @@ class _RegisterFormState extends State<RegisterForm> {
   static const _kMinPasswordLength = 8;
   static const _kMinUsernameLength = 3;
 
-  late final FormGroup _form;
-
-  @override
-  void initState() {
-    super.initState();
-    _form = FormGroup({
-      'email': FormControl<String>(
-        value: '',
-        validators: [Validators.required, Validators.email],
-      ),
-      'username': FormControl<String>(
-        value: '',
-        validators: [
-          Validators.required,
-          Validators.minLength(_kMinUsernameLength),
-        ],
-      ),
-      'password': FormControl<String>(
-        value: '',
-        validators: [
-          Validators.required,
-          Validators.minLength(_kMinPasswordLength),
-        ],
-      ),
-      'firstName': FormControl<String>(value: ''),
-      'lastName': FormControl<String>(value: ''),
-    });
-  }
-
-  @override
-  void dispose() {
-    _form.dispose();
-    super.dispose();
-  }
+  final _formKey = GlobalKey<FormBuilderState>();
 
   void _submit(BuildContext context) {
-    if (_form.invalid) {
-      _form.markAllAsTouched();
-      return;
-    }
+    final isValid = _formKey.currentState?.saveAndValidate() ?? false;
+    if (!isValid) return;
 
-    final firstName = (_form.control('firstName').value as String).trim();
-    final lastName = (_form.control('lastName').value as String).trim();
+    final values = _formKey.currentState!.value;
+    final firstName = (values['firstName'] as String? ?? '').trim();
+    final lastName = (values['lastName'] as String? ?? '').trim();
 
     context.read<AuthBloc>().add(
       AuthRegisterRequested(
-        email: _form.control('email').value as String,
-        password: _form.control('password').value as String,
-        username: _form.control('username').value as String,
+        email: values['email'] as String,
+        password: values['password'] as String,
+        username: values['username'] as String,
         firstName: firstName.isEmpty ? null : firstName,
         lastName: lastName.isEmpty ? null : lastName,
       ),
@@ -87,15 +54,15 @@ class _RegisterFormState extends State<RegisterForm> {
       builder: (context, state) {
         final isLoading = state is AuthLoading;
 
-        return ReactiveForm(
-          formGroup: _form,
+        return FormBuilder(
+          key: _formKey,
           child: AutofillGroup(
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.stretch,
               mainAxisSize: MainAxisSize.min,
               children: [
                 AuthTextField(
-                  formControlName: 'email',
+                  name: 'email',
                   label: 'Email',
                   hint: 'Enter your email address',
                   keyboardType: TextInputType.emailAddress,
@@ -103,27 +70,34 @@ class _RegisterFormState extends State<RegisterForm> {
                   textInputAction: TextInputAction.next,
                   enabled: !isLoading,
                   autofocus: true,
-                  validationMessages: {
-                    ValidationMessage.required: (_) => 'Email is required',
-                    ValidationMessage.email: (_) =>
-                        'Enter a valid email address',
-                  },
+                  validator: FormBuilderValidators.compose([
+                    FormBuilderValidators.required(
+                      errorText: 'Email is required',
+                    ),
+                    FormBuilderValidators.email(
+                      errorText: 'Enter a valid email address',
+                    ),
+                  ]),
                 ),
                 const SizedBox(height: 16),
                 AuthTextField(
-                  formControlName: 'username',
+                  name: 'username',
                   label: 'Username',
                   hint: 'Choose a username',
                   autofillHints: const [AutofillHints.username],
                   textInputAction: TextInputAction.next,
                   enabled: !isLoading,
-                  validationMessages: {
-                    ValidationMessage.required: (_) => 'Username is required',
-                    ValidationMessage.minLength: (e) {
-                      final min = (e as Map)['requiredLength'] as int;
-                      return 'Username must be at least $min characters';
-                    },
-                  },
+                  validator: FormBuilderValidators.compose([
+                    FormBuilderValidators.required(
+                      errorText: 'Username is required',
+                    ),
+                    FormBuilderValidators.minLength(
+                      _kMinUsernameLength,
+                      errorText:
+                          'Username must be at least '
+                          '$_kMinUsernameLength characters',
+                    ),
+                  ]),
                 ),
                 const SizedBox(height: 16),
                 // Optional name fields — side by side on wider screens
@@ -131,30 +105,28 @@ class _RegisterFormState extends State<RegisterForm> {
                   children: [
                     Expanded(
                       child: AuthTextField(
-                        formControlName: 'firstName',
+                        name: 'firstName',
                         label: 'First Name',
                         autofillHints: const [AutofillHints.givenName],
                         textInputAction: TextInputAction.next,
                         enabled: !isLoading,
-                        validationMessages: const {},
                       ),
                     ),
                     const SizedBox(width: 12),
                     Expanded(
                       child: AuthTextField(
-                        formControlName: 'lastName',
+                        name: 'lastName',
                         label: 'Last Name',
                         autofillHints: const [AutofillHints.familyName],
                         textInputAction: TextInputAction.next,
                         enabled: !isLoading,
-                        validationMessages: const {},
                       ),
                     ),
                   ],
                 ),
                 const SizedBox(height: 16),
                 AuthTextField(
-                  formControlName: 'password',
+                  name: 'password',
                   label: 'Password',
                   hint: 'Create a password',
                   isPassword: true,
@@ -162,13 +134,17 @@ class _RegisterFormState extends State<RegisterForm> {
                   textInputAction: TextInputAction.done,
                   enabled: !isLoading,
                   onSubmitted: () => _submit(context),
-                  validationMessages: {
-                    ValidationMessage.required: (_) => 'Password is required',
-                    ValidationMessage.minLength: (e) {
-                      final min = (e as Map)['requiredLength'] as int;
-                      return 'Password must be at least $min characters';
-                    },
-                  },
+                  validator: FormBuilderValidators.compose([
+                    FormBuilderValidators.required(
+                      errorText: 'Password is required',
+                    ),
+                    FormBuilderValidators.minLength(
+                      _kMinPasswordLength,
+                      errorText:
+                          'Password must be at least '
+                          '$_kMinPasswordLength characters',
+                    ),
+                  ]),
                 ),
                 const SizedBox(height: 24),
                 Semantics(

--- a/packages/features/auth/pubspec.yaml
+++ b/packages/features/auth/pubspec.yaml
@@ -24,7 +24,8 @@ dependencies:
 
   flutter_bloc: ^9.1.1
   equatable: ^2.0.6
-  reactive_forms: ^18.1.1
+  flutter_form_builder: ^10.3.0
+  form_builder_validators: ^11.3.0
   intl: ^0.20.2
 
 dev_dependencies:

--- a/packages/ui/pubspec.yaml
+++ b/packages/ui/pubspec.yaml
@@ -21,10 +21,6 @@ dependencies:
   di:
     path: ../core/di
 
-  # Forms
-  reactive_forms: ^18.1.1
-  reactive_forms_annotations: ^8.0.1
-
   # Essential UI
   flutter_animate: ^4.5.0
   cached_network_image: ^3.3.1
@@ -77,8 +73,6 @@ dependencies:
   cupertino_icons: ^1.0.9
 
 dev_dependencies:
-  build_runner: ^2.4.12
-  reactive_forms_generator: ^8.0.3
   flutter_lints: ^6.0.0
 
   # Testing

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -515,6 +515,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_form_builder:
+    dependency: transitive
+    description:
+      name: flutter_form_builder
+      sha256: "1233251b4bc1d5deb245745d2a89dcebf4cdd382e1ec3f21f1c6703b700e574f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.3.0+2"
   flutter_lints:
     dependency: transitive
     description:
@@ -682,6 +690,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  form_builder_validators:
+    dependency: transitive
+    description:
+      name: form_builder_validators
+      sha256: cd9a06b35abaed8bf050467c1239e3ee1c8795f42d4cb6568c08dbb8a4d6bd36
+      url: "https://pub.dev"
+    source: hosted
+    version: "11.3.0"
   freezed:
     dependency: transitive
     description:
@@ -1308,30 +1324,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
-  reactive_forms:
-    dependency: transitive
-    description:
-      name: reactive_forms
-      sha256: "4c8fe71f21ac88996c01a56fe19ea5ec39b47292cb07f99a467e1bb977136a98"
-      url: "https://pub.dev"
-    source: hosted
-    version: "18.1.1"
-  reactive_forms_annotations:
-    dependency: transitive
-    description:
-      name: reactive_forms_annotations
-      sha256: da53d15516d02fef91c5bd4761118a814fbecb7e0ee3a6440f81fb5f4983e3d3
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.0.1"
-  reactive_forms_generator:
-    dependency: transitive
-    description:
-      name: reactive_forms_generator
-      sha256: "1f275e78cae31b3dc9f28627a2e83536564090e72a74f1b019dfea9e520a7fea"
-      url: "https://pub.dev"
-    source: hosted
-    version: "8.4.0"
   recase:
     dependency: transitive
     description:
@@ -1874,4 +1866,4 @@ packages:
     version: "2.2.2"
 sdks:
   dart: ">=3.11.0 <4.0.0"
-  flutter: ">=3.35.0"
+  flutter: ">=3.38.0"


### PR DESCRIPTION
## Summary by Sourcery

Migrate auth feature forms from reactive_forms to flutter_form_builder while preserving accessibility behavior for validation errors.

New Features:
- Introduce a FormBuilder-based AuthTextField wrapper that integrates with flutter_form_builder forms and validators.

Enhancements:
- Rework auth text field live-region error announcements to read from FormBuilder field state while keeping screen-reader accessibility.
- Refactor login and registration forms to use FormBuilder with key-based state management and composed validators instead of reactive_forms.

Build:
- Remove reactive_forms and related generator dependencies from ui and auth packages, and add flutter_form_builder and form_builder_validators to the auth package dependencies.