### PR TITLE
Feature/server onboarding

### DIFF
--- a/packages/app_shell/lib/src/bootstrap/app_bootstrap_cubit.dart
+++ b/packages/app_shell/lib/src/bootstrap/app_bootstrap_cubit.dart
@@ -102,6 +102,23 @@ class AppBootstrapCubit extends Cubit<AppBootstrapState> {
     await _attempt();
   }
 
+  /// Advances the app past the server-add leg after the onboarding flow
+  /// (#36) has persisted and activated the first server.
+  ///
+  /// Emits [AppBootstrapNeedsAuth]; the router redirect moves the app to
+  /// `/auth` (a registered server routes to the auth leg unconditionally
+  /// — the authenticated → home transition is #37's).
+  ///
+  /// Only meaningful from [AppBootstrapNeedsServer]; a no-op otherwise,
+  /// for the same fire-and-forget reason as [retry] — it is invoked from
+  /// a BlocListener reacting to the onboarding bloc's success state, and
+  /// a duplicate or late signal must not throw into an unawaited future.
+  void onServerRegistered() {
+    if (state is! AppBootstrapNeedsServer) return;
+    _logger.info('First server registered; advancing to auth');
+    emit(const AppBootstrapNeedsAuth());
+  }
+
   Future<void> _attempt() async {
     try {
       if (!_hydratedStorageReady) {

--- a/packages/app_shell/lib/src/router/app_router.dart
+++ b/packages/app_shell/lib/src/router/app_router.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
@@ -37,6 +37,14 @@ const reservedDeepLinkPathPatterns = <String>[
   '/server/:serverId/collection/:userId',
 ];
 
+/// Builds the real server-add screen subtree (#36) for the
+/// [AppRoutes.serverAdd] route. Supplied by [BgeApp] when the root
+/// container carries the onboarding services (native); when null the
+/// pre-#36 placeholder is kept — which is also the correct web behavior,
+/// where the route is unreachable ([AppBootstrapNeedsServer] never
+/// occurs on web) and no `WellKnownClient` implementation exists.
+typedef ServerAddScreenBuilder = Widget Function(BuildContext context);
+
 /// Builds the application router.
 ///
 /// Redirects are driven entirely by [bootstrapCubit]'s state: while
@@ -49,6 +57,7 @@ const reservedDeepLinkPathPatterns = <String>[
 GoRouter buildAppRouter({
   required AppBootstrapCubit bootstrapCubit,
   required BootstrapStreamListenable refreshListenable,
+  ServerAddScreenBuilder? serverAddBuilder,
 }) {
   return GoRouter(
     initialLocation: AppRoutes.splash,
@@ -79,8 +88,10 @@ GoRouter buildAppRouter({
       GoRoute(path: AppRoutes.splash, builder: (_, _) => const SplashScreen()),
       GoRoute(
         path: AppRoutes.serverAdd,
-        // Real server-add UI lands with #36 and replaces this builder.
-        builder: (_, _) =>
+        // Real server-add UI (#36) when the shell supplied a builder;
+        // the placeholder otherwise (tests, web).
+        builder: (context, _) =>
+            serverAddBuilder?.call(context) ??
             const ShellPlaceholderScreen(kind: ShellPlaceholderKind.serverAdd),
       ),
       GoRoute(

--- a/packages/app_shell/lib/src/widgets/bge_app.dart
+++ b/packages/app_shell/lib/src/widgets/bge_app.dart
@@ -4,7 +4,11 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 import 'package:interfaces/orchestration.dart';
+import 'package:interfaces/services.dart';
+import 'package:models/domain.dart';
+import 'package:network_interface/network_interface.dart';
 import 'package:observability/observability.dart';
+import 'package:server_onboarding/server_onboarding.dart';
 import 'package:ui_tokens/ui_tokens.dart';
 
 import '../../l10n/shell_localizations.dart';
@@ -182,6 +186,39 @@ class _BgeAppState extends State<BgeApp> {
     _router = buildAppRouter(
       bootstrapCubit: widget.bootstrapCubit,
       refreshListenable: _refreshListenable,
+      serverAddBuilder: _buildServerAddBuilder(),
+    );
+  }
+
+  /// The #36 server-add wiring — the first widget-layer consumer of the
+  /// root container (#72's "thin provider when actually needed").
+  ///
+  /// Returns null (→ router placeholder) when the container is absent
+  /// (tests/embedders) or carries no [WellKnownClient] (web, where the
+  /// route is unreachable anyway). Dependency resolution happens inside
+  /// the route builder, at navigation time: `bootstrapCubit.orchestrator`
+  /// is null while the router is constructed in [initState], but is
+  /// guaranteed non-null once [AppBootstrapNeedsServer] can route here —
+  /// that state is only ever emitted by a successful native bootstrap,
+  /// which populates the orchestrator first.
+  ServerAddScreenBuilder? _buildServerAddBuilder() {
+    final container = widget.rootContainer;
+    if (container == null || !container.isRegistered<WellKnownClient>()) {
+      return null;
+    }
+    return (context) => BlocProvider<ServerOnboardingBloc>(
+      create: (_) => ServerOnboardingBloc(
+        wellKnownClient: container.get<WellKnownClient>(),
+        versionNegotiator: container.get<VersionNegotiator>(),
+        connectivityService: container.get<ConnectivityService>(),
+        buildInfo: container.get<BuildInfo>(),
+        orchestrator: widget.bootstrapCubit.orchestrator!,
+      ),
+      child: BlocListener<ServerOnboardingBloc, ServerOnboardingState>(
+        listenWhen: (_, current) => current is ServerOnboardingSucceeded,
+        listener: (_, _) => widget.bootstrapCubit.onServerRegistered(),
+        child: const ServerAddScreen(),
+      ),
     );
   }
 
@@ -330,6 +367,10 @@ class _BgeAppState extends State<BgeApp> {
         },
         localizationsDelegates: [
           ...ShellLocalizations.localizationsDelegates,
+          // #36: app_shell owns the server-add route wiring, so it also
+          // owns registering the feature's delegate — app entry points
+          // stay thin.
+          ServerOnboardingLocalizations.delegate,
           ...widget.additionalLocalizationsDelegates,
         ],
         supportedLocales: ShellLocalizations.supportedLocales,

--- a/packages/app_shell/pubspec.yaml
+++ b/packages/app_shell/pubspec.yaml
@@ -20,8 +20,12 @@ dependencies:
     path: ../core/interfaces
   models:
     path: ../core/models
+  network_interface:
+    path: ../network/network_interface
   observability:
     path: ../core/observability
+  server_onboarding:
+    path: ../features/server_onboarding
   ui_tokens:
     path: ../ui/tokens
 

--- a/packages/app_shell/test/bootstrap/app_bootstrap_cubit_test.dart
+++ b/packages/app_shell/test/bootstrap/app_bootstrap_cubit_test.dart
@@ -155,6 +155,50 @@ void main() {
       });
     });
 
+    group('onServerRegistered()', () {
+      blocTest<AppBootstrapCubit, AppBootstrapState>(
+        'advances NeedsServer → NeedsAuth after onboarding succeeds (#36)',
+        build: () => buildCubit(
+          bootstrap: FakePlatformBootstrap(
+            outcomes: const [BootstrapResult(hasServer: false)],
+          ),
+        ),
+        act: (cubit) async {
+          await cubit.initialize();
+          cubit.onServerRegistered();
+        },
+        expect: () => const [
+          AppBootstrapNeedsServer(),
+          AppBootstrapNeedsAuth(),
+        ],
+      );
+
+      blocTest<AppBootstrapCubit, AppBootstrapState>(
+        'is a no-op outside NeedsServer (duplicate/late success signals '
+        'must not throw or re-emit)',
+        build: () => buildCubit(
+          bootstrap: FakePlatformBootstrap(
+            orchestrator: _MockServerOrchestrator(),
+          ),
+        ),
+        act: (cubit) async {
+          await cubit.initialize(); // → NeedsAuth
+          cubit.onServerRegistered(); // already past server-add
+          cubit.onServerRegistered();
+        },
+        expect: () => const [AppBootstrapNeedsAuth()],
+      );
+
+      test('is a no-op before initialize() (Initializing state)', () {
+        final cubit = buildCubit(bootstrap: FakePlatformBootstrap());
+        addTearDown(cubit.close);
+
+        cubit.onServerRegistered();
+
+        expect(cubit.state, const AppBootstrapInitializing());
+      });
+    });
+
     group('retry()', () {
       blocTest<AppBootstrapCubit, AppBootstrapState>(
         're-emits Initializing, then the outcome; attemptCount accumulates '

--- a/packages/core/di/lib/src/server_orchestrator_impl.dart
+++ b/packages/core/di/lib/src/server_orchestrator_impl.dart
@@ -160,6 +160,55 @@ class ServerOrchestratorImpl implements ServerOrchestrator {
   }
 
   @override
+  Future<String> addAndActivateServer({
+    required String displayName,
+    required String serverUrl,
+    required String bgeServerId,
+    required ServerIdentity identity,
+  }) async {
+    _assertReady();
+
+    // Persist first. The repository enforces uniqueness
+    // (DuplicateServerException) atomically on its own; orchestrator
+    // state is untouched until connectServer below, which serializes
+    // through the standard lock. connectServer cannot be invoked inside
+    // _withLock (the re-entrancy guard would trip), so this composes the
+    // two steps instead — the window between them is harmless: the row
+    // exists in ConnectionState.disconnected, exactly like any other
+    // registered-but-unconnected server.
+    final config = await _serverRepository.addServer(
+      displayName: displayName,
+      serverUrl: serverUrl,
+      bgeServerId: bgeServerId,
+      identity: identity,
+    );
+
+    // Connect through the standard path: capacity enforcement, demotion
+    // of any current active server, and the activate-before-commit
+    // discipline all apply unchanged. On any failure the just-persisted
+    // row is removed again so a failed onboarding never leaves a zombie
+    // config behind (#36).
+    try {
+      await connectServer(config.id, makeActive: true);
+    } catch (_) {
+      try {
+        await _serverRepository.removeServer(config.id);
+      } catch (e, st) {
+        // Rollback is best-effort: the original failure is the one the
+        // caller needs to see.
+        _logError(
+          'rollback of ${config.id} after failed onboarding activation',
+          e,
+          st,
+        );
+      }
+      rethrow;
+    }
+
+    return config.id;
+  }
+
+  @override
   Future<void> connectServer(String serverId, {bool makeActive = false}) async {
     _assertReady();
 

--- a/packages/core/di/test/server_orchestrator_impl_test.dart
+++ b/packages/core/di/test/server_orchestrator_impl_test.dart
@@ -236,6 +236,178 @@ void main() {
       });
     });
 
+    group('addAndActivateServer()', () {
+      final identity = _config(id: 'new').cachedIdentity;
+
+      void stubAddServer({Object? error}) {
+        final stub = when(
+          () => mockRepo.addServer(
+            displayName: any(named: 'displayName'),
+            serverUrl: any(named: 'serverUrl'),
+            bgeServerId: any(named: 'bgeServerId'),
+            identity: any(named: 'identity'),
+          ),
+        );
+        if (error != null) {
+          stub.thenThrow(error);
+        } else {
+          stub.thenAnswer((_) async => _config(id: 'new'));
+        }
+      }
+
+      void stubRemoveServer({Object? error}) {
+        final stub = when(() => mockRepo.removeServer(any()));
+        if (error != null) {
+          stub.thenThrow(error);
+        } else {
+          stub.thenAnswer((_) async {});
+        }
+      }
+
+      setUp(() async {
+        registerFallbackValue(identity);
+        await orchestrator.initialize();
+        stubUpdateConnectionState();
+        stubUpdateLastActive();
+        stubGetServer('new');
+        stubAddServer();
+        stubRemoveServer();
+      });
+
+      test('persists, connects, and makes the server active', () async {
+        final id = await orchestrator.addAndActivateServer(
+          displayName: 'My Server',
+          serverUrl: 'https://bge.example.com',
+          bgeServerId: 'bge-new',
+          identity: identity,
+        );
+
+        expect(id, 'new');
+        expect(orchestrator.activeServerId, 'new');
+        expect(orchestrator.currentConnectedCount, 1);
+        verify(
+          () => mockRepo.addServer(
+            displayName: 'My Server',
+            serverUrl: 'https://bge.example.com',
+            bgeServerId: 'bge-new',
+            identity: identity,
+          ),
+        ).called(1);
+        verify(() => mockContexts['new']!.activate()).called(greaterThan(0));
+        verifyNever(() => mockRepo.removeServer(any()));
+      });
+
+      test('rethrows DuplicateServerException without rollback (nothing '
+          'was persisted by this call)', () async {
+        stubAddServer(
+          error: const DuplicateServerException('https://bge.example.com'),
+        );
+
+        await expectLater(
+          orchestrator.addAndActivateServer(
+            displayName: 'My Server',
+            serverUrl: 'https://bge.example.com',
+            bgeServerId: 'bge-new',
+            identity: identity,
+          ),
+          throwsA(isA<DuplicateServerException>()),
+        );
+        expect(orchestrator.currentConnectedCount, 0);
+        verifyNever(() => mockRepo.removeServer(any()));
+      });
+
+      test('rolls the persisted row back when activation fails', () async {
+        // The context created for 'new' throws on activate.
+        stubGetServer('new');
+        // Arrange the factory-produced context to fail: intercept after
+        // creation by making activate throw for this id.
+        orchestrator = ServerOrchestratorImpl(
+          serverRepository: mockRepo,
+          preferencesRepository: mockPrefsRepo,
+          contextFactory: (config) {
+            final ctx = _mockContext(config.id);
+            when(() => ctx.activate()).thenThrow(StateError('boom'));
+            mockContexts[config.id] = ctx;
+            return ctx;
+          },
+          isDesktopOverride: true,
+        );
+        await orchestrator.initialize();
+
+        await expectLater(
+          orchestrator.addAndActivateServer(
+            displayName: 'My Server',
+            serverUrl: 'https://bge.example.com',
+            bgeServerId: 'bge-new',
+            identity: identity,
+          ),
+          throwsA(isA<StateError>()),
+        );
+        expect(orchestrator.currentConnectedCount, 0);
+        expect(orchestrator.activeServerId, isNull);
+        verify(() => mockRepo.removeServer('new')).called(1);
+      });
+
+      test('rolls back and rethrows ServerCapacityExceededException at '
+          'capacity', () async {
+        when(() => mockPrefsRepo.get()).thenAnswer(
+          (_) async => const DevicePreferences(maxMonitoredServers: 1),
+        );
+        stubGetServer('existing');
+        await orchestrator.connectServer('existing');
+
+        await expectLater(
+          orchestrator.addAndActivateServer(
+            displayName: 'My Server',
+            serverUrl: 'https://bge.example.com',
+            bgeServerId: 'bge-new',
+            identity: identity,
+          ),
+          throwsA(isA<ServerCapacityExceededException>()),
+        );
+        expect(orchestrator.currentConnectedCount, 1);
+        verify(() => mockRepo.removeServer('new')).called(1);
+      });
+
+      test('a failing rollback does not mask the original failure', () async {
+        when(() => mockPrefsRepo.get()).thenAnswer(
+          (_) async => const DevicePreferences(maxMonitoredServers: 1),
+        );
+        stubGetServer('existing');
+        await orchestrator.connectServer('existing');
+        stubRemoveServer(error: StateError('rollback failed'));
+
+        await expectLater(
+          orchestrator.addAndActivateServer(
+            displayName: 'My Server',
+            serverUrl: 'https://bge.example.com',
+            bgeServerId: 'bge-new',
+            identity: identity,
+          ),
+          throwsA(isA<ServerCapacityExceededException>()),
+        );
+      });
+
+      test('demotes the previously active server (single-active '
+          'invariant)', () async {
+        stubGetServer('existing');
+        await orchestrator.connectServer('existing');
+        expect(orchestrator.activeServerId, 'existing');
+
+        await orchestrator.addAndActivateServer(
+          displayName: 'My Server',
+          serverUrl: 'https://bge.example.com',
+          bgeServerId: 'bge-new',
+          identity: identity,
+        );
+
+        expect(orchestrator.activeServerId, 'new');
+        verify(
+          () => mockContexts['existing']!.background(),
+        ).called(greaterThan(0));
+      });
+    });
+
     group('disconnectServer()', () {
       setUp(() async {
         await orchestrator.initialize();

--- a/packages/core/interfaces/lib/src/orchestration/server_orchestrator.dart
+++ b/packages/core/interfaces/lib/src/orchestration/server_orchestrator.dart
@@ -1,3 +1,5 @@
+import 'package:models/domain.dart';
+
 import 'server_context.dart';
 
 /// Coordinates lifecycle and atomic state transitions across all server
@@ -30,6 +32,30 @@ abstract class ServerOrchestrator {
   ///
   /// Throws [StateError] if called more than once without disposal.
   Future<void> initialize();
+
+  /// Persists a newly discovered server and connects it as the active
+  /// foreground server, atomically from the caller's perspective (#36).
+  ///
+  /// The caller (the server-add flow) has already fetched and vetted
+  /// [identity] — well-known discovery and version negotiation (#13)
+  /// happen *before* this call; the orchestrator applies no policy of
+  /// its own beyond its usual capacity rules.
+  ///
+  /// On any failure after the repository add (capacity, activation), the
+  /// persisted config is removed again so a failed onboarding never
+  /// leaves a zombie entry behind.
+  ///
+  /// Returns the persisted [ServerConfig]'s local id.
+  ///
+  /// Throws [DuplicateServerException] if [serverUrl] or [bgeServerId]
+  /// is already registered.
+  /// Throws [ServerCapacityExceededException] if at capacity.
+  Future<String> addAndActivateServer({
+    required String displayName,
+    required String serverUrl,
+    required String bgeServerId,
+    required ServerIdentity identity,
+  });
 
   /// Creates a context for a disconnected server and connects it.
   ///

--- a/packages/features/server_onboarding/.gitignore
+++ b/packages/features/server_onboarding/.gitignore
@@ -1,0 +1,37 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.buildlog/
+.history
+.svn/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+# Libraries should not include pubspec.lock, per https://dart.dev/guides/libraries/private-files#pubspeclock.
+/pubspec.lock
+**/doc/api/
+.dart_tool/
+.flutter-plugins-dependencies
+/build/
+/coverage/
+
+# Generated localizations (#33): gitignored + regenerated. Run
+# `melos run generate` (the gen-l10n stage) locally; CI regenerates in
+# its `generate` job. Do not commit these.
+lib/l10n/*_localizations*.dart
+lib/l10n/untranslated.txt

--- a/packages/features/server_onboarding/.metadata
+++ b/packages/features/server_onboarding/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: "ad70ec4617166f1c38e5d2bfd388af71fda14f06"
+  channel: "stable"
+
+project_type: package

--- a/packages/features/server_onboarding/CHANGELOG.md
+++ b/packages/features/server_onboarding/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 0.0.1
+
+* TODO: Describe initial release.

--- a/packages/features/server_onboarding/CHANGELOG.md
+++ b/packages/features/server_onboarding/CHANGELOG.md
@@ -1,3 +1,4 @@
 ## 0.0.1
 
-* TODO: Describe initial release.
+* Initial release (#36): server discovery → version negotiation → persist
+  and activate, with reactive_forms UI, full l10n, and accessibility.

--- a/packages/features/server_onboarding/LICENSE
+++ b/packages/features/server_onboarding/LICENSE
@@ -1,0 +1,1 @@
+TODO: Add your license here.

--- a/packages/features/server_onboarding/README.md
+++ b/packages/features/server_onboarding/README.md
@@ -1,0 +1,39 @@
+<!--
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/tools/pub/writing-package-pages).
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/to/develop-packages).
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder.
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to
+contribute to the package, how to file issues, what response they can expect
+from the package authors, and more.

--- a/packages/features/server_onboarding/README.md
+++ b/packages/features/server_onboarding/README.md
@@ -1,39 +1,38 @@
-<!--
-This README describes the package. If you publish this package to pub.dev,
-this README's contents appear on the landing page for your package.
+# server_onboarding
 
-For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/tools/pub/writing-package-pages).
+First-run server-add feature (#36): discover a Board Games Empire server,
+negotiate client/server version compatibility, then persist and activate it.
 
-For general information about developing packages, see the Dart guide for
-[creating packages](https://dart.dev/guides/libraries/create-packages)
-and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/to/develop-packages).
--->
+## Flow
 
-TODO: Put a short description of the package here that helps potential users
-know whether this package might be useful for them.
+`ServerOnboardingBloc` drives:
 
-## Features
+1. normalize + validate the entered URL (local; never touches the network);
+2. connectivity fast-fail (#9) — surfaced before any fetch;
+3. `WellKnownClient.fetchIdentity` discovery;
+4. `VersionNegotiator.negotiate` (#13) — a mismatch **never** persists;
+5. `ServerOrchestrator.addAndActivateServer` — persist + activate.
 
-TODO: List what your package can do. Maybe include images, gifs, or videos.
+Failures are sealed *kinds* (with payloads where a message needs
+interpolation); localization happens in the widget layer, keeping the bloc
+locale-free (#33).
 
-## Getting started
+## URL rules
 
-TODO: List prerequisites and provide or point to information on how to
-start using the package.
+Input is trimmed; `https://` is assumed when no scheme is given. Plain `http`
+is allowed only for loopback and RFC 1918 hosts (self-hosting / LAN); `https`
+is required otherwise. Path prefixes are preserved (reverse-proxy
+deployments); query/fragment and a trailing slash are dropped.
 
-## Usage
+## Wiring
 
-TODO: Include short and useful examples for package users. Add longer examples
-to `/example` folder.
+`app_shell` owns construction: it supplies the screen to the `/server-add`
+route, provides the bloc from the root container, and advances bootstrap via
+`AppBootstrapCubit.onServerRegistered()` on success. The route is native-only
+in practice — web is same-origin and never reaches it.
 
-```dart
-const like = 'sample';
-```
+## Accessibility
 
-## Additional information
-
-TODO: Tell users more about the package: where to find more information, how to
-contribute to the package, how to file issues, what response they can expect
-from the package authors, and more.
+Labeled fields (never hint-only), failure and in-flight state in `liveRegion`
+semantics, submit disabled (not hidden) while in flight, full keyboard
+operability.

--- a/packages/features/server_onboarding/analysis_options.yaml
+++ b/packages/features/server_onboarding/analysis_options.yaml
@@ -1,0 +1,4 @@
+include: package:flutter_lints/flutter.yaml
+
+# Additional information about this file can be found at
+# https://dart.dev/guides/language/analysis-options

--- a/packages/features/server_onboarding/l10n.yaml
+++ b/packages/features/server_onboarding/l10n.yaml
@@ -1,0 +1,9 @@
+arb-dir: lib/l10n
+template-arb-file: intl_en.arb
+output-localization-file: server_onboarding_localizations.dart
+output-class: ServerOnboardingLocalizations
+nullable-getter: false
+# #33: written by gen-l10n when non-template locales are missing keys.
+# Gitignored — visibility only; partial coverage is allowed (missing
+# messages inherit from the template).
+untranslated-messages-file: lib/l10n/untranslated.txt

--- a/packages/features/server_onboarding/lib/l10n/intl_en.arb
+++ b/packages/features/server_onboarding/lib/l10n/intl_en.arb
@@ -1,0 +1,115 @@
+{
+  "@@locale": "en",
+  "serverAddTitle": "Add a Server",
+  "@serverAddTitle": {
+    "description": "Screen title for the first-run add-server flow"
+  },
+  "serverAddIntro": "Enter the address of your Board Games Empire server to get started.",
+  "@serverAddIntro": {
+    "description": "Introductory sentence above the add-server form"
+  },
+  "serverAddUrlLabel": "Server address",
+  "@serverAddUrlLabel": {
+    "description": "Label for the server URL field"
+  },
+  "serverAddUrlHint": "bge.example.com",
+  "@serverAddUrlHint": {
+    "description": "Hint (example value) shown inside the server URL field"
+  },
+  "serverAddUrlHelper": "https is assumed when no scheme is given.",
+  "@serverAddUrlHelper": {
+    "description": "Helper text under the URL field explaining scheme handling"
+  },
+  "serverAddAliasLabel": "Nickname (optional)",
+  "@serverAddAliasLabel": {
+    "description": "Label for the optional server alias field"
+  },
+  "serverAddAliasHint": "Home server",
+  "@serverAddAliasHint": {
+    "description": "Hint (example value) shown inside the alias field"
+  },
+  "serverAddSubmit": "Connect",
+  "@serverAddSubmit": {
+    "description": "Submit button label for the add-server form"
+  },
+  "serverAddInProgress": "Contacting server…",
+  "@serverAddInProgress": {
+    "description": "Progress label announced and shown while discovery runs"
+  },
+  "serverAddErrorTitle": "Couldn't add server",
+  "@serverAddErrorTitle": {
+    "description": "Heading shown above any add-server failure message"
+  },
+  "serverAddErrorUrlMalformed": "That doesn't look like a valid server address. Check it and try again.",
+  "@serverAddErrorUrlMalformed": {
+    "description": "Error for blank or unparseable URL input"
+  },
+  "serverAddErrorUrlScheme": "Only http and https addresses are supported.",
+  "@serverAddErrorUrlScheme": {
+    "description": "Error for an unsupported URL scheme such as ftp"
+  },
+  "serverAddErrorUrlInsecure": "Plain http is only allowed for local and private network addresses. Use https for this server.",
+  "@serverAddErrorUrlInsecure": {
+    "description": "Error when http is used toward a public host"
+  },
+  "serverAddErrorOffline": "You're offline. Connect to a network and try again.",
+  "@serverAddErrorOffline": {
+    "description": "Error shown when the device has no connectivity"
+  },
+  "serverAddErrorUnreachable": "Couldn't reach the server. Check the address and your connection.",
+  "@serverAddErrorUnreachable": {
+    "description": "Error for a network failure or timeout during discovery"
+  },
+  "serverAddErrorNotBge": "No Board Games Empire server was found at that address.",
+  "@serverAddErrorNotBge": {
+    "description": "Error when the well-known document returns 404"
+  },
+  "serverAddErrorInvalidResponse": "The server sent an unexpected response. It may be misconfigured or an incompatible version.",
+  "@serverAddErrorInvalidResponse": {
+    "description": "Error for a non-200 response or unparseable identity document"
+  },
+  "serverAddErrorClientTooOld": "This server requires app version {requiredMinimum} or newer (you have {clientVersion}). Please update the app.",
+  "@serverAddErrorClientTooOld": {
+    "description": "Version negotiation failure: client older than the server's minimum",
+    "placeholders": {
+      "requiredMinimum": {
+        "type": "String",
+        "example": "1.2.0"
+      },
+      "clientVersion": {
+        "type": "String",
+        "example": "1.0.0"
+      }
+    }
+  },
+  "serverAddErrorClientTooNew": "This server supports app versions up to {supportedMaximum} (you have {clientVersion}). The server needs to be updated.",
+  "@serverAddErrorClientTooNew": {
+    "description": "Version negotiation failure: client newer than the server's maximum",
+    "placeholders": {
+      "supportedMaximum": {
+        "type": "String",
+        "example": "2.0.0"
+      },
+      "clientVersion": {
+        "type": "String",
+        "example": "2.1.0"
+      }
+    }
+  },
+  "serverAddErrorSchemaTooNew": "This server speaks a newer protocol than this app understands. Please update the app.",
+  "@serverAddErrorSchemaTooNew": {
+    "description": "Version negotiation failure: discovery document schema too new"
+  },
+  "serverAddErrorDuplicate": "That server is already registered on this device.",
+  "@serverAddErrorDuplicate": {
+    "description": "Error when the server URL or id already exists locally"
+  },
+  "serverAddErrorCapacity": "You've reached the maximum number of connected servers on this device.",
+  "@serverAddErrorCapacity": {
+    "description": "Error when the device is at its connected-server capacity"
+  },
+  "serverAddErrorUnexpected": "Something went wrong while adding the server. Please try again.",
+  "@serverAddErrorUnexpected": {
+    "description": "Fallback error for unanticipated failures"
+  }
+}

--- a/packages/features/server_onboarding/lib/server_onboarding.dart
+++ b/packages/features/server_onboarding/lib/server_onboarding.dart
@@ -1,0 +1,13 @@
+library;
+
+export 'l10n/server_onboarding_localizations.dart';
+
+export 'src/bloc/server_onboarding_bloc.dart';
+export 'src/bloc/server_onboarding_event.dart';
+export 'src/bloc/server_onboarding_state.dart';
+
+export 'src/screens/server_add_screen.dart';
+
+export 'src/url/server_url_input.dart';
+
+export 'src/widgets/server_add_form.dart';

--- a/packages/features/server_onboarding/lib/src/bloc/server_onboarding_bloc.dart
+++ b/packages/features/server_onboarding/lib/src/bloc/server_onboarding_bloc.dart
@@ -1,0 +1,154 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:interfaces/orchestration.dart';
+import 'package:interfaces/repositories.dart';
+import 'package:interfaces/services.dart';
+import 'package:models/domain.dart';
+import 'package:network_interface/network_interface.dart';
+import 'package:observability/observability.dart';
+
+import '../url/server_url_input.dart';
+import 'server_onboarding_event.dart';
+import 'server_onboarding_state.dart';
+
+/// Drives the first-run server-add flow (#36):
+///
+/// normalize/validate the URL → connectivity fast-fail (#9) →
+/// `WellKnownClient.fetchIdentity` → `VersionNegotiator.negotiate` (#13)
+/// → `ServerOrchestrator.addAndActivateServer`.
+///
+/// Invariants enforced here (and pinned by bloc tests):
+/// - a version-negotiation mismatch **never** reaches the persist step;
+/// - an offline device fails immediately, before any fetch (no timeout
+///   wait);
+/// - local URL validation failures never touch the network.
+///
+/// All collaborators are root-scope: server-add runs before any
+/// `ServerContext` exists. The orchestrator arrives as the interface —
+/// this package never sees a platform concrete.
+class ServerOnboardingBloc
+    extends Bloc<ServerOnboardingEvent, ServerOnboardingState> {
+  ServerOnboardingBloc({
+    required WellKnownClient wellKnownClient,
+    required VersionNegotiator versionNegotiator,
+    required ConnectivityService connectivityService,
+    required BuildInfo buildInfo,
+    required ServerOrchestrator orchestrator,
+    BgeLogger? logger,
+  }) : _wellKnownClient = wellKnownClient,
+       _versionNegotiator = versionNegotiator,
+       _connectivityService = connectivityService,
+       _buildInfo = buildInfo,
+       _orchestrator = orchestrator,
+       _logger = logger ?? BgeLogger('bge.onboarding'),
+       super(const ServerOnboardingIdle()) {
+    on<ServerOnboardingSubmitted>(_onSubmitted);
+  }
+
+  final WellKnownClient _wellKnownClient;
+  final VersionNegotiator _versionNegotiator;
+  final ConnectivityService _connectivityService;
+  final BuildInfo _buildInfo;
+  final ServerOrchestrator _orchestrator;
+  final BgeLogger _logger;
+
+  Future<void> _onSubmitted(
+    ServerOnboardingSubmitted event,
+    Emitter<ServerOnboardingState> emit,
+  ) async {
+    // Re-entrancy: ignore submits while one is in flight (the form
+    // disables its button, but a race between tap and rebuild is cheap
+    // to close here too).
+    if (state is ServerOnboardingInProgress) return;
+
+    // 1. Local validation — never touches the network.
+    final urlResult = normalizeServerUrl(event.url);
+    if (urlResult is ServerUrlInvalid) {
+      emit(ServerOnboardingInvalidUrl(urlResult.error));
+      return;
+    }
+    final serverUrl = (urlResult as ServerUrlValid).normalized;
+
+    emit(const ServerOnboardingInProgress());
+
+    // 2. Offline fast-fail (#9): surface immediately instead of letting
+    // the fetch run into its 10s timeout.
+    if (_connectivityService.current == ConnectivityState.offline) {
+      emit(const ServerOnboardingOffline());
+      return;
+    }
+
+    // 3. Discovery.
+    final ServerIdentity identity;
+    try {
+      identity = await _wellKnownClient.fetchIdentity(serverUrl);
+    } on WellKnownNotFoundException {
+      emit(const ServerOnboardingNotBgeServer());
+      return;
+    } on WellKnownUnreachableException {
+      emit(const ServerOnboardingUnreachable());
+      return;
+    } on WellKnownInvalidResponseException {
+      emit(const ServerOnboardingInvalidResponse());
+      return;
+    }
+
+    // 4. Version negotiation (#13) — a mismatch never persists.
+    final negotiation = _versionNegotiator.negotiate(
+      buildInfo: _buildInfo,
+      identity: identity,
+    );
+    switch (negotiation) {
+      case VersionCompatible():
+        break;
+      case ClientTooOld(:final clientVersion, :final requiredMinimum):
+        emit(
+          ServerOnboardingClientTooOld(
+            clientVersion: clientVersion,
+            requiredMinimum: requiredMinimum,
+          ),
+        );
+        return;
+      case ClientTooNew(:final clientVersion, :final supportedMaximum):
+        emit(
+          ServerOnboardingClientTooNew(
+            clientVersion: clientVersion,
+            supportedMaximum: supportedMaximum,
+          ),
+        );
+        return;
+      case SchemaTooNew():
+        emit(const ServerOnboardingSchemaTooNew());
+        return;
+    }
+
+    // 5. Persist + activate. Blank alias falls back to the server's
+    // advertised display name.
+    final alias = event.alias?.trim();
+    final displayName = (alias == null || alias.isEmpty)
+        ? identity.name
+        : alias;
+
+    try {
+      final serverId = await _orchestrator.addAndActivateServer(
+        displayName: displayName,
+        serverUrl: serverUrl,
+        bgeServerId: identity.serverId,
+        identity: identity,
+      );
+      emit(
+        ServerOnboardingSucceeded(serverId: serverId, displayName: displayName),
+      );
+    } on DuplicateServerException {
+      emit(const ServerOnboardingDuplicate());
+    } on ServerCapacityExceededException {
+      emit(const ServerOnboardingCapacityExceeded());
+    } catch (e, st) {
+      _logger.error(
+        'Server onboarding failed after negotiation',
+        error: e,
+        stackTrace: st,
+      );
+      emit(ServerOnboardingUnexpectedFailure(e));
+    }
+  }
+}

--- a/packages/features/server_onboarding/lib/src/bloc/server_onboarding_event.dart
+++ b/packages/features/server_onboarding/lib/src/bloc/server_onboarding_event.dart
@@ -1,0 +1,25 @@
+import 'package:equatable/equatable.dart';
+
+/// Events for `ServerOnboardingBloc` (#36).
+sealed class ServerOnboardingEvent extends Equatable {
+  const ServerOnboardingEvent();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+/// The user submitted the add-server form.
+final class ServerOnboardingSubmitted extends ServerOnboardingEvent {
+  const ServerOnboardingSubmitted({required this.url, this.alias});
+
+  /// Raw user input — normalization/validation is the bloc's first step,
+  /// so the full policy is covered by bloc tests.
+  final String url;
+
+  /// Optional display-name alias; blank/null falls back to the server's
+  /// advertised `name` from the discovery document.
+  final String? alias;
+
+  @override
+  List<Object?> get props => [url, alias];
+}

--- a/packages/features/server_onboarding/lib/src/bloc/server_onboarding_state.dart
+++ b/packages/features/server_onboarding/lib/src/bloc/server_onboarding_state.dart
@@ -1,0 +1,137 @@
+import 'package:equatable/equatable.dart';
+
+import '../url/server_url_input.dart';
+
+/// States for `ServerOnboardingBloc` (#36).
+///
+/// Failures carry *kinds* (and payloads where messages need
+/// interpolation), never display strings — localization is the widget
+/// layer's job, keeping the bloc free of any locale concern (#33).
+sealed class ServerOnboardingState extends Equatable {
+  const ServerOnboardingState();
+
+  @override
+  List<Object?> get props => const [];
+}
+
+/// Form idle, awaiting input.
+final class ServerOnboardingIdle extends ServerOnboardingState {
+  const ServerOnboardingIdle();
+}
+
+/// Discovery/persist in flight; the form disables its submit control.
+final class ServerOnboardingInProgress extends ServerOnboardingState {
+  const ServerOnboardingInProgress();
+}
+
+/// The server was persisted and activated. The shell reacts by advancing
+/// bootstrap past the server-add leg.
+final class ServerOnboardingSucceeded extends ServerOnboardingState {
+  const ServerOnboardingSucceeded({
+    required this.serverId,
+    required this.displayName,
+  });
+
+  /// Local (MetaDB) id of the persisted server.
+  final String serverId;
+
+  /// The resolved display name (user alias or the server's advertised
+  /// name) — available for a success announcement.
+  final String displayName;
+
+  @override
+  List<Object?> get props => [serverId, displayName];
+}
+
+/// Why onboarding failed. Each kind maps to one localized message in the
+/// widget layer; kinds that need interpolation carry their payloads.
+sealed class ServerOnboardingFailure extends ServerOnboardingState {
+  const ServerOnboardingFailure();
+}
+
+/// The entered URL failed local validation — no network was touched.
+final class ServerOnboardingInvalidUrl extends ServerOnboardingFailure {
+  const ServerOnboardingInvalidUrl(this.error);
+
+  final ServerUrlError error;
+
+  @override
+  List<Object?> get props => [error];
+}
+
+/// The device is offline (#9 fast-fail — surfaced before any fetch, no
+/// timeout wait).
+final class ServerOnboardingOffline extends ServerOnboardingFailure {
+  const ServerOnboardingOffline();
+}
+
+/// Network failure or timeout reaching the server.
+final class ServerOnboardingUnreachable extends ServerOnboardingFailure {
+  const ServerOnboardingUnreachable();
+}
+
+/// 404 on the well-known document — wrong URL or not a BGE server.
+final class ServerOnboardingNotBgeServer extends ServerOnboardingFailure {
+  const ServerOnboardingNotBgeServer();
+}
+
+/// Non-200 or unparseable identity document.
+final class ServerOnboardingInvalidResponse extends ServerOnboardingFailure {
+  const ServerOnboardingInvalidResponse();
+}
+
+/// Version negotiation (#13): this client is older than the server's
+/// minimum.
+final class ServerOnboardingClientTooOld extends ServerOnboardingFailure {
+  const ServerOnboardingClientTooOld({
+    required this.clientVersion,
+    required this.requiredMinimum,
+  });
+
+  final String clientVersion;
+  final String requiredMinimum;
+
+  @override
+  List<Object?> get props => [clientVersion, requiredMinimum];
+}
+
+/// Version negotiation (#13): this client is newer than the server's
+/// maximum.
+final class ServerOnboardingClientTooNew extends ServerOnboardingFailure {
+  const ServerOnboardingClientTooNew({
+    required this.clientVersion,
+    required this.supportedMaximum,
+  });
+
+  final String clientVersion;
+  final String supportedMaximum;
+
+  @override
+  List<Object?> get props => [clientVersion, supportedMaximum];
+}
+
+/// Version negotiation (#13): the discovery document's schema is newer
+/// than this client understands.
+final class ServerOnboardingSchemaTooNew extends ServerOnboardingFailure {
+  const ServerOnboardingSchemaTooNew();
+}
+
+/// This server (by URL or BGE id) is already registered. Richer
+/// known-server UX is #82's scope.
+final class ServerOnboardingDuplicate extends ServerOnboardingFailure {
+  const ServerOnboardingDuplicate();
+}
+
+/// The device is at its configured connected-server capacity.
+final class ServerOnboardingCapacityExceeded extends ServerOnboardingFailure {
+  const ServerOnboardingCapacityExceeded();
+}
+
+/// Anything unanticipated (activation failure, storage error, …). The
+/// original error is retained for the feedback pipeline, but excluded
+/// from equality so bloc tests can match on the state alone.
+final class ServerOnboardingUnexpectedFailure extends ServerOnboardingFailure {
+  const ServerOnboardingUnexpectedFailure(this.cause);
+
+  final Object cause;
+}

--- a/packages/features/server_onboarding/lib/src/screens/server_add_screen.dart
+++ b/packages/features/server_onboarding/lib/src/screens/server_add_screen.dart
@@ -37,7 +37,7 @@ class ServerAddScreen extends StatelessWidget {
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
                   const SizedBox(height: 24),
-                  const ServerAddForm(),
+                  ServerAddForm(),
                 ],
               ),
             ),

--- a/packages/features/server_onboarding/lib/src/screens/server_add_screen.dart
+++ b/packages/features/server_onboarding/lib/src/screens/server_add_screen.dart
@@ -37,7 +37,7 @@ class ServerAddScreen extends StatelessWidget {
                     style: Theme.of(context).textTheme.bodyMedium,
                   ),
                   const SizedBox(height: 24),
-                  ServerAddForm(),
+                  const ServerAddForm(),
                 ],
               ),
             ),

--- a/packages/features/server_onboarding/lib/src/screens/server_add_screen.dart
+++ b/packages/features/server_onboarding/lib/src/screens/server_add_screen.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+
+import '../../l10n/server_onboarding_localizations.dart';
+import '../widgets/server_add_form.dart';
+
+/// First-run add-server screen (#36). Expects a `ServerOnboardingBloc`
+/// to be provided above it (the shell's router wiring owns bloc
+/// construction and success handling).
+class ServerAddScreen extends StatelessWidget {
+  const ServerAddScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = ServerOnboardingLocalizations.of(context);
+
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 480),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Semantics(
+                    header: true,
+                    child: Text(
+                      l10n.serverAddTitle,
+                      style: Theme.of(context).textTheme.headlineMedium,
+                    ),
+                  ),
+                  const SizedBox(height: 8),
+                  Text(
+                    l10n.serverAddIntro,
+                    style: Theme.of(context).textTheme.bodyMedium,
+                  ),
+                  const SizedBox(height: 24),
+                  const ServerAddForm(),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/features/server_onboarding/lib/src/url/server_url_input.dart
+++ b/packages/features/server_onboarding/lib/src/url/server_url_input.dart
@@ -104,6 +104,7 @@ ServerUrlResult normalizeServerUrl(String input) {
       if (!_isLoopbackOrPrivateHost(uri.host)) {
         return const ServerUrlInvalid(ServerUrlError.insecureHttp);
       }
+      break;
     default:
       return const ServerUrlInvalid(ServerUrlError.unsupportedScheme);
   }

--- a/packages/features/server_onboarding/lib/src/url/server_url_input.dart
+++ b/packages/features/server_onboarding/lib/src/url/server_url_input.dart
@@ -1,0 +1,163 @@
+/// Normalization and validation for the user-entered server URL (#36).
+///
+/// Policy (locked in the #36 design review):
+/// - input is trimmed; `https://` is prepended when no scheme is given;
+/// - the host must be non-empty;
+/// - `http` is permitted only for loopback (`localhost`, `127.0.0.0/8`,
+///   `::1`) and RFC 1918 private hosts (`10/8`, `172.16/12`,
+///   `192.168/16`) — the self-hosting / LAN development reality — and
+///   rejected everywhere else;
+/// - any scheme other than `http`/`https` is rejected;
+/// - path prefixes are preserved (a BGE server may live under a path on
+///   a shared reverse proxy) and a single trailing slash is dropped
+///   (matching `WellKnownClient`'s own normalization).
+///
+/// Pure and synchronous so the rules are unit-testable without a bloc.
+sealed class ServerUrlResult {
+  const ServerUrlResult();
+}
+
+/// The input normalized to a usable base URL.
+final class ServerUrlValid extends ServerUrlResult {
+  const ServerUrlValid(this.normalized);
+
+  /// Scheme + host (+ port) (+ path prefix), no trailing slash.
+  final String normalized;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ServerUrlValid && other.normalized == normalized;
+
+  @override
+  int get hashCode => normalized.hashCode;
+
+  @override
+  String toString() => 'ServerUrlValid($normalized)';
+}
+
+/// Why an input was rejected. Widget layer maps each to a localized
+/// message.
+enum ServerUrlError {
+  /// Blank, whitespace-only, or structurally unparseable input.
+  malformed,
+
+  /// A scheme other than http/https (ftp, bge, file, …).
+  unsupportedScheme,
+
+  /// Plain http toward a host that is neither loopback nor RFC 1918.
+  insecureHttp,
+}
+
+final class ServerUrlInvalid extends ServerUrlResult {
+  const ServerUrlInvalid(this.error);
+
+  final ServerUrlError error;
+
+  @override
+  bool operator ==(Object other) =>
+      other is ServerUrlInvalid && other.error == error;
+
+  @override
+  int get hashCode => error.hashCode;
+
+  @override
+  String toString() => 'ServerUrlInvalid($error)';
+}
+
+/// Applies the policy above to raw user [input].
+ServerUrlResult normalizeServerUrl(String input) {
+  var candidate = input.trim();
+  if (candidate.isEmpty) {
+    return const ServerUrlInvalid(ServerUrlError.malformed);
+  }
+
+  // Prepend https:// only when no scheme is present at all. A lone
+  // "scheme-relative" (//host) or partial scheme still parses; the
+  // scheme check below handles the rest.
+  final hasScheme = RegExp(r'^[a-zA-Z][a-zA-Z0-9+.-]*://').hasMatch(candidate);
+  if (!hasScheme) candidate = 'https://$candidate';
+
+  final Uri uri;
+  try {
+    uri = Uri.parse(candidate);
+  } on FormatException {
+    return const ServerUrlInvalid(ServerUrlError.malformed);
+  }
+
+  if (uri.host.isEmpty) {
+    return const ServerUrlInvalid(ServerUrlError.malformed);
+  }
+
+  // Uri.parse is lenient: "https://ht tp://x" parses with host "ht%20tp"
+  // rather than throwing. A real host is a registered name
+  // (letters/digits/./-, plus _ in practice) or a bracketed IPv6
+  // literal — anything else (percent-escapes, spaces, slashes) means the
+  // input was malformed, so reject on host shape.
+  if (!_isWellFormedHost(uri.host)) {
+    return const ServerUrlInvalid(ServerUrlError.malformed);
+  }
+
+  switch (uri.scheme) {
+    case 'https':
+      break;
+    case 'http':
+      if (!_isLoopbackOrPrivateHost(uri.host)) {
+        return const ServerUrlInvalid(ServerUrlError.insecureHttp);
+      }
+    default:
+      return const ServerUrlInvalid(ServerUrlError.unsupportedScheme);
+  }
+
+  // Preserve the path prefix; drop query/fragment (never part of a base
+  // URL) and a trailing slash (WellKnownClient normalizes it anyway —
+  // doing it here keeps the persisted ServerConfig.serverUrl canonical).
+  // Note: Uri.replace(query: null) means "keep existing" in Dart, so the
+  // base is reconstructed explicitly from its kept components.
+  var path = uri.path;
+  if (path.endsWith('/')) path = path.substring(0, path.length - 1);
+
+  final normalized = Uri(
+    scheme: uri.scheme,
+    host: uri.host,
+    port: uri.hasPort ? uri.port : null,
+    path: path,
+  ).toString();
+
+  return ServerUrlValid(normalized);
+}
+
+bool _isWellFormedHost(String host) {
+  // IPv6 literal. Uri.host may return it bracketed ("[::1]") or bare
+  // ("::1") depending on the input and SDK; accept either. The presence
+  // of a colon unambiguously marks IPv6 here (ports were already split
+  // off by Uri parsing).
+  if (host.contains(':')) {
+    final inner = host.startsWith('[') && host.endsWith(']')
+        ? host.substring(1, host.length - 1)
+        : host;
+    return RegExp(r'^[0-9a-fA-F:]+$').hasMatch(inner);
+  }
+  // Registered name / IPv4: letters, digits, dot, hyphen, underscore.
+  // No spaces, no percent-escapes, no slashes — those signal a
+  // malformed input that Uri.parse tolerated.
+  return RegExp(r'^[a-zA-Z0-9._-]+$').hasMatch(host);
+}
+
+bool _isLoopbackOrPrivateHost(String host) {
+  final lower = host.toLowerCase();
+  if (lower == 'localhost' || lower == '::1' || lower == '[::1]') return true;
+
+  final parts = lower.split('.');
+  if (parts.length == 4) {
+    final octets = parts.map(int.tryParse).toList();
+    if (octets.every((o) => o != null && o >= 0 && o <= 255)) {
+      final a = octets[0]!;
+      final b = octets[1]!;
+      if (a == 127) return true; // loopback
+      if (a == 10) return true; // 10/8
+      if (a == 172 && b >= 16 && b <= 31) return true; // 172.16/12
+      if (a == 192 && b == 168) return true; // 192.168/16
+    }
+  }
+  return false;
+}

--- a/packages/features/server_onboarding/lib/src/widgets/server_add_form.dart
+++ b/packages/features/server_onboarding/lib/src/widgets/server_add_form.dart
@@ -1,0 +1,181 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:reactive_forms/reactive_forms.dart';
+
+import '../bloc/server_onboarding_bloc.dart';
+import '../bloc/server_onboarding_event.dart';
+import '../bloc/server_onboarding_state.dart';
+import '../../l10n/server_onboarding_localizations.dart';
+import '../url/server_url_input.dart';
+
+/// The add-server form (#36): one URL field, one optional alias field,
+/// one submit button.
+///
+/// Accessibility:
+/// - both fields carry visible labels (never hint-only);
+/// - failure messages and the in-flight progress indicator render in
+///   `liveRegion` semantics so screen readers announce them;
+/// - the submit control is disabled (not hidden) while a request is in
+///   flight;
+/// - everything is reachable and operable by keyboard — the URL field
+///   advances to the alias field, and the alias field submits on the
+///   keyboard's done action, in addition to the submit button.
+///
+/// The `FormGroup` is owned and disposed by [ReactiveFormBuilder]; the
+/// widget is deliberately *not* `const` so a rebuild re-runs the builder
+/// against the retained group rather than a discarded inline one.
+class ServerAddForm extends StatelessWidget {
+  const ServerAddForm({super.key});
+
+  static const urlControlName = 'url';
+  static const aliasControlName = 'alias';
+
+  void _submit(BuildContext context, FormGroup form) {
+    final url = form.control(urlControlName).value as String? ?? '';
+    final alias = form.control(aliasControlName).value as String?;
+    context.read<ServerOnboardingBloc>().add(
+      ServerOnboardingSubmitted(url: url, alias: alias),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = ServerOnboardingLocalizations.of(context);
+
+    return ReactiveFormBuilder(
+      form: () => FormGroup({
+        urlControlName: FormControl<String>(validators: [Validators.required]),
+        aliasControlName: FormControl<String>(),
+      }),
+      builder: (context, form, _) {
+        return BlocBuilder<ServerOnboardingBloc, ServerOnboardingState>(
+          builder: (context, state) {
+            final inProgress = state is ServerOnboardingInProgress;
+            final failure = state is ServerOnboardingFailure ? state : null;
+
+            return Column(
+              crossAxisAlignment: CrossAxisAlignment.stretch,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                ReactiveTextField<String>(
+                  formControlName: urlControlName,
+                  readOnly: inProgress,
+                  keyboardType: TextInputType.url,
+                  autocorrect: false,
+                  textInputAction: TextInputAction.next,
+                  decoration: InputDecoration(
+                    labelText: l10n.serverAddUrlLabel,
+                    hintText: l10n.serverAddUrlHint,
+                    helperText: l10n.serverAddUrlHelper,
+                  ),
+                ),
+                const SizedBox(height: 16),
+                ReactiveTextField<String>(
+                  formControlName: aliasControlName,
+                  readOnly: inProgress,
+                  textInputAction: TextInputAction.done,
+                  onSubmitted: (_) {
+                    if (!inProgress) _submit(context, form);
+                  },
+                  decoration: InputDecoration(
+                    labelText: l10n.serverAddAliasLabel,
+                    hintText: l10n.serverAddAliasHint,
+                  ),
+                ),
+                const SizedBox(height: 24),
+                if (failure != null) ...[
+                  Semantics(
+                    liveRegion: true,
+                    child: _FailureBanner(
+                      title: l10n.serverAddErrorTitle,
+                      message: _failureMessage(l10n, failure),
+                    ),
+                  ),
+                  const SizedBox(height: 16),
+                ],
+                FilledButton(
+                  onPressed: inProgress ? null : () => _submit(context, form),
+                  child: inProgress
+                      ? Semantics(
+                          liveRegion: true,
+                          child: Row(
+                            mainAxisAlignment: MainAxisAlignment.center,
+                            mainAxisSize: MainAxisSize.min,
+                            children: [
+                              const SizedBox(
+                                width: 16,
+                                height: 16,
+                                child: CircularProgressIndicator(
+                                  strokeWidth: 2,
+                                ),
+                              ),
+                              const SizedBox(width: 12),
+                              Text(l10n.serverAddInProgress),
+                            ],
+                          ),
+                        )
+                      : Text(l10n.serverAddSubmit),
+                ),
+              ],
+            );
+          },
+        );
+      },
+    );
+  }
+}
+
+String _failureMessage(
+  ServerOnboardingLocalizations l10n,
+  ServerOnboardingFailure failure,
+) => switch (failure) {
+  ServerOnboardingInvalidUrl(:final error) => switch (error) {
+    ServerUrlError.malformed => l10n.serverAddErrorUrlMalformed,
+    ServerUrlError.unsupportedScheme => l10n.serverAddErrorUrlScheme,
+    ServerUrlError.insecureHttp => l10n.serverAddErrorUrlInsecure,
+  },
+  ServerOnboardingOffline() => l10n.serverAddErrorOffline,
+  ServerOnboardingUnreachable() => l10n.serverAddErrorUnreachable,
+  ServerOnboardingNotBgeServer() => l10n.serverAddErrorNotBge,
+  ServerOnboardingInvalidResponse() => l10n.serverAddErrorInvalidResponse,
+  ServerOnboardingClientTooOld(:final clientVersion, :final requiredMinimum) =>
+    l10n.serverAddErrorClientTooOld(requiredMinimum, clientVersion),
+  ServerOnboardingClientTooNew(:final clientVersion, :final supportedMaximum) =>
+    l10n.serverAddErrorClientTooNew(supportedMaximum, clientVersion),
+  ServerOnboardingSchemaTooNew() => l10n.serverAddErrorSchemaTooNew,
+  ServerOnboardingDuplicate() => l10n.serverAddErrorDuplicate,
+  ServerOnboardingCapacityExceeded() => l10n.serverAddErrorCapacity,
+  ServerOnboardingUnexpectedFailure() => l10n.serverAddErrorUnexpected,
+};
+
+class _FailureBanner extends StatelessWidget {
+  const _FailureBanner({required this.title, required this.message});
+
+  final String title;
+  final String message;
+
+  @override
+  Widget build(BuildContext context) {
+    final colors = Theme.of(context).colorScheme;
+    return Container(
+      padding: const EdgeInsets.all(12),
+      decoration: BoxDecoration(
+        color: colors.errorContainer,
+        borderRadius: BorderRadius.circular(8),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text(
+            title,
+            style: Theme.of(
+              context,
+            ).textTheme.titleSmall?.copyWith(color: colors.onErrorContainer),
+          ),
+          const SizedBox(height: 4),
+          Text(message, style: TextStyle(color: colors.onErrorContainer)),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/features/server_onboarding/lib/src/widgets/server_add_form.dart
+++ b/packages/features/server_onboarding/lib/src/widgets/server_add_form.dart
@@ -25,7 +25,7 @@ import '../url/server_url_input.dart';
 /// widget is deliberately *not* `const` so a rebuild re-runs the builder
 /// against the retained group rather than a discarded inline one.
 class ServerAddForm extends StatelessWidget {
-  const ServerAddForm({super.key});
+  ServerAddForm({super.key});
 
   static const urlControlName = 'url';
   static const aliasControlName = 'alias';

--- a/packages/features/server_onboarding/lib/src/widgets/server_add_form.dart
+++ b/packages/features/server_onboarding/lib/src/widgets/server_add_form.dart
@@ -21,11 +21,12 @@ import '../url/server_url_input.dart';
 ///   advances to the alias field, and the alias field submits on the
 ///   keyboard's done action, in addition to the submit button.
 ///
-/// The `FormGroup` is owned and disposed by [ReactiveFormBuilder]; the
-/// widget is deliberately *not* `const` so a rebuild re-runs the builder
-/// against the retained group rather than a discarded inline one.
+/// The `FormGroup` is owned and disposed by [ReactiveFormBuilder], which
+/// builds it once from the `form` factory and retains it across rebuilds
+/// — so the widget can stay `const` without risking a per-build group
+/// that discards typed input.
 class ServerAddForm extends StatelessWidget {
-  ServerAddForm({super.key});
+  const ServerAddForm({super.key});
 
   static const urlControlName = 'url';
   static const aliasControlName = 'alias';

--- a/packages/features/server_onboarding/pubspec.yaml
+++ b/packages/features/server_onboarding/pubspec.yaml
@@ -1,0 +1,42 @@
+name: server_onboarding
+description: "Server onboarding feature (#36) — discovery, negotiation, persist, activate"
+publish_to: none
+
+environment:
+  sdk: ">=3.9.0 <4.0.0"
+  flutter: ">=3.0.0"
+resolution: workspace
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_localizations:
+    sdk: flutter
+
+  interfaces:
+    path: ../../core/interfaces
+  models:
+    path: ../../core/models
+  network_interface:
+    path: ../../network/network_interface
+  observability:
+    path: ../../core/observability
+
+  flutter_bloc: ^9.1.1
+  equatable: ^2.0.6
+  reactive_forms: ^18.1.1
+  intl: ^0.20.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  bloc_test: ^10.0.0
+  mocktail: ^1.0.5
+  very_good_analysis: ^10.2.0
+  flutter_lints: ^6.0.0
+  l10n_test_support:
+    path: ../../testing/l10n
+
+flutter:
+  generate: true
+  uses-material-design: true

--- a/packages/features/server_onboarding/test/bloc/server_onboarding_bloc_test.dart
+++ b/packages/features/server_onboarding/test/bloc/server_onboarding_bloc_test.dart
@@ -1,0 +1,364 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:interfaces/orchestration.dart';
+import 'package:interfaces/repositories.dart';
+import 'package:interfaces/services.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/domain.dart';
+import 'package:network_interface/network_interface.dart';
+import 'package:server_onboarding/server_onboarding.dart';
+
+class _MockWellKnownClient extends Mock implements WellKnownClient {}
+
+class _MockVersionNegotiator extends Mock implements VersionNegotiator {}
+
+class _MockConnectivityService extends Mock implements ConnectivityService {}
+
+class _MockServerOrchestrator extends Mock implements ServerOrchestrator {}
+
+const _kBuildInfo = BuildInfo(
+  version: '1.2.3',
+  buildNumber: '42',
+  appName: 'BGE',
+  packageName: 'com.bge.app',
+);
+
+const _kUrl = 'https://bge.example.com';
+
+ServerIdentity _identity({String name = 'Home BGE'}) => ServerIdentity(
+  wellKnownSchemaVersion: 1,
+  serverId: '550e8400-e29b-41d4-a716-446655440000',
+  name: name,
+  issuer: _kUrl,
+  deviceAuthorizationEndpoint: '/api/auth/device',
+  authBasePath: '/api/auth',
+  sessionEndpoint: '/api/auth/get-session',
+  signOutEndpoint: '/api/auth/sign-out',
+  passkeySupported: true,
+  twoFactorSupported: true,
+  anonymousAuthSupported: true,
+);
+
+void main() {
+  late _MockWellKnownClient wellKnown;
+  late _MockVersionNegotiator negotiator;
+  late _MockConnectivityService connectivity;
+  late _MockServerOrchestrator orchestrator;
+
+  setUpAll(() {
+    registerFallbackValue(_kBuildInfo);
+    registerFallbackValue(_identity());
+  });
+
+  setUp(() {
+    wellKnown = _MockWellKnownClient();
+    negotiator = _MockVersionNegotiator();
+    connectivity = _MockConnectivityService();
+    orchestrator = _MockServerOrchestrator();
+
+    when(() => connectivity.current).thenReturn(ConnectivityState.online);
+    when(
+      () => wellKnown.fetchIdentity(any()),
+    ).thenAnswer((_) async => _identity());
+    when(
+      () => negotiator.negotiate(
+        buildInfo: any(named: 'buildInfo'),
+        identity: any(named: 'identity'),
+      ),
+    ).thenReturn(const VersionCompatible());
+    when(
+      () => orchestrator.addAndActivateServer(
+        displayName: any(named: 'displayName'),
+        serverUrl: any(named: 'serverUrl'),
+        bgeServerId: any(named: 'bgeServerId'),
+        identity: any(named: 'identity'),
+      ),
+    ).thenAnswer((_) async => 'local-id-1');
+  });
+
+  ServerOnboardingBloc build() => ServerOnboardingBloc(
+    wellKnownClient: wellKnown,
+    versionNegotiator: negotiator,
+    connectivityService: connectivity,
+    buildInfo: _kBuildInfo,
+    orchestrator: orchestrator,
+  );
+
+  group('ServerOnboardingBloc', () {
+    test('starts idle', () {
+      final bloc = build();
+      addTearDown(bloc.close);
+      expect(bloc.state, const ServerOnboardingIdle());
+    });
+
+    group('local URL validation', () {
+      blocTest<ServerOnboardingBloc, ServerOnboardingState>(
+        'invalid URL fails without touching the network',
+        build: build,
+        act: (bloc) =>
+            bloc.add(const ServerOnboardingSubmitted(url: 'ftp://x.example')),
+        expect: () => const [
+          ServerOnboardingInvalidUrl(ServerUrlError.unsupportedScheme),
+        ],
+        verify: (_) => verifyNever(() => wellKnown.fetchIdentity(any())),
+      );
+    });
+
+    group('offline fast-fail (#9)', () {
+      blocTest<ServerOnboardingBloc, ServerOnboardingState>(
+        'surfaces offline before any fetch',
+        build: build,
+        setUp: () => when(
+          () => connectivity.current,
+        ).thenReturn(ConnectivityState.offline),
+        act: (bloc) => bloc.add(const ServerOnboardingSubmitted(url: _kUrl)),
+        expect: () => const [
+          ServerOnboardingInProgress(),
+          ServerOnboardingOffline(),
+        ],
+        verify: (_) => verifyNever(() => wellKnown.fetchIdentity(any())),
+      );
+    });
+
+    group('discovery failures', () {
+      blocTest<ServerOnboardingBloc, ServerOnboardingState>(
+        '404 → not a BGE server',
+        build: build,
+        setUp: () => when(() => wellKnown.fetchIdentity(any())).thenThrow(
+          const WellKnownNotFoundException(serverUrl: _kUrl, message: '404'),
+        ),
+        act: (bloc) => bloc.add(const ServerOnboardingSubmitted(url: _kUrl)),
+        expect: () => const [
+          ServerOnboardingInProgress(),
+          ServerOnboardingNotBgeServer(),
+        ],
+      );
+
+      blocTest<ServerOnboardingBloc, ServerOnboardingState>(
+        'network failure → unreachable',
+        build: build,
+        setUp: () => when(() => wellKnown.fetchIdentity(any())).thenThrow(
+          const WellKnownUnreachableException(
+            serverUrl: _kUrl,
+            message: 'timeout',
+          ),
+        ),
+        act: (bloc) => bloc.add(const ServerOnboardingSubmitted(url: _kUrl)),
+        expect: () => const [
+          ServerOnboardingInProgress(),
+          ServerOnboardingUnreachable(),
+        ],
+      );
+
+      blocTest<ServerOnboardingBloc, ServerOnboardingState>(
+        'bad body → invalid response',
+        build: build,
+        setUp: () => when(() => wellKnown.fetchIdentity(any())).thenThrow(
+          const WellKnownInvalidResponseException(
+            serverUrl: _kUrl,
+            message: 'parse',
+            statusCode: 200,
+          ),
+        ),
+        act: (bloc) => bloc.add(const ServerOnboardingSubmitted(url: _kUrl)),
+        expect: () => const [
+          ServerOnboardingInProgress(),
+          ServerOnboardingInvalidResponse(),
+        ],
+      );
+    });
+
+    group('version negotiation (#13) — a mismatch never persists', () {
+      blocTest<ServerOnboardingBloc, ServerOnboardingState>(
+        'clientTooOld surfaces payload and never reaches the orchestrator',
+        build: build,
+        setUp: () =>
+            when(
+              () => negotiator.negotiate(
+                buildInfo: any(named: 'buildInfo'),
+                identity: any(named: 'identity'),
+              ),
+            ).thenReturn(
+              const ClientTooOld(
+                clientVersion: '1.2.3',
+                requiredMinimum: '2.0.0',
+              ),
+            ),
+        act: (bloc) => bloc.add(const ServerOnboardingSubmitted(url: _kUrl)),
+        expect: () => const [
+          ServerOnboardingInProgress(),
+          ServerOnboardingClientTooOld(
+            clientVersion: '1.2.3',
+            requiredMinimum: '2.0.0',
+          ),
+        ],
+        verify: (_) => verifyNever(
+          () => orchestrator.addAndActivateServer(
+            displayName: any(named: 'displayName'),
+            serverUrl: any(named: 'serverUrl'),
+            bgeServerId: any(named: 'bgeServerId'),
+            identity: any(named: 'identity'),
+          ),
+        ),
+      );
+
+      blocTest<ServerOnboardingBloc, ServerOnboardingState>(
+        'clientTooNew surfaces payload and never persists',
+        build: build,
+        setUp: () =>
+            when(
+              () => negotiator.negotiate(
+                buildInfo: any(named: 'buildInfo'),
+                identity: any(named: 'identity'),
+              ),
+            ).thenReturn(
+              const ClientTooNew(
+                clientVersion: '1.2.3',
+                supportedMaximum: '1.0.0',
+              ),
+            ),
+        act: (bloc) => bloc.add(const ServerOnboardingSubmitted(url: _kUrl)),
+        expect: () => const [
+          ServerOnboardingInProgress(),
+          ServerOnboardingClientTooNew(
+            clientVersion: '1.2.3',
+            supportedMaximum: '1.0.0',
+          ),
+        ],
+        verify: (_) => verifyNever(
+          () => orchestrator.addAndActivateServer(
+            displayName: any(named: 'displayName'),
+            serverUrl: any(named: 'serverUrl'),
+            bgeServerId: any(named: 'bgeServerId'),
+            identity: any(named: 'identity'),
+          ),
+        ),
+      );
+
+      blocTest<ServerOnboardingBloc, ServerOnboardingState>(
+        'schemaTooNew never persists',
+        build: build,
+        setUp: () => when(
+          () => negotiator.negotiate(
+            buildInfo: any(named: 'buildInfo'),
+            identity: any(named: 'identity'),
+          ),
+        ).thenReturn(const SchemaTooNew(serverSchemaVersion: 9)),
+        act: (bloc) => bloc.add(const ServerOnboardingSubmitted(url: _kUrl)),
+        expect: () => const [
+          ServerOnboardingInProgress(),
+          ServerOnboardingSchemaTooNew(),
+        ],
+        verify: (_) => verifyNever(
+          () => orchestrator.addAndActivateServer(
+            displayName: any(named: 'displayName'),
+            serverUrl: any(named: 'serverUrl'),
+            bgeServerId: any(named: 'bgeServerId'),
+            identity: any(named: 'identity'),
+          ),
+        ),
+      );
+    });
+
+    group('persist + activate', () {
+      blocTest<ServerOnboardingBloc, ServerOnboardingState>(
+        'succeeds with the normalized URL and the server-advertised name '
+        'when the alias is blank',
+        build: build,
+        act: (bloc) => bloc.add(
+          const ServerOnboardingSubmitted(url: 'bge.example.com/', alias: ' '),
+        ),
+        expect: () => const [
+          ServerOnboardingInProgress(),
+          ServerOnboardingSucceeded(
+            serverId: 'local-id-1',
+            displayName: 'Home BGE',
+          ),
+        ],
+        verify: (_) => verify(
+          () => orchestrator.addAndActivateServer(
+            displayName: 'Home BGE',
+            serverUrl: 'https://bge.example.com',
+            bgeServerId: '550e8400-e29b-41d4-a716-446655440000',
+            identity: any(named: 'identity'),
+          ),
+        ).called(1),
+      );
+
+      blocTest<ServerOnboardingBloc, ServerOnboardingState>(
+        'a non-blank alias wins over the advertised name',
+        build: build,
+        act: (bloc) => bloc.add(
+          const ServerOnboardingSubmitted(url: _kUrl, alias: 'My Server'),
+        ),
+        expect: () => const [
+          ServerOnboardingInProgress(),
+          ServerOnboardingSucceeded(
+            serverId: 'local-id-1',
+            displayName: 'My Server',
+          ),
+        ],
+      );
+
+      blocTest<ServerOnboardingBloc, ServerOnboardingState>(
+        'duplicate registration maps to its own failure',
+        build: build,
+        setUp: () => when(
+          () => orchestrator.addAndActivateServer(
+            displayName: any(named: 'displayName'),
+            serverUrl: any(named: 'serverUrl'),
+            bgeServerId: any(named: 'bgeServerId'),
+            identity: any(named: 'identity'),
+          ),
+        ).thenThrow(const DuplicateServerException(_kUrl)),
+        act: (bloc) => bloc.add(const ServerOnboardingSubmitted(url: _kUrl)),
+        expect: () => const [
+          ServerOnboardingInProgress(),
+          ServerOnboardingDuplicate(),
+        ],
+      );
+
+      blocTest<ServerOnboardingBloc, ServerOnboardingState>(
+        'capacity maps to its own failure',
+        build: build,
+        setUp: () =>
+            when(
+              () => orchestrator.addAndActivateServer(
+                displayName: any(named: 'displayName'),
+                serverUrl: any(named: 'serverUrl'),
+                bgeServerId: any(named: 'bgeServerId'),
+                identity: any(named: 'identity'),
+              ),
+            ).thenThrow(
+              const ServerCapacityExceededException(
+                currentConnected: 5,
+                maxCapacity: 5,
+              ),
+            ),
+        act: (bloc) => bloc.add(const ServerOnboardingSubmitted(url: _kUrl)),
+        expect: () => const [
+          ServerOnboardingInProgress(),
+          ServerOnboardingCapacityExceeded(),
+        ],
+      );
+
+      blocTest<ServerOnboardingBloc, ServerOnboardingState>(
+        'anything unanticipated maps to the fallback failure',
+        build: build,
+        setUp: () => when(
+          () => orchestrator.addAndActivateServer(
+            displayName: any(named: 'displayName'),
+            serverUrl: any(named: 'serverUrl'),
+            bgeServerId: any(named: 'bgeServerId'),
+            identity: any(named: 'identity'),
+          ),
+        ).thenThrow(StateError('activation blew up')),
+        act: (bloc) => bloc.add(const ServerOnboardingSubmitted(url: _kUrl)),
+        expect: () => [
+          const ServerOnboardingInProgress(),
+          isA<ServerOnboardingUnexpectedFailure>(),
+        ],
+      );
+    });
+  });
+}

--- a/packages/features/server_onboarding/test/l10n/server_onboarding_arb_coverage_test.dart
+++ b/packages/features/server_onboarding/test/l10n/server_onboarding_arb_coverage_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:l10n_test_support/l10n_test_support.dart';
+
+/// The #33 key-coverage check for the server-onboarding feature's ARB
+/// files — identical policy to the shell's and auth's: template
+/// descriptions and locale declarations are hard failures, unknown keys
+/// are hard failures, partial coverage is allowed and reported.
+void main() {
+  group('server_onboarding ARB coverage', () {
+    late ArbCoverageReport report;
+
+    setUpAll(() {
+      report = analyzeArbDirectory('lib/l10n', templateFileName: 'intl_en.arb');
+    });
+
+    test('the template defines at least the onboarding key surface', () {
+      expect(report.templateKeys, isNotEmpty);
+      expect(report.templateKeys, contains('serverAddTitle'));
+      expect(report.templateKeys, contains('serverAddErrorClientTooOld'));
+    });
+
+    test('every template key carries a translator description', () {
+      expect(report.keysMissingDescription, isEmpty, reason: report.describe());
+    });
+
+    test('no non-template locale carries keys the template lacks', () {
+      for (final locale in report.locales) {
+        expect(locale.unknownKeys, isEmpty, reason: report.describe());
+      }
+    });
+
+    test('declared @@locale values agree with their file names', () {
+      for (final locale in report.locales) {
+        expect(
+          locale.declaredLocaleMatchesFileName,
+          isTrue,
+          reason: '${locale.fileName} declares ${locale.declaredLocale}',
+        );
+      }
+    });
+
+    test('partial coverage is surfaced, not failed (repo policy)', () {
+      if (report.hasUntranslated) {
+        // ignore: avoid_print
+        print(report.describe());
+      }
+    });
+  });
+}

--- a/packages/features/server_onboarding/test/url/server_url_input_test.dart
+++ b/packages/features/server_onboarding/test/url/server_url_input_test.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:server_onboarding/server_onboarding.dart';
+
+void main() {
+  group('normalizeServerUrl', () {
+    group('malformed input', () {
+      for (final input in ['', '   ', 'ht tp://x', 'https://']) {
+        test('rejects ${input.isEmpty ? '<empty>' : '"$input"'}', () {
+          expect(
+            normalizeServerUrl(input),
+            const ServerUrlInvalid(ServerUrlError.malformed),
+          );
+        });
+      }
+
+      // Uri.parse is lenient and will happily percent-encode a space
+      // into the authority ("https://ht tp://x" → host "ht%20tp")
+      // instead of throwing; the host-shape guard must reject these.
+      for (final input in [
+        'ht tp://x',
+        'bge example.com',
+        'https://exa mple.com',
+        'https://%00',
+      ]) {
+        test('rejects host-malformed "$input"', () {
+          expect(
+            normalizeServerUrl(input),
+            const ServerUrlInvalid(ServerUrlError.malformed),
+          );
+        });
+      }
+    });
+
+    group('scheme handling', () {
+      test('prepends https when no scheme is given', () {
+        expect(
+          normalizeServerUrl('bge.example.com'),
+          const ServerUrlValid('https://bge.example.com'),
+        );
+      });
+
+      test('accepts explicit https', () {
+        expect(
+          normalizeServerUrl('https://bge.example.com'),
+          const ServerUrlValid('https://bge.example.com'),
+        );
+      });
+
+      test('rejects non-http(s) schemes', () {
+        expect(
+          normalizeServerUrl('ftp://bge.example.com'),
+          const ServerUrlInvalid(ServerUrlError.unsupportedScheme),
+        );
+      });
+
+      test('rejects plain http toward a public host', () {
+        expect(
+          normalizeServerUrl('http://bge.example.com'),
+          const ServerUrlInvalid(ServerUrlError.insecureHttp),
+        );
+      });
+    });
+
+    group('http exemptions for self-hosting (loopback + RFC 1918)', () {
+      for (final host in [
+        'localhost',
+        '127.0.0.1',
+        '127.8.8.8',
+        '[::1]',
+        '10.0.0.5',
+        '172.16.0.1',
+        '172.31.255.254',
+        '192.168.1.10',
+      ]) {
+        test('allows http://$host', () {
+          expect(
+            normalizeServerUrl('http://$host:3000'),
+            ServerUrlValid('http://$host:3000'),
+          );
+        });
+      }
+
+      for (final host in ['172.15.0.1', '172.32.0.1', '11.0.0.1', '8.8.8.8']) {
+        test('rejects http://$host (public)', () {
+          expect(
+            normalizeServerUrl('http://$host'),
+            const ServerUrlInvalid(ServerUrlError.insecureHttp),
+          );
+        });
+      }
+    });
+
+    group('normalization', () {
+      test('trims surrounding whitespace', () {
+        expect(
+          normalizeServerUrl('  https://bge.example.com  '),
+          const ServerUrlValid('https://bge.example.com'),
+        );
+      });
+
+      test('drops a trailing slash', () {
+        expect(
+          normalizeServerUrl('https://bge.example.com/'),
+          const ServerUrlValid('https://bge.example.com'),
+        );
+      });
+
+      test('preserves a path prefix (reverse-proxy deployment)', () {
+        expect(
+          normalizeServerUrl('https://shared.example.com/bge/'),
+          const ServerUrlValid('https://shared.example.com/bge'),
+        );
+      });
+
+      test('preserves an explicit port', () {
+        expect(
+          normalizeServerUrl('https://bge.example.com:8443'),
+          const ServerUrlValid('https://bge.example.com:8443'),
+        );
+      });
+
+      test('strips query and fragment', () {
+        expect(
+          normalizeServerUrl('https://bge.example.com/bge?utm=x#top'),
+          const ServerUrlValid('https://bge.example.com/bge'),
+        );
+      });
+    });
+  });
+}

--- a/packages/features/server_onboarding/test/widget/server_add_screen_test.dart
+++ b/packages/features/server_onboarding/test/widget/server_add_screen_test.dart
@@ -1,0 +1,141 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter/semantics.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:server_onboarding/server_onboarding.dart';
+
+class _MockServerOnboardingBloc
+    extends MockBloc<ServerOnboardingEvent, ServerOnboardingState>
+    implements ServerOnboardingBloc {}
+
+Widget _harness(ServerOnboardingBloc bloc) => MaterialApp(
+  localizationsDelegates: ServerOnboardingLocalizations.localizationsDelegates,
+  supportedLocales: ServerOnboardingLocalizations.supportedLocales,
+  home: BlocProvider<ServerOnboardingBloc>.value(
+    value: bloc,
+    child: const ServerAddScreen(),
+  ),
+);
+
+void main() {
+  late _MockServerOnboardingBloc bloc;
+
+  setUpAll(() {
+    registerFallbackValue(const ServerOnboardingSubmitted(url: ''));
+  });
+
+  setUp(() {
+    bloc = _MockServerOnboardingBloc();
+    whenListen(
+      bloc,
+      const Stream<ServerOnboardingState>.empty(),
+      initialState: const ServerOnboardingIdle(),
+    );
+  });
+
+  group('ServerAddScreen', () {
+    testWidgets('renders labeled URL and alias fields and a submit button '
+        '(labels, never hint-only)', (tester) async {
+      await tester.pumpWidget(_harness(bloc));
+
+      expect(find.text('Server address'), findsOneWidget);
+      expect(find.text('Nickname (optional)'), findsOneWidget);
+      expect(find.widgetWithText(FilledButton, 'Connect'), findsOneWidget);
+      // The screen title is a semantic header.
+      expect(find.text('Add a Server'), findsOneWidget);
+    });
+
+    testWidgets('submit dispatches the raw field values', (tester) async {
+      await tester.pumpWidget(_harness(bloc));
+
+      await tester.enterText(find.byType(TextField).first, 'bge.example.com');
+      await tester.enterText(find.byType(TextField).last, 'Home');
+      await tester.tap(find.widgetWithText(FilledButton, 'Connect'));
+      await tester.pump();
+
+      verify(
+        () => bloc.add(
+          const ServerOnboardingSubmitted(
+            url: 'bge.example.com',
+            alias: 'Home',
+          ),
+        ),
+      ).called(1);
+    });
+
+    testWidgets('pressing done on the alias field submits from the '
+        'keyboard', (tester) async {
+      await tester.pumpWidget(_harness(bloc));
+
+      await tester.enterText(find.byType(TextField).first, 'bge.example.com');
+      await tester.enterText(find.byType(TextField).last, 'Home');
+      await tester.testTextInput.receiveAction(TextInputAction.done);
+      await tester.pump();
+
+      verify(() => bloc.add(any<ServerOnboardingSubmitted>())).called(1);
+    });
+
+    testWidgets('disables (not hides) the submit control while in flight '
+        'and shows progress', (tester) async {
+      whenListen(
+        bloc,
+        const Stream<ServerOnboardingState>.empty(),
+        initialState: const ServerOnboardingInProgress(),
+      );
+      await tester.pumpWidget(_harness(bloc));
+
+      final button = tester.widget<FilledButton>(find.byType(FilledButton));
+      expect(button.onPressed, isNull);
+      expect(find.text('Contacting server…'), findsOneWidget);
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('renders a localized failure message in a live region', (
+      tester,
+    ) async {
+      whenListen(
+        bloc,
+        const Stream<ServerOnboardingState>.empty(),
+        initialState: const ServerOnboardingOffline(),
+      );
+      await tester.pumpWidget(_harness(bloc));
+
+      expect(find.text("Couldn't add server"), findsOneWidget);
+      expect(
+        find.text("You're offline. Connect to a network and try again."),
+        findsOneWidget,
+      );
+
+      // The banner is announced: its subtree sits under a liveRegion
+      // Semantics node.
+      final semantics = tester.getSemantics(find.text("Couldn't add server"));
+      expect(_hasLiveRegionAncestor(semantics), isTrue);
+    });
+
+    testWidgets('interpolates version-negotiation payloads', (tester) async {
+      whenListen(
+        bloc,
+        const Stream<ServerOnboardingState>.empty(),
+        initialState: const ServerOnboardingClientTooOld(
+          clientVersion: '1.0.0',
+          requiredMinimum: '2.0.0',
+        ),
+      );
+      await tester.pumpWidget(_harness(bloc));
+
+      expect(find.textContaining('2.0.0'), findsOneWidget);
+      expect(find.textContaining('1.0.0'), findsOneWidget);
+    });
+  });
+}
+
+bool _hasLiveRegionAncestor(SemanticsNode node) {
+  SemanticsNode? current = node;
+  while (current != null) {
+    if (current.flagsCollection.isLiveRegion) return true;
+    current = current.parent;
+  }
+  return false;
+}

--- a/packages/features/server_onboarding/test/widget/server_add_screen_test.dart
+++ b/packages/features/server_onboarding/test/widget/server_add_screen_test.dart
@@ -1,6 +1,5 @@
 import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter/semantics.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
@@ -108,10 +107,19 @@ void main() {
         findsOneWidget,
       );
 
-      // The banner is announced: its subtree sits under a liveRegion
-      // Semantics node.
-      final semantics = tester.getSemantics(find.text("Couldn't add server"));
-      expect(_hasLiveRegionAncestor(semantics), isTrue);
+      // The banner is announced: it sits under a Semantics widget with
+      // liveRegion enabled. Asserted at the widget-tree level to stay
+      // independent of SemanticsNode flag-API changes across Flutter
+      // versions.
+      expect(
+        find.ancestor(
+          of: find.text("Couldn't add server"),
+          matching: find.byWidgetPredicate(
+            (w) => w is Semantics && (w.properties.liveRegion ?? false),
+          ),
+        ),
+        findsOneWidget,
+      );
     });
 
     testWidgets('interpolates version-negotiation payloads', (tester) async {
@@ -129,13 +137,4 @@ void main() {
       expect(find.textContaining('1.0.0'), findsOneWidget);
     });
   });
-}
-
-bool _hasLiveRegionAncestor(SemanticsNode node) {
-  SemanticsNode? current = node;
-  while (current != null) {
-    if (current.flagsCollection.isLiveRegion) return true;
-    current = current.parent;
-  }
-  return false;
 }

--- a/packages/platform/native_platform/lib/src/native_root_module.dart
+++ b/packages/platform/native_platform/lib/src/native_root_module.dart
@@ -1,7 +1,10 @@
 import 'package:connectivity_platform/connectivity_platform.dart';
+import 'package:di/di.dart';
+import 'package:dio_network/dio_network.dart';
 import 'package:interfaces/orchestration.dart';
 import 'package:interfaces/services.dart';
 import 'package:models/domain.dart';
+import 'package:network_interface/network_interface.dart';
 import 'package:observability/observability.dart';
 
 import 'build_info/package_info_build_info_reader.dart';
@@ -32,12 +35,16 @@ import 'feedback/file_feedback_sink.dart';
 /// `runBgeApp`'s belt-and-braces fallback.
 ///
 /// Registrations: [BuildInfo] (resolved read, #35), the durable
-/// [FeedbackSink] (#69), and the device-global [ConnectivityService]
+/// [FeedbackSink] (#69), the device-global [ConnectivityService]
 /// (#9) — disposed via its [Disposable] conformance when the root
-/// container tears down. The [FeedbackService] itself is composed and
-/// registered by `runBgeApp` — it needs shell-side collaborators
-/// (breadcrumb ring, locale, the transport resolver) that don't exist at
-/// this altitude.
+/// container tears down — and the #36 server-onboarding pair:
+/// [WellKnownClient] (lazy; its dedicated unauthenticated [Dio] is not
+/// built until discovery actually runs) and [VersionNegotiator]
+/// (stateless, const). Both are **root**-scope by necessity: server-add
+/// runs before any [ServerContext] exists. The [FeedbackService] itself
+/// is composed and registered by `runBgeApp` — it needs shell-side
+/// collaborators (breadcrumb ring, locale, the transport resolver) that
+/// don't exist at this altitude.
 ///
 /// [buildInfoReader] and [connectivityFactory] are injectable for tests;
 /// production uses the concrete [PackageInfoBuildInfoReader] and
@@ -58,5 +65,10 @@ Future<void> registerNativeRootModule(
           await disposable.onDispose();
         }
       },
-    );
+    )
+    // #36 server onboarding. Lazy: WellKnownClientImpl constructs its
+    // dedicated unauthenticated Dio, which should not exist until
+    // discovery actually runs.
+    ..registerLazySingleton<WellKnownClient>(WellKnownClientImpl.new)
+    ..registerLazySingleton<VersionNegotiator>(VersionNegotiatorImpl.new);
 }

--- a/packages/platform/native_platform/pubspec.yaml
+++ b/packages/platform/native_platform/pubspec.yaml
@@ -28,6 +28,8 @@ dependencies:
     path: ../../storage/drift_storage
   key_storage:
     path: ../../storage/key_storage
+  network_interface:
+    path: ../../network/network_interface
   dio_network:
     path: ../../network/dio_network
   connectivity_platform:

--- a/packages/platform/native_platform/test/native_root_module_test.dart
+++ b/packages/platform/native_platform/test/native_root_module_test.dart
@@ -1,9 +1,11 @@
 import 'package:di/di.dart';
+import 'package:dio_network/dio_network.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:interfaces/orchestration.dart';
 import 'package:interfaces/services.dart';
 import 'package:models/domain.dart';
 import 'package:native_platform/native_platform.dart';
+import 'package:network_interface/network_interface.dart';
 import 'package:observability/observability.dart';
 
 /// Tests for `registerNativeRootModule`'s registrations: the resolved
@@ -141,6 +143,37 @@ void main() {
       await container.dispose();
 
       expect(constructions, 0);
+    });
+
+    test('registers WellKnownClient lazily for server onboarding '
+        '(#36)', () async {
+      final container = DependencyContainerImpl();
+
+      await registerNativeRootModule(
+        container,
+        buildInfoReader: const _StubBuildInfoReader(_info),
+        connectivityFactory: _FakeConnectivityService.new,
+      );
+
+      expect(container.isRegistered<WellKnownClient>(), isTrue);
+      expect(container.get<WellKnownClient>(), isA<WellKnownClientImpl>());
+      expect(
+        container.get<WellKnownClient>(),
+        same(container.get<WellKnownClient>()),
+      );
+    });
+
+    test('registers VersionNegotiator for server onboarding (#36)', () async {
+      final container = DependencyContainerImpl();
+
+      await registerNativeRootModule(
+        container,
+        buildInfoReader: const _StubBuildInfoReader(_info),
+        connectivityFactory: _FakeConnectivityService.new,
+      );
+
+      expect(container.isRegistered<VersionNegotiator>(), isTrue);
+      expect(container.get<VersionNegotiator>(), isA<VersionNegotiatorImpl>());
     });
   });
 }

--- a/packages/platform/web/lib/src/web_root_module.dart
+++ b/packages/platform/web/lib/src/web_root_module.dart
@@ -1,4 +1,5 @@
 import 'package:connectivity_platform/connectivity_platform.dart';
+import 'package:di/di.dart';
 import 'package:interfaces/orchestration.dart';
 import 'package:interfaces/services.dart';
 import 'package:models/domain.dart';
@@ -61,5 +62,11 @@ Future<void> registerWebRootModule(
           await disposable.onDispose();
         }
       },
-    );
+    )
+    // #36/#87: pure, stateless. Web registers no WellKnownClient —
+    // same-origin means a server always exists, /server-add is
+    // unreachable, and no web implementation exists; the negotiator is
+    // registered anyway because the refresh-time re-check (#87) applies
+    // to web's identity fetch during auth (#37).
+    ..registerLazySingleton<VersionNegotiator>(VersionNegotiatorImpl.new);
 }

--- a/packages/platform/web/pubspec.yaml
+++ b/packages/platform/web/pubspec.yaml
@@ -37,6 +37,8 @@ dependencies:
   package_info_plus: ^10.2.0
 
 dev_dependencies:
+  network_interface:
+    path: ../../network/network_interface
   flutter_test:
     sdk: flutter
   very_good_analysis: ^10.2.0

--- a/packages/platform/web/test/web_root_module_test.dart
+++ b/packages/platform/web/test/web_root_module_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:interfaces/orchestration.dart';
 import 'package:interfaces/services.dart';
 import 'package:models/domain.dart';
+import 'package:network_interface/network_interface.dart';
 import 'package:observability/observability.dart';
 import 'package:web_platform/web.dart';
 
@@ -132,6 +133,33 @@ void main() {
       await container.dispose();
 
       expect(constructions, 0);
+    });
+
+    test('registers VersionNegotiator (pure; needed for #87 refresh-time '
+        're-check on web)', () async {
+      final container = DependencyContainerImpl();
+
+      await registerWebRootModule(
+        container,
+        buildInfoReader: const _StubBuildInfoReader(_info),
+        connectivityFactory: _FakeConnectivityService.new,
+      );
+
+      expect(container.isRegistered<VersionNegotiator>(), isTrue);
+      expect(container.get<VersionNegotiator>(), isA<VersionNegotiatorImpl>());
+    });
+
+    test('does not register WellKnownClient — web is same-origin, '
+        '/server-add is unreachable, and no web impl exists', () async {
+      final container = DependencyContainerImpl();
+
+      await registerWebRootModule(
+        container,
+        buildInfoReader: const _StubBuildInfoReader(_info),
+        connectivityFactory: _FakeConnectivityService.new,
+      );
+
+      expect(container.isRegistered<WellKnownClient>(), isFalse);
     });
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,6 +32,7 @@ workspace:
   - packages/core/di
   - packages/core/observability
   - packages/features/auth
+  - packages/features/server_onboarding
   - packages/storage/drift_storage
   - packages/storage/key_storage
   - packages/storage/storage_interface


### PR DESCRIPTION
## Summary by Sourcery

Add a full first-run server onboarding flow that discovers a BGE server, negotiates version compatibility, then persists and activates it via new orchestration APIs, with native-only routing, DI wiring, localization, and accessibility-focused UI.

New Features:
- Introduce a server onboarding feature package with bloc-driven URL-based discovery, version negotiation, and server add UI wired to the /server-add route
- Add a ServerOrchestrator.addAndActivateServer API to persist and activate a newly discovered server atomically from the caller’s perspective

Bug Fixes:
- Ensure failed server onboarding rolls back newly persisted server configs and preserves single-active-server invariants

Enhancements:
- Wire server onboarding success into the app bootstrap flow so first server registration advances the app from NeedsServer to NeedsAuth
- Extend native and web root modules to register WellKnownClient and VersionNegotiator services required for server onboarding and version checks
- Improve URL normalization and validation rules for onboarding to enforce HTTPS, allow safe HTTP for local/private hosts, and handle malformed inputs predictably

Build:
- Register the server_onboarding feature and network_interface packages in the workspace and dependent pubspecs

Documentation:
- Add README and CHANGELOG for the server_onboarding feature documenting the discovery, negotiation, and persist/activate flow and accessibility behavior

Tests:
- Add comprehensive bloc, widget, URL-normalization, orchestration, bootstrap, and DI registration tests covering the server onboarding behavior and error handling
- Add ARB coverage tests for the server_onboarding feature’s localizations