### PR TITLE
feat: global error handling, resolves #34

### DIFF
--- a/packages/app_shell/lib/app_shell.dart
+++ b/packages/app_shell/lib/app_shell.dart
@@ -2,8 +2,9 @@
 ///
 /// Owns the bootstrap sequence ([AppBootstrapCubit] over a platform-supplied
 /// [PlatformBootstrap]), the `go_router` route table (including reserved
-/// deep-link paths, #10), and the shell screens (splash, bootstrap failure,
-/// placeholders, not-yet-available).
+/// deep-link paths, #10), global uncaught-error capture (#34), and the
+/// shell screens (splash, bootstrap failure, placeholders,
+/// not-yet-available).
 ///
 /// Platform composition roots live in `packages/platform/*`; the apps under
 /// `apps/*` are thin `main.dart` wrappers that hand a [PlatformBootstrap]
@@ -14,7 +15,9 @@ export 'src/bootstrap/app_bootstrap_cubit.dart';
 export 'src/bootstrap/app_bootstrap_state.dart';
 export 'src/bootstrap/platform_bootstrap.dart';
 export 'src/bootstrap/run_bge_app.dart';
+export 'src/observability/global_error_hooks.dart';
 export 'src/observability/shell_observability.dart';
+export 'src/observability/uncaught_error_record.dart';
 export 'src/router/app_router.dart';
 export 'src/screens/bootstrap_error_screen.dart';
 export 'src/screens/not_yet_available_screen.dart';

--- a/packages/app_shell/lib/src/bootstrap/run_bge_app.dart
+++ b/packages/app_shell/lib/src/bootstrap/run_bge_app.dart
@@ -1,28 +1,35 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:observability/observability.dart';
 
+import '../observability/global_error_hooks.dart';
+import '../observability/shell_observability.dart';
 import '../widgets/bge_app.dart';
 import 'app_bootstrap_cubit.dart';
 import 'platform_bootstrap.dart';
-import '../observability/shell_observability.dart';
-
-/// Hook for uncaught framework/platform errors (seam for the global error
-/// wiring issue, #34, which will replace this with full zone + reporting
-/// integration).
-typedef UncaughtErrorHandler =
-    void Function(Object error, StackTrace stackTrace);
 
 /// Boots the application. This is the entire contract of each app's
 /// `main.dart`: perform platform-specific setup, then hand a
 /// [PlatformBootstrap] to this function.
 ///
-/// Sequencing: observability (breadcrumb capture) → binding init → error
-/// hooks → construct [AppBootstrapCubit] → start (not await) its
-/// bootstrap → `runApp`. Breadcrumbs attach first so every later step —
-/// including bootstrap failures — is already captured for feedback
-/// reports.
+/// Sequencing: observability (breadcrumb capture + last-error slot) →
+/// binding init → global error hooks → construct [AppBootstrapCubit] →
+/// start (not await) its bootstrap → `runApp`. Breadcrumbs attach first so
+/// every later step — including bootstrap failures — is already captured
+/// for feedback reports.
+///
+/// Error capture (issue #34) is [installGlobalErrorHooks]: the two
+/// catch-all surfaces the Flutter team recommends, with **no custom
+/// Zone** — per official guidance (3.3+), `PlatformDispatcher.onError`
+/// supersedes `runZonedGuarded`. The pre-binding window here is a single
+/// pure-Dart call ([ShellObservability.initialize]) and needs no zone.
+///
+/// `ErrorWidget.builder` (the in-build failure UI) is deliberately NOT
+/// replaced in this bootstrap — that is presentation, split to #66 so the
+/// capture wiring stays reviewable on its own. Until #66 lands, build
+/// failures show Flutter's default error widget while still being fully
+/// captured by the hooks above.
+///
 /// The splash route renders while bootstrap runs; hydrated-storage
 /// initialization happens inside the cubit so its failures surface on the
 /// retryable error screen instead of as a blank frame.
@@ -33,45 +40,12 @@ Future<void> runBgeApp({
   ThemeMode themeMode = ThemeMode.system,
   List<LocalizationsDelegate<dynamic>> additionalLocalizationsDelegates =
       const [],
-  UncaughtErrorHandler? onUncaughtError,
+  UncaughtErrorReporter uncaughtErrorReporter =
+      const NoopUncaughtErrorReporter(),
 }) async {
   ShellObservability.initialize();
-  final binding = WidgetsFlutterBinding.ensureInitialized();
-
-  // Uncaught errors are always breadcrumbed so they appear in feedback
-  // reports; the optional [onUncaughtError] hook is chained on top. Full
-  // zone-based reporting is #34's scope and replaces neither of these.
-  //
-  // We delegate to FlutterError.presentError (the framework's *default*
-  // handler, which is stable across the process) rather than to the
-  // current FlutterError.onError. If runBgeApp runs more than once in a
-  // process (hot restart, some test setups), reading the current handler
-  // would chain our own previous handler into the new one, growing the
-  // chain and duplicating reports on every restart. presentError is a
-  // fixed target, so re-installation is idempotent.
-  final uncaughtLogger = BgeLogger('bge.shell.uncaught');
-  FlutterError.onError = (details) {
-    FlutterError.presentError(details);
-    uncaughtLogger.error(
-      'Uncaught framework error',
-      error: details.exception,
-      stackTrace: details.stack,
-      context: {if (details.library != null) 'library': details.library},
-    );
-    onUncaughtError?.call(
-      details.exception,
-      details.stack ?? StackTrace.current,
-    );
-  };
-  binding.platformDispatcher.onError = (error, stackTrace) {
-    uncaughtLogger.error(
-      'Uncaught platform error',
-      error: error,
-      stackTrace: stackTrace,
-    );
-    onUncaughtError?.call(error, stackTrace);
-    return onUncaughtError != null;
-  };
+  WidgetsFlutterBinding.ensureInitialized();
+  installGlobalErrorHooks(reporter: uncaughtErrorReporter);
 
   final bootstrapCubit = AppBootstrapCubit(
     platformBootstrap: platformBootstrap,

--- a/packages/app_shell/lib/src/observability/global_error_hooks.dart
+++ b/packages/app_shell/lib/src/observability/global_error_hooks.dart
@@ -46,6 +46,17 @@ typedef RecordUncaughtError = void Function(UncaughtErrorRecord record);
 /// async errors; a custom zone risks binding zone-mismatch and bypassing
 /// `onError`. These two hooks are the entire catch-all surface.
 ///
+/// **`onError` returns `true` unconditionally — two deliberate
+/// consequences.** (1) Uncaught async errors are marked handled and do not
+/// propagate to any engine-level/native crash reporter; that is by design
+/// — BGE is privacy-first, and the sole crash sink is the app's own
+/// `FeedbackService` (posting only to the user-controlled server), never a
+/// third-party platform. (2) Widget/integration tests that would otherwise
+/// fail on an uncaught async error pass silently under these hooks;
+/// tests must therefore assert on captured records (inject a [reporter] or
+/// read [ShellObservability.lastUncaughtError]) rather than relying on
+/// uncaught-error propagation.
+///
 /// **Idempotent re-installation.** The framework hook delegates to
 /// [presentError] — when not injected, [FlutterError.presentError] is
 /// read *at invocation time* (it is a mutable static field, so this both
@@ -55,12 +66,34 @@ typedef RecordUncaughtError = void Function(UncaughtErrorRecord record);
 /// process (hot restart, test setups), the new handlers simply replace
 /// the old ones; the chain cannot grow and reports cannot duplicate.
 ///
-/// **Capture path per error:** static-message log via [logger] (the
-/// breadcrumb trail stays PII-free by construction — only the error's
-/// runtime type enters crumb context), then one [UncaughtErrorRecord] is
-/// built and handed to [recordError] (the last-error slot) and
-/// [reporter]. Failures anywhere in that capture path are swallowed and
-/// logged at warn.
+/// **Capture path per error — each side effect is independently
+/// guarded** so no single failure can starve the others or escape the
+/// hook:
+///
+/// 1. [presentError] runs in its own guard (a broken presenter must not
+///    skip capture); it is intentionally OUTSIDE the record/report guard
+///    because swallowing its output is not its job — it is the framework's
+///    console presenter.
+/// 2. The static-message [logger] call (PII-free by construction — only
+///    the error's runtime type enters crumb context) is guarded.
+/// 3. One [UncaughtErrorRecord] is built and handed to [recordError] (the
+///    last-error slot) and [reporter], each in its own guard so a throwing
+///    `recordError` (e.g. a public caller invoking this before
+///    [ShellObservability.initialize]) cannot prevent the [reporter] — the
+///    component that actually uploads crashes — from being notified, and
+///    vice versa.
+///
+/// Every guard routes its own failure to [logger] at warn, so a
+/// crash-inside-crash never propagates (which, on the framework path,
+/// would re-enter these hooks) yet never becomes silent either.
+///
+/// **Re-entrancy.** A [recordError] that notifies listeners (the last-error
+/// slot is a `ValueListenable`, and `FeedbackService` will listen) can, if
+/// a listener throws, route back through `FlutterError.reportError` into
+/// [FlutterError.onError] and re-enter this capture — an unbounded storm
+/// turning one crash into a `StackOverflowError`. A re-entrancy guard
+/// detects the nested call, still presents and logs the secondary error,
+/// but skips the record/report side effects that caused the re-entry.
 ///
 /// `ErrorWidget.builder` (the in-build failure UI) is deliberately NOT
 /// replaced here — that is presentation, split to #66 so this unit stays
@@ -72,47 +105,88 @@ void installGlobalErrorHooks({
   BgeLogger? logger,
 }) {
   final log = logger ?? BgeLogger('bge.shell.uncaught');
+  var inCapture = false;
+
+  /// Runs [action], routing any throw to a warn-level log instead of
+  /// letting it escape the hook (and, on the framework path, re-enter it).
+  void guarded(String failureMessage, void Function() action) {
+    try {
+      action();
+    } catch (error, stackTrace) {
+      log.warn(failureMessage, error: error, stackTrace: stackTrace);
+    }
+  }
 
   void capture(
+    void Function() present,
     String message,
     Object error,
     StackTrace stackTrace, {
     String? library,
   }) {
-    log.error(
-      message,
-      error: error,
-      stackTrace: stackTrace,
-      context: {'errorType': error.runtimeType.toString(), 'library': ?library},
-    );
-    try {
-      final record = UncaughtErrorRecord.capture(error, stackTrace);
-      recordError(record);
-      reporter.report(record);
-    } catch (captureError, captureStack) {
-      // A crash inside crash capture must never propagate — it would
-      // re-enter these hooks (framework path) or crash the app
-      // (platform path returns true regardless).
+    // Present first and always — it is the framework's console presenter,
+    // guarded only so a broken presenter can't skip capture below.
+    guarded('Uncaught-error presentation failed', present);
+
+    // Re-entrancy guard: a throwing last-error listener routes back through
+    // FlutterError.reportError into FlutterError.onError and re-enters
+    // here. Present + log the nested error (above/below) but skip the
+    // record/report side effects that triggered it, breaking the loop.
+    if (inCapture) {
       log.warn(
-        'Uncaught-error capture failed',
-        error: captureError,
-        stackTrace: captureStack,
+        'Re-entrant uncaught error during capture; skipping record/report',
+        error: error,
+        stackTrace: stackTrace,
       );
+      return;
+    }
+    inCapture = true;
+    try {
+      // Logged before the record is built so the error is breadcrumbed even
+      // if record construction throws. Guarded because a custom log sink
+      // could throw. errorType is recomputed in UncaughtErrorRecord.capture;
+      // the duplication is deliberate for exactly this ordering.
+      guarded('Uncaught-error logging failed', () {
+        log.error(
+          message,
+          error: error,
+          stackTrace: stackTrace,
+          context: {
+            'errorType': error.runtimeType.toString(),
+            'library': ?library,
+          },
+        );
+      });
+
+      final record = UncaughtErrorRecord.capture(error, stackTrace);
+      // Independent guards: a throwing recordError (e.g. invoked before
+      // ShellObservability.initialize) must not prevent the reporter — the
+      // component that uploads crashes — from being notified, and vice
+      // versa. UncaughtErrorReporter.report's "called once per uncaught
+      // error" contract depends on this.
+      guarded('Uncaught-error slot update failed', () => recordError(record));
+      guarded('Uncaught-error report failed', () => reporter.report(record));
+    } finally {
+      inCapture = false;
     }
   }
 
   FlutterError.onError = (details) {
-    (presentError ?? FlutterError.presentError)(details);
     capture(
+      () => (presentError ?? FlutterError.presentError)(details),
       'Uncaught framework error',
       details.exception,
+      // Best-effort fallback: a framework error without a stack is rare;
+      // when it happens the hook's own stack is a poorer localisation than
+      // the (absent) failure site, but better than an empty trace.
       details.stack ?? StackTrace.current,
       library: details.library,
     );
   };
 
   PlatformDispatcher.instance.onError = (error, stackTrace) {
-    capture('Uncaught platform error', error, stackTrace);
+    // No presenter on the platform path; pass a no-op.
+    capture(() {}, 'Uncaught platform error', error, stackTrace);
     return true;
   };
 }

--- a/packages/app_shell/lib/src/observability/global_error_hooks.dart
+++ b/packages/app_shell/lib/src/observability/global_error_hooks.dart
@@ -1,0 +1,118 @@
+import 'package:flutter/foundation.dart';
+import 'package:observability/observability.dart';
+
+import 'shell_observability.dart';
+import 'uncaught_error_record.dart';
+
+/// Consumes captured [UncaughtErrorRecord]s (issue #34).
+///
+/// The seam the follow-up `FeedbackService` wiring implements. The
+/// default is [NoopUncaughtErrorReporter]: capture (logging, breadcrumbs,
+/// the last-error slot) happens regardless; *reporting* is opt-in.
+abstract interface class UncaughtErrorReporter {
+  /// Called once per uncaught error with the same record instance that
+  /// filled the last-error slot. Implementations must not assume they run
+  /// on any particular zone or that UI exists yet; errors thrown here are
+  /// swallowed by the hooks (a crash inside crash reporting must never
+  /// take the app down).
+  void report(UncaughtErrorRecord record);
+}
+
+/// Default reporter: does nothing.
+final class NoopUncaughtErrorReporter implements UncaughtErrorReporter {
+  const NoopUncaughtErrorReporter();
+
+  @override
+  void report(UncaughtErrorRecord record) {}
+}
+
+/// Sink for captured records; defaults to
+/// [ShellObservability.recordUncaughtError].
+typedef RecordUncaughtError = void Function(UncaughtErrorRecord record);
+
+/// Installs the process-global uncaught-error hooks (issue #34).
+///
+/// Wires the two catch-all surfaces the Flutter team recommends:
+///
+/// - [FlutterError.onError] — framework errors (build/layout/paint).
+///   Delegates first to [presentError] so console output survives, then
+///   captures.
+/// - [PlatformDispatcher.instance.onError] — uncaught async and non-UI
+///   Dart errors. Returns `true` unconditionally after capture; returning
+///   `false` can hard-crash the app.
+///
+/// **No custom Zone.** Per official Flutter guidance (3.3+),
+/// `PlatformDispatcher.onError` supersedes `runZonedGuarded` for uncaught
+/// async errors; a custom zone risks binding zone-mismatch and bypassing
+/// `onError`. These two hooks are the entire catch-all surface.
+///
+/// **Idempotent re-installation.** The framework hook delegates to
+/// [presentError] — when not injected, [FlutterError.presentError] is
+/// read *at invocation time* (it is a mutable static field, so this both
+/// satisfies const-default rules and always honours the framework's
+/// current presenter, e.g. under test bindings) — and never reads or
+/// chains the previous `onError`. If this runs more than once in a
+/// process (hot restart, test setups), the new handlers simply replace
+/// the old ones; the chain cannot grow and reports cannot duplicate.
+///
+/// **Capture path per error:** static-message log via [logger] (the
+/// breadcrumb trail stays PII-free by construction — only the error's
+/// runtime type enters crumb context), then one [UncaughtErrorRecord] is
+/// built and handed to [recordError] (the last-error slot) and
+/// [reporter]. Failures anywhere in that capture path are swallowed and
+/// logged at warn.
+///
+/// `ErrorWidget.builder` (the in-build failure UI) is deliberately NOT
+/// replaced here — that is presentation, split to #66 so this unit stays
+/// capture-only.
+void installGlobalErrorHooks({
+  FlutterExceptionHandler? presentError,
+  UncaughtErrorReporter reporter = const NoopUncaughtErrorReporter(),
+  RecordUncaughtError recordError = ShellObservability.recordUncaughtError,
+  BgeLogger? logger,
+}) {
+  final log = logger ?? BgeLogger('bge.shell.uncaught');
+
+  void capture(
+    String message,
+    Object error,
+    StackTrace stackTrace, {
+    String? library,
+  }) {
+    log.error(
+      message,
+      error: error,
+      stackTrace: stackTrace,
+      context: {'errorType': error.runtimeType.toString(), 'library': ?library},
+    );
+    try {
+      final record = UncaughtErrorRecord.capture(error, stackTrace);
+      recordError(record);
+      reporter.report(record);
+    } catch (captureError, captureStack) {
+      // A crash inside crash capture must never propagate — it would
+      // re-enter these hooks (framework path) or crash the app
+      // (platform path returns true regardless).
+      log.warn(
+        'Uncaught-error capture failed',
+        error: captureError,
+        stackTrace: captureStack,
+      );
+    }
+  }
+
+  FlutterError.onError = (details) {
+    (presentError ?? FlutterError.presentError)(details);
+    capture(
+      'Uncaught framework error',
+      details.exception,
+      details.stack ?? StackTrace.current,
+      library: details.library,
+    );
+  };
+
+  PlatformDispatcher.instance.onError = (error, stackTrace) {
+    capture('Uncaught platform error', error, stackTrace);
+    return true;
+  };
+}

--- a/packages/app_shell/lib/src/observability/shell_observability.dart
+++ b/packages/app_shell/lib/src/observability/shell_observability.dart
@@ -4,6 +4,8 @@ import 'package:flutter/foundation.dart';
 import 'package:logging/logging.dart';
 import 'package:observability/observability.dart';
 
+import 'uncaught_error_record.dart';
+
 /// Process-wide observability wiring owned by the shell.
 ///
 /// `package:logging` is inherently global (loggers propagate to
@@ -12,11 +14,13 @@ import 'package:observability/observability.dart';
 /// the ring buffer has history from the very first bootstrap step — which
 /// is exactly what a feedback report about "the app won't start" needs.
 ///
-/// The feedback UI ("ask each time" in alpha) consumes [breadcrumbs] via
-/// `FeedbackService` when that wiring lands; #34 layers full zone-based
-/// error reporting on top of the same buffer.
+/// The feedback UI ("ask each time" in alpha) consumes [breadcrumbs] and
+/// [lastUncaughtError] via `FeedbackService` when that wiring lands;
+/// `installGlobalErrorHooks` (issue #34) feeds [lastUncaughtError] through
+/// [recordUncaughtError].
 abstract final class ShellObservability {
   static BreadcrumbBuffer? _buffer;
+  static ValueNotifier<UncaughtErrorRecord?>? _lastUncaughtError;
   static StreamSubscription<LogRecord>? _debugConsoleSubscription;
   static Level? _previousRootLevel;
 
@@ -34,7 +38,55 @@ abstract final class ShellObservability {
     return buffer;
   }
 
+  /// Single-slot, RAM-only record of the last uncaught error (issue #34).
+  ///
+  /// Stack traces stay **out** of the [BreadcrumbBuffer] by design (the
+  /// backend DTO has a dedicated `stackTrace` field, traces aren't
+  /// pattern-redacted, and the 100-slot ring must stay small); this slot
+  /// is where the last crash's full detail lives until the user submits —
+  /// or declines — a feedback report. Exposed as a [ValueListenable] so
+  /// the feedback prompt can react to a crash landing instead of polling.
+  ///
+  /// Throws before [initialize] — same fail-fast contract as
+  /// [breadcrumbs].
+  static ValueListenable<UncaughtErrorRecord?> get lastUncaughtError =>
+      _lastUncaughtErrorOrThrow;
+
+  static ValueNotifier<UncaughtErrorRecord?> get _lastUncaughtErrorOrThrow {
+    final notifier = _lastUncaughtError;
+    if (notifier == null) {
+      throw StateError(
+        'ShellObservability.initialize() must run before lastUncaughtError '
+        'is used; runBgeApp does this first.',
+      );
+    }
+    return notifier;
+  }
+
   static bool get isInitialized => _buffer != null;
+
+  /// Publishes [record] as the last uncaught error, replacing any
+  /// previous record (single slot — most recent crash wins) and notifying
+  /// listeners.
+  ///
+  /// Throws before [initialize]: silently dropping a crash would lose
+  /// exactly the data a feedback report needs, so the ordering bug fails
+  /// fast instead. (`installGlobalErrorHooks` additionally guards its
+  /// capture path, so a mis-ordered production install degrades to a
+  /// warn-level log rather than a secondary crash.)
+  static void recordUncaughtError(UncaughtErrorRecord record) {
+    _lastUncaughtErrorOrThrow.value = record;
+  }
+
+  /// Empties the last-error slot, notifying listeners. Called after a
+  /// feedback report is submitted, or when the user declines to send one.
+  ///
+  /// Safe to call before [initialize] or after [reset] — clearing a slot
+  /// that does not exist is harmless by definition, unlike recording,
+  /// where dropping data silently would matter.
+  static void clearUncaughtError() {
+    _lastUncaughtError?.value = null;
+  }
 
   /// Attaches breadcrumb capture. Idempotent.
   ///
@@ -48,6 +100,7 @@ abstract final class ShellObservability {
     _previousRootLevel = Logger.root.level;
     Logger.root.level = Level.ALL;
     _buffer = (buffer ?? BreadcrumbBuffer())..attach();
+    _lastUncaughtError = ValueNotifier<UncaughtErrorRecord?>(null);
     if (kDebugMode) {
       _debugConsoleSubscription = Logger.root.onRecord.listen((record) {
         debugPrint(
@@ -61,11 +114,14 @@ abstract final class ShellObservability {
   /// Detaches and clears all wiring so tests can re-initialize cleanly,
   /// including restoring [Logger.root]'s level to whatever it was before
   /// [initialize] raised it — otherwise the `Level.ALL` override would leak
-  /// across tests and into embedding apps.
+  /// across tests and into embedding apps. Disposes the last-error
+  /// notifier so recorded crash state cannot leak either.
   @visibleForTesting
   static Future<void> reset() async {
     await _buffer?.detach();
     _buffer = null;
+    _lastUncaughtError?.dispose();
+    _lastUncaughtError = null;
     await _debugConsoleSubscription?.cancel();
     _debugConsoleSubscription = null;
     if (_previousRootLevel != null) {

--- a/packages/app_shell/lib/src/observability/shell_observability.dart
+++ b/packages/app_shell/lib/src/observability/shell_observability.dart
@@ -27,15 +27,19 @@ abstract final class ShellObservability {
   /// The process-wide breadcrumb ring buffer. Throws if [initialize] has
   /// not run yet — that ordering bug should fail fast, not report empty
   /// breadcrumbs.
-  static BreadcrumbBuffer get breadcrumbs {
-    final buffer = _buffer;
-    if (buffer == null) {
+  static BreadcrumbBuffer get breadcrumbs =>
+      _require(_buffer, 'breadcrumbs are read');
+
+  /// Fail-fast accessor shared by [breadcrumbs] and the last-error slot so
+  /// the two "initialize() must run first" messages can't drift apart.
+  static T _require<T>(T? value, String usage) {
+    if (value == null) {
       throw StateError(
-        'ShellObservability.initialize() must run before breadcrumbs are '
-        'read; runBgeApp does this first.',
+        'ShellObservability.initialize() must run before $usage; '
+        'runBgeApp does this first.',
       );
     }
-    return buffer;
+    return value;
   }
 
   /// Single-slot, RAM-only record of the last uncaught error (issue #34).
@@ -52,16 +56,8 @@ abstract final class ShellObservability {
   static ValueListenable<UncaughtErrorRecord?> get lastUncaughtError =>
       _lastUncaughtErrorOrThrow;
 
-  static ValueNotifier<UncaughtErrorRecord?> get _lastUncaughtErrorOrThrow {
-    final notifier = _lastUncaughtError;
-    if (notifier == null) {
-      throw StateError(
-        'ShellObservability.initialize() must run before lastUncaughtError '
-        'is used; runBgeApp does this first.',
-      );
-    }
-    return notifier;
-  }
+  static ValueNotifier<UncaughtErrorRecord?> get _lastUncaughtErrorOrThrow =>
+      _require(_lastUncaughtError, 'lastUncaughtError is used');
 
   static bool get isInitialized => _buffer != null;
 

--- a/packages/app_shell/lib/src/observability/uncaught_error_record.dart
+++ b/packages/app_shell/lib/src/observability/uncaught_error_record.dart
@@ -1,0 +1,59 @@
+import 'package:observability/observability.dart';
+
+/// Immutable, RAM-only record of the last uncaught error (issue #34).
+///
+/// One instance feeds two consumers: `ShellObservability`'s single-slot
+/// last-error notifier (read later by the alpha "ask each time" feedback
+/// prompt) and the injectable `UncaughtErrorReporter` seam.
+///
+/// ## Sanitisation at capture
+///
+/// [message] is the error's `toString()` run through
+/// [Redaction.redactEmailsIn] at construction — matching the
+/// BreadcrumbBuffer's capture-time philosophy, so nothing downstream has
+/// to remember to redact. The raw error object is deliberately **not**
+/// retained: keeping it would reintroduce the unredacted text through the
+/// back door.
+///
+/// ## Stack traces
+///
+/// [stackTrace] is kept verbatim — it is the one piece
+/// `FeedbackService.buildReport` needs untouched (tail-preserving
+/// truncation against protocol caps happens there, not here). Traces are
+/// not pattern-redacted anywhere; the privacy control is that this record
+/// lives only in RAM and never persists to disk, so it is wiped when the
+/// OS ends the process. It leaves the device only inside a feedback
+/// report the user has explicitly reviewed and submitted.
+final class UncaughtErrorRecord {
+  /// Captures [error] and [stackTrace], redacting the error text now.
+  ///
+  /// [timestamp] defaults to construction time; injectable for tests.
+  UncaughtErrorRecord.capture(
+    Object error,
+    this.stackTrace, {
+    DateTime? timestamp,
+  }) : message = Redaction.redactEmailsIn(error.toString()),
+       errorType = error.runtimeType.toString(),
+       timestamp = timestamp ?? DateTime.now();
+
+  /// The error's `toString()`, email-redacted at capture.
+  final String message;
+
+  /// The error's runtime type name (e.g. `StateError`) — safe to put in
+  /// breadcrumb context and report titles without leaking message
+  /// contents.
+  final String errorType;
+
+  /// The stack trace exactly as thrown. Never logged into the breadcrumb
+  /// ring; see the class docs for where it is (and isn't) allowed to go.
+  final StackTrace stackTrace;
+
+  /// When the error was captured.
+  final DateTime timestamp;
+
+  /// Deliberately excludes [message] and [stackTrace] so an incidental
+  /// `toString()` (interpolation, `Object?` logging) can't re-leak
+  /// details outside the reviewed feedback path.
+  @override
+  String toString() => 'UncaughtErrorRecord($errorType at $timestamp)';
+}

--- a/packages/app_shell/test/observability/global_error_hooks_test.dart
+++ b/packages/app_shell/test/observability/global_error_hooks_test.dart
@@ -1,0 +1,241 @@
+import 'dart:ui';
+
+import 'package:app_shell/app_shell.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:observability/observability.dart';
+
+/// Red-phase tests for `installGlobalErrorHooks` (issue #34).
+///
+/// Design decisions pinned here (see #34 for rationale):
+///
+/// - **No custom Zone.** Per official Flutter guidance (3.3+),
+///   `PlatformDispatcher.instance.onError` supersedes `runZonedGuarded`;
+///   these hooks are the entire catch-all surface.
+/// - **Idempotent re-installation.** The framework hook delegates to an
+///   injectable `presentError` (defaulting to `FlutterError.presentError`,
+///   a fixed target) and never reads/chains the previous handler, so hot
+///   restart cannot grow a handler chain or duplicate reports.
+/// - **`onError` returns `true` unconditionally** after capture —
+///   returning `false` can hard-crash the app.
+/// - **Reporter failures are swallowed.** A crash inside crash reporting
+///   must never take the app down or re-enter the hooks.
+///
+/// Presentation of build failures (`ErrorWidget.builder`) is deliberately
+/// NOT wired here — split to #66 to keep this unit capture-only.
+///
+/// Handlers are process globals, so every test saves and restores both
+/// hooks; leaking a test handler would corrupt the rest of the suite.
+class _RecordingReporter implements UncaughtErrorReporter {
+  final List<UncaughtErrorRecord> records = [];
+
+  @override
+  void report(UncaughtErrorRecord record) => records.add(record);
+}
+
+class _ThrowingReporter implements UncaughtErrorReporter {
+  @override
+  void report(UncaughtErrorRecord record) =>
+      throw StateError('reporter exploded');
+}
+
+void main() {
+  late FlutterExceptionHandler? savedFlutterOnError;
+  late ErrorCallback? savedDispatcherOnError;
+
+  setUp(() {
+    savedFlutterOnError = FlutterError.onError;
+    savedDispatcherOnError = PlatformDispatcher.instance.onError;
+  });
+
+  tearDown(() async {
+    FlutterError.onError = savedFlutterOnError;
+    PlatformDispatcher.instance.onError = savedDispatcherOnError;
+    await ShellObservability.reset();
+  });
+
+  FlutterErrorDetails frameworkDetails({Object? exception}) =>
+      FlutterErrorDetails(
+        exception: exception ?? StateError('framework boom'),
+        stack: StackTrace.current,
+        library: 'test harness',
+      );
+
+  group('installGlobalErrorHooks — FlutterError.onError', () {
+    test('delegates to the injected presentError so console output '
+        'survives, then reports exactly once', () {
+      final presented = <FlutterErrorDetails>[];
+      final reporter = _RecordingReporter();
+      installGlobalErrorHooks(
+        presentError: presented.add,
+        reporter: reporter,
+        recordError: (_) {},
+      );
+
+      final details = frameworkDetails();
+      FlutterError.onError!(details);
+
+      expect(presented, [same(details)]);
+      expect(reporter.records, hasLength(1));
+    });
+
+    test('the reported record carries the redacted message, error type, '
+        'and original stack trace', () {
+      final reporter = _RecordingReporter();
+      UncaughtErrorRecord? recorded;
+      installGlobalErrorHooks(
+        presentError: (_) {},
+        reporter: reporter,
+        recordError: (record) => recorded = record,
+      );
+
+      final trace = StackTrace.current;
+      FlutterError.onError!(
+        FlutterErrorDetails(
+          exception: Exception('failed for john.doe@email.com'),
+          stack: trace,
+          library: 'test harness',
+        ),
+      );
+
+      final record = reporter.records.single;
+      expect(record.message, contains('j**n.d*e@email.com'));
+      expect(record.message, isNot(contains('john.doe@email.com')));
+      expect(record.stackTrace, same(trace));
+      expect(
+        recorded,
+        same(record),
+        reason:
+            'the same record instance feeds the last-error slot and '
+            'the reporter — one capture, two consumers',
+      );
+    });
+
+    test('a throwing reporter is swallowed — a crash inside crash '
+        'reporting must not propagate', () {
+      installGlobalErrorHooks(
+        presentError: (_) {},
+        reporter: _ThrowingReporter(),
+        recordError: (_) {},
+      );
+
+      expect(() => FlutterError.onError!(frameworkDetails()), returnsNormally);
+    });
+  });
+
+  group('installGlobalErrorHooks — PlatformDispatcher.onError', () {
+    test('captures the error and returns true unconditionally', () {
+      final reporter = _RecordingReporter();
+      installGlobalErrorHooks(
+        presentError: (_) {},
+        reporter: reporter,
+        recordError: (_) {},
+      );
+
+      final handler = PlatformDispatcher.instance.onError;
+      expect(handler, isNotNull);
+
+      final handled = handler!(StateError('async boom'), StackTrace.current);
+
+      expect(handled, isTrue);
+      expect(reporter.records, hasLength(1));
+      expect(reporter.records.single.errorType, 'StateError');
+    });
+
+    test('returns true even when the reporter throws — capture failure '
+        'must not let the engine treat the error as unhandled', () {
+      installGlobalErrorHooks(
+        presentError: (_) {},
+        reporter: _ThrowingReporter(),
+        recordError: (_) {},
+      );
+
+      final handled = PlatformDispatcher.instance.onError!(
+        StateError('async boom'),
+        StackTrace.current,
+      );
+
+      expect(handled, isTrue);
+    });
+  });
+
+  group('installGlobalErrorHooks — idempotent re-installation', () {
+    test('installing twice does not chain handlers: one framework error '
+        'still presents and reports exactly once (hot-restart safety)', () {
+      final presented = <FlutterErrorDetails>[];
+      final reporter = _RecordingReporter();
+      void install() => installGlobalErrorHooks(
+        presentError: presented.add,
+        reporter: reporter,
+        recordError: (_) {},
+      );
+
+      install();
+      install();
+
+      FlutterError.onError!(frameworkDetails());
+      expect(presented, hasLength(1));
+      expect(reporter.records, hasLength(1));
+    });
+
+    test('installing twice reports one dispatcher error exactly once', () {
+      final reporter = _RecordingReporter();
+      void install() => installGlobalErrorHooks(
+        presentError: (_) {},
+        reporter: reporter,
+        recordError: (_) {},
+      );
+
+      install();
+      install();
+
+      PlatformDispatcher.instance.onError!(
+        StateError('async boom'),
+        StackTrace.current,
+      );
+      expect(reporter.records, hasLength(1));
+    });
+  });
+
+  group('installGlobalErrorHooks — observability integration (defaults)', () {
+    test('an uncaught framework error lands as a redaction-safe breadcrumb '
+        'with the error type in context, and fills the last-error slot', () {
+      ShellObservability.initialize();
+      installGlobalErrorHooks(presentError: (_) {});
+
+      FlutterError.onError!(frameworkDetails());
+
+      final crumb = ShellObservability.breadcrumbs.snapshot().last;
+      expect(crumb.message, 'Uncaught framework error');
+      expect(crumb.loggerName, 'bge.shell.uncaught');
+      expect(crumb.level, BgeLogLevel.error);
+      expect(crumb.sanitizedContext, containsPair('errorType', 'StateError'));
+
+      final last = ShellObservability.lastUncaughtError.value;
+      expect(last, isNotNull);
+      expect(last!.errorType, 'StateError');
+    });
+
+    test('an uncaught platform error breadcrumbs as "Uncaught platform '
+        'error" and fills the last-error slot', () {
+      ShellObservability.initialize();
+      installGlobalErrorHooks(presentError: (_) {});
+
+      PlatformDispatcher.instance.onError!(
+        FormatException('bad payload'),
+        StackTrace.current,
+      );
+
+      final crumb = ShellObservability.breadcrumbs.snapshot().last;
+      expect(crumb.message, 'Uncaught platform error');
+      expect(
+        crumb.sanitizedContext,
+        containsPair('errorType', 'FormatException'),
+      );
+      expect(
+        ShellObservability.lastUncaughtError.value?.errorType,
+        'FormatException',
+      );
+    });
+  });
+}

--- a/packages/app_shell/test/observability/global_error_hooks_test.dart
+++ b/packages/app_shell/test/observability/global_error_hooks_test.dart
@@ -39,6 +39,15 @@ class _ThrowingReporter implements UncaughtErrorReporter {
       throw StateError('reporter exploded');
 }
 
+/// A reporter that counts calls — used to prove the reporter still fires
+/// when the *other* side effect (recordError) throws.
+class _CountingReporter implements UncaughtErrorReporter {
+  int calls = 0;
+
+  @override
+  void report(UncaughtErrorRecord record) => calls++;
+}
+
 void main() {
   late FlutterExceptionHandler? savedFlutterOnError;
   late ErrorCallback? savedDispatcherOnError;
@@ -112,7 +121,9 @@ void main() {
     });
 
     test('a throwing reporter is swallowed — a crash inside crash '
-        'reporting must not propagate', () {
+        'reporting must not propagate — and the failure is logged at warn '
+        'so it never becomes silent', () {
+      ShellObservability.initialize();
       installGlobalErrorHooks(
         presentError: (_) {},
         reporter: _ThrowingReporter(),
@@ -120,6 +131,15 @@ void main() {
       );
 
       expect(() => FlutterError.onError!(frameworkDetails()), returnsNormally);
+
+      final warns = ShellObservability.breadcrumbs.snapshot().where(
+        (c) =>
+            c.level == BgeLogLevel.warn &&
+            c.message ==
+                'Uncaught-error '
+                    'report failed',
+      );
+      expect(warns, hasLength(1));
     });
   });
 
@@ -159,35 +179,43 @@ void main() {
     });
   });
 
-  group('installGlobalErrorHooks — idempotent re-installation', () {
-    test('installing twice does not chain handlers: one framework error '
-        'still presents and reports exactly once (hot-restart safety)', () {
-      final presented = <FlutterErrorDetails>[];
+  group('installGlobalErrorHooks — independent side-effect guards', () {
+    test('a throwing recordError does not starve the reporter — the '
+        'component that uploads crashes must still be notified', () {
+      final reporter = _CountingReporter();
+      installGlobalErrorHooks(
+        presentError: (_) {},
+        reporter: reporter,
+        recordError: (_) => throw StateError('slot not ready'),
+      );
+
+      expect(() => FlutterError.onError!(frameworkDetails()), returnsNormally);
+      expect(reporter.calls, 1);
+    });
+
+    test('a throwing presentError does not skip capture', () {
       final reporter = _RecordingReporter();
-      void install() => installGlobalErrorHooks(
-        presentError: presented.add,
+      installGlobalErrorHooks(
+        presentError: (_) => throw StateError('bad presenter'),
         reporter: reporter,
         recordError: (_) {},
       );
 
-      install();
-      install();
-
-      FlutterError.onError!(frameworkDetails());
-      expect(presented, hasLength(1));
+      expect(() => FlutterError.onError!(frameworkDetails()), returnsNormally);
       expect(reporter.records, hasLength(1));
     });
 
-    test('installing twice reports one dispatcher error exactly once', () {
+    test('presentError runs even for the platform path is not applicable — '
+        'the platform hook still captures with a no-op presenter', () {
       final reporter = _RecordingReporter();
-      void install() => installGlobalErrorHooks(
-        presentError: (_) {},
+      installGlobalErrorHooks(
+        presentError: (_) => fail(
+          'presentError must not run on the '
+          'platform path',
+        ),
         reporter: reporter,
         recordError: (_) {},
       );
-
-      install();
-      install();
 
       PlatformDispatcher.instance.onError!(
         StateError('async boom'),
@@ -195,6 +223,68 @@ void main() {
       );
       expect(reporter.records, hasLength(1));
     });
+  });
+
+  group('installGlobalErrorHooks — re-entrancy guard', () {
+    test('a last-error listener that throws does not cause an unbounded '
+        'capture storm; the nested error is logged and side effects are '
+        'skipped', () {
+      ShellObservability.initialize();
+      // A real listener on the slot that throws — exactly the shape a buggy
+      // FeedbackService listener would take. Its throw routes through
+      // ChangeNotifier.notifyListeners → FlutterError.reportError →
+      // FlutterError.onError, re-entering capture.
+      ShellObservability.lastUncaughtError.addListener(
+        () => throw StateError('listener exploded'),
+      );
+      installGlobalErrorHooks(presentError: (_) {});
+
+      // Without the guard this recurses to a StackOverflowError.
+      expect(() => FlutterError.onError!(frameworkDetails()), returnsNormally);
+
+      final reentrantWarns = ShellObservability.breadcrumbs.snapshot().where(
+        (c) =>
+            c.level == BgeLogLevel.warn &&
+            c.message.startsWith('Re-entrant uncaught error'),
+      );
+      expect(reentrantWarns, isNotEmpty);
+    });
+  });
+
+  test('installing twice does not chain handlers: one framework error '
+      'still presents and reports exactly once (hot-restart safety)', () {
+    final presented = <FlutterErrorDetails>[];
+    final reporter = _RecordingReporter();
+    void install() => installGlobalErrorHooks(
+      presentError: presented.add,
+      reporter: reporter,
+      recordError: (_) {},
+    );
+
+    install();
+    install();
+
+    FlutterError.onError!(frameworkDetails());
+    expect(presented, hasLength(1));
+    expect(reporter.records, hasLength(1));
+  });
+
+  test('installing twice reports one dispatcher error exactly once', () {
+    final reporter = _RecordingReporter();
+    void install() => installGlobalErrorHooks(
+      presentError: (_) {},
+      reporter: reporter,
+      recordError: (_) {},
+    );
+
+    install();
+    install();
+
+    PlatformDispatcher.instance.onError!(
+      StateError('async boom'),
+      StackTrace.current,
+    );
+    expect(reporter.records, hasLength(1));
   });
 
   group('installGlobalErrorHooks — observability integration (defaults)', () {

--- a/packages/app_shell/test/observability/shell_observability_test.dart
+++ b/packages/app_shell/test/observability/shell_observability_test.dart
@@ -65,4 +65,82 @@ void main() {
       expect(Logger.root.level, Level.WARNING);
     });
   });
+
+  group('ShellObservability.lastUncaughtError (issue #34)', () {
+    // Single-slot, RAM-only crash record. Stack traces stay OUT of the
+    // BreadcrumbBuffer by design (dedicated `stackTrace` DTO field on the
+    // backend, traces aren't pattern-redacted, and the ring must stay
+    // small); this slot is where the last uncaught error's full detail
+    // lives until the user submits — or declines — a feedback report.
+
+    UncaughtErrorRecord record([String message = 'boom']) =>
+        UncaughtErrorRecord.capture(StateError(message), StackTrace.current);
+
+    test('throws before initialize() — same fail-fast contract as '
+        'breadcrumbs', () {
+      expect(() => ShellObservability.lastUncaughtError, throwsStateError);
+    });
+
+    test('recordUncaughtError throws before initialize() rather than '
+        'silently dropping a crash', () {
+      expect(
+        () => ShellObservability.recordUncaughtError(record()),
+        throwsStateError,
+      );
+    });
+
+    test('starts empty after initialize()', () {
+      ShellObservability.initialize();
+
+      expect(ShellObservability.lastUncaughtError.value, isNull);
+    });
+
+    test('recordUncaughtError publishes the record and notifies listeners '
+        'so the feedback prompt can react instead of polling', () {
+      ShellObservability.initialize();
+      var notifications = 0;
+      ShellObservability.lastUncaughtError.addListener(() => notifications++);
+
+      final crash = record();
+      ShellObservability.recordUncaughtError(crash);
+
+      expect(ShellObservability.lastUncaughtError.value, same(crash));
+      expect(notifications, 1);
+    });
+
+    test('a second record replaces the first — single slot, most recent '
+        'crash wins', () {
+      ShellObservability.initialize();
+
+      ShellObservability.recordUncaughtError(record('first'));
+      final second = record('second');
+      ShellObservability.recordUncaughtError(second);
+
+      expect(ShellObservability.lastUncaughtError.value, same(second));
+    });
+
+    test('clearUncaughtError empties the slot and notifies — called after '
+        'a report is submitted or the user declines', () {
+      ShellObservability.initialize();
+      ShellObservability.recordUncaughtError(record());
+      var notifications = 0;
+      ShellObservability.lastUncaughtError.addListener(() => notifications++);
+
+      ShellObservability.clearUncaughtError();
+
+      expect(ShellObservability.lastUncaughtError.value, isNull);
+      expect(notifications, 1);
+    });
+
+    test('reset() drops the recorded error so crash state cannot leak '
+        'across tests or re-initializations', () async {
+      ShellObservability.initialize();
+      ShellObservability.recordUncaughtError(record());
+
+      await ShellObservability.reset();
+      ShellObservability.initialize();
+
+      expect(ShellObservability.lastUncaughtError.value, isNull);
+    });
+  });
 }

--- a/packages/app_shell/test/observability/uncaught_error_record_test.dart
+++ b/packages/app_shell/test/observability/uncaught_error_record_test.dart
@@ -1,0 +1,82 @@
+import 'package:app_shell/app_shell.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+/// Red-phase tests for [UncaughtErrorRecord] (issue #34).
+///
+/// The record is the RAM-only payload held in ShellObservability's
+/// single-slot last-error notifier and handed to UncaughtErrorReporter
+/// implementations. Sanitisation happens at construction — matching the
+/// BreadcrumbBuffer's capture-time philosophy — so nothing downstream has
+/// to remember to redact. Stack traces are kept raw (they are not
+/// pattern-redacted anywhere; the privacy control is that they never
+/// leave RAM until the user explicitly submits a feedback report).
+void main() {
+  group('UncaughtErrorRecord.capture', () {
+    test('redacts email addresses in the error message at construction', () {
+      final record = UncaughtErrorRecord.capture(
+        Exception('login failed for john.doe@email.com'),
+        StackTrace.current,
+      );
+
+      // Exact masked shape is pinned by redaction_test.dart; here we pin
+      // that the record went through Redaction.redactEmailsIn.
+      expect(record.message, contains('j**n.d*e@email.com'));
+      expect(record.message, isNot(contains('john.doe@email.com')));
+    });
+
+    test('keeps the message unchanged when no email is present', () {
+      final record = UncaughtErrorRecord.capture(
+        StateError('nothing sensitive here'),
+        StackTrace.current,
+      );
+
+      expect(record.message, 'Bad state: nothing sensitive here');
+    });
+
+    test('records the error runtime type so crumb context and reports can '
+        'name what crashed without leaking message contents', () {
+      final record = UncaughtErrorRecord.capture(
+        StateError('boom'),
+        StackTrace.current,
+      );
+
+      expect(record.errorType, 'StateError');
+    });
+
+    test('preserves the stack trace instance untouched — the trace is the '
+        'one piece FeedbackService needs verbatim', () {
+      final trace = StackTrace.current;
+
+      final record = UncaughtErrorRecord.capture(StateError('boom'), trace);
+
+      expect(record.stackTrace, same(trace));
+    });
+
+    test('timestamp defaults to construction time', () {
+      final before = DateTime.now();
+      final record = UncaughtErrorRecord.capture(
+        StateError('boom'),
+        StackTrace.current,
+      );
+      final after = DateTime.now();
+
+      expect(
+        record.timestamp.isBefore(before) || record.timestamp.isAfter(after),
+        isFalse,
+        reason: 'timestamp must fall within the construction window',
+      );
+    });
+
+    test('an injected timestamp is respected (testability seam)', () {
+      final fixed = DateTime.utc(2026, 7, 7, 12);
+
+      final record = UncaughtErrorRecord.capture(
+        StateError('boom'),
+        StackTrace.current,
+        timestamp: fixed,
+      );
+
+      expect(record.timestamp, fixed);
+    });
+  });
+}

--- a/packages/platform/native_platform/lib/src/native_platform_bootstrap.dart
+++ b/packages/platform/native_platform/lib/src/native_platform_bootstrap.dart
@@ -196,7 +196,7 @@ class NativePlatformBootstrap implements PlatformBootstrap {
       File('${databaseFile.path}-journal'),
     ];
     for (final file in companions) {
-      // Best-effort: the existsSync/delete window is a TOCTOU race (the
+      // Best-effort: the exists/delete window is a TOCTOU race (the
       // file may vanish or lock between the two calls), and a companion
       // that is already gone is success, not failure. Attempt the delete
       // and swallow FileSystemException — a genuinely undeletable file is


### PR DESCRIPTION
## Summary by Sourcery

Introduce process-wide global uncaught-error capture with a RAM-only last-error slot and hook-based reporting, and wire it into app bootstrap and observability.

New Features:
- Expose a ShellObservability.lastUncaughtError ValueListenable to hold the most recent uncaught error for feedback workflows.
- Add a global error hooks installer that captures framework and platform errors, logs them, updates observability, and forwards them to a pluggable UncaughtErrorReporter.
- Introduce UncaughtErrorRecord as a sanitized, in-memory representation of an uncaught error, including redacted message, type, stack trace, and timestamp.

Enhancements:
- Update runBgeApp bootstrap sequencing to initialize observability and install global error hooks with a default no-op reporter.
- Export new observability types (global error hooks and uncaught error record) from the app shell public API.
- Clarify native platform bootstrap comments around best-effort journal cleanup and TOCTOU behavior.

Tests:
- Add comprehensive tests for ShellObservability.lastUncaughtError behavior, including initialization, notifications, replacement, clearing, and reset.
- Add tests for installGlobalErrorHooks covering framework and platform error capture, idempotent installation, reporter failure handling, and observability integration.
- Add tests for UncaughtErrorRecord to validate email redaction, type capture, stack preservation, and timestamp handling.