### PR TITLE
feat: auth wiring, resolves #37

### DIFF
--- a/apps/mobile/ios/Podfile.lock
+++ b/apps/mobile/ios/Podfile.lock
@@ -1,66 +1,15 @@
 PODS:
-  - connectivity_plus (0.0.1):
-    - Flutter
-  - device_info_plus (0.0.1):
-    - Flutter
   - Flutter (1.0.0)
-  - flutter_secure_storage_darwin (10.0.0):
-    - Flutter
-    - FlutterMacOS
-  - image_picker_ios (0.0.1):
-    - Flutter
-  - package_info_plus (0.4.5):
-    - Flutter
-  - path_provider_foundation (0.0.1):
-    - Flutter
-    - FlutterMacOS
-  - rive_native (0.0.1):
-    - Flutter
-  - sqflite_darwin (0.0.4):
-    - Flutter
-    - FlutterMacOS
 
 DEPENDENCIES:
-  - connectivity_plus (from `.symlinks/plugins/connectivity_plus/ios`)
-  - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Flutter (from `Flutter`)
-  - flutter_secure_storage_darwin (from `.symlinks/plugins/flutter_secure_storage_darwin/darwin`)
-  - image_picker_ios (from `.symlinks/plugins/image_picker_ios/ios`)
-  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
-  - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
-  - rive_native (from `.symlinks/plugins/rive_native/ios`)
-  - sqflite_darwin (from `.symlinks/plugins/sqflite_darwin/darwin`)
 
 EXTERNAL SOURCES:
-  connectivity_plus:
-    :path: ".symlinks/plugins/connectivity_plus/ios"
-  device_info_plus:
-    :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
     :path: Flutter
-  flutter_secure_storage_darwin:
-    :path: ".symlinks/plugins/flutter_secure_storage_darwin/darwin"
-  image_picker_ios:
-    :path: ".symlinks/plugins/image_picker_ios/ios"
-  package_info_plus:
-    :path: ".symlinks/plugins/package_info_plus/ios"
-  path_provider_foundation:
-    :path: ".symlinks/plugins/path_provider_foundation/darwin"
-  rive_native:
-    :path: ".symlinks/plugins/rive_native/ios"
-  sqflite_darwin:
-    :path: ".symlinks/plugins/sqflite_darwin/darwin"
 
 SPEC CHECKSUMS:
-  connectivity_plus: cb623214f4e1f6ef8fe7403d580fdad517d2f7dd
-  device_info_plus: 21fcca2080fbcd348be798aa36c3e5ed849eefbe
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  flutter_secure_storage_darwin: acdb3f316ed05a3e68f856e0353b133eec373a23
-  image_picker_ios: e0ece4aa2a75771a7de3fa735d26d90817041326
-  package_info_plus: af8e2ca6888548050f16fa2f1938db7b5a5df499
-  path_provider_foundation: bb55f6dbba17d0dccd6737fe6f7f34fbd0376880
-  rive_native: c9ed76ccf380f38205edcb8f552121aac8ec39da
-  sqflite_darwin: 20b2a3a3b70e43edae938624ce550a3cbf66a3d0
 
 PODFILE CHECKSUM: 3c63482e143d1b91d2d2560aee9fb04ecc74ac7e
 

--- a/apps/mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/apps/mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -12,11 +12,11 @@
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
 		7835887016CDB72258F40002 /* Pods_RunnerTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 021E82ACDFDF9A79986172FA /* Pods_RunnerTests.framework */; };
+		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 		82613AAD3D883D2945077ACF /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = EBB1DB17B8F19FC830E97C4F /* Pods_Runner.framework */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
-		78A318202AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage in Frameworks */ = {isa = PBXBuildFile; productRef = 78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -55,6 +55,7 @@
 		6398708AF60AFC3CF5A1316F /* Pods-RunnerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-RunnerTests.debug.xcconfig"; path = "Target Support Files/Pods-RunnerTests/Pods-RunnerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -66,7 +67,6 @@
 		EBB1DB17B8F19FC830E97C4F /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F093BD67D6B2C74011F1A2E5 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		F61179AF245B29F1ED983ACB /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
-		78E0A7A72DC9AD7400C4905E /* FlutterGeneratedPluginSwiftPackage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = FlutterGeneratedPluginSwiftPackage; path = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -192,9 +192,6 @@
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 		97C146ED1CF9000F007C117D /* Runner */ = {
-			packageProductDependencies = (
-				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
-			);
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
@@ -205,13 +202,15 @@
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
-				C6D9886A9C899FE914E91FC5 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
 			);
 			name = Runner;
+			packageProductDependencies = (
+				78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */,
+			);
 			productName = Runner;
 			productReference = 97C146EE1CF9000F007C117D /* Runner.app */;
 			productType = "com.apple.product-type.application";
@@ -220,9 +219,6 @@
 
 /* Begin PBXProject section */
 		97C146E61CF9000F007C117D /* Project object */ = {
-			packageReferences = (
-				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */,
-			);
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = YES;
@@ -248,6 +244,9 @@
 				Base,
 			);
 			mainGroup = 97C146E51CF9000F007C117D;
+			packageReferences = (
+				781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */,
+			);
 			productRefGroup = 97C146EF1CF9000F007C117D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -354,23 +353,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
-		};
-		C6D9886A9C899FE914E91FC5 /* [CP] Embed Pods Frameworks */ = {
-			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
-			);
-			name = "[CP] Embed Pods Frameworks";
-			outputFileListPaths = (
-				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
-			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -733,12 +715,14 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
 /* Begin XCLocalSwiftPackageReference section */
-		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage" */ = {
+		781AD8BC2B33823900A9FFBB /* XCLocalSwiftPackageReference "FlutterGeneratedPluginSwiftPackage" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Flutter/ephemeral/Packages/FlutterGeneratedPluginSwiftPackage;
 		};
 /* End XCLocalSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		78A3181F2AECB46A00862997 /* FlutterGeneratedPluginSwiftPackage */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/packages/app_shell/lib/src/bootstrap/app_bootstrap_cubit.dart
+++ b/packages/app_shell/lib/src/bootstrap/app_bootstrap_cubit.dart
@@ -16,6 +16,14 @@ import 'platform_bootstrap.dart';
 ///   supports it, and executing it still requires explicit user
 ///   confirmation in the UI — the shell never deletes the meta database
 ///   on its own.
+///
+/// Auth transitions (#37): bootstrap itself never emits
+/// [AppBootstrapReady] — a registered server routes to the auth leg
+/// unconditionally, and the authenticated ↔ auth transitions are driven
+/// by the auth wiring through [onAuthenticated] / [onSignedOut], the
+/// same presentation-layer-coordination pattern as [onServerRegistered]
+/// (a BlocListener over the auth bloc invokes them; blocs never depend
+/// on blocs).
 class AppBootstrapCubit extends Cubit<AppBootstrapState> {
   AppBootstrapCubit({
     required PlatformBootstrap platformBootstrap,
@@ -107,7 +115,7 @@ class AppBootstrapCubit extends Cubit<AppBootstrapState> {
   ///
   /// Emits [AppBootstrapNeedsAuth]; the router redirect moves the app to
   /// `/auth` (a registered server routes to the auth leg unconditionally
-  /// — the authenticated → home transition is #37's).
+  /// — the authenticated → home transition is [onAuthenticated]'s, #37).
   ///
   /// Only meaningful from [AppBootstrapNeedsServer]; a no-op otherwise,
   /// for the same fire-and-forget reason as [retry] — it is invoked from
@@ -116,6 +124,43 @@ class AppBootstrapCubit extends Cubit<AppBootstrapState> {
   void onServerRegistered() {
     if (state is! AppBootstrapNeedsServer) return;
     _logger.info('First server registered; advancing to auth');
+    emit(const AppBootstrapNeedsAuth());
+  }
+
+  /// Advances the app past the auth leg once the auth wiring (#37)
+  /// reports an authenticated session — sign-in, sign-up, or a
+  /// successful startup restore all arrive here identically.
+  ///
+  /// Emits [AppBootstrapReady]; the router redirect moves the app to
+  /// `/home`.
+  ///
+  /// Only meaningful from [AppBootstrapNeedsAuth]; a no-op otherwise,
+  /// for the same fire-and-forget reason as [retry] — it is invoked from
+  /// a BlocListener reacting to the auth bloc's authenticated state, and
+  /// a duplicate or late signal (including the repository's state
+  /// mirroring re-confirming an already-ready session) must not throw
+  /// into an unawaited future.
+  void onAuthenticated() {
+    if (state is! AppBootstrapNeedsAuth) return;
+    _logger.info('Authenticated; advancing to home');
+    emit(const AppBootstrapReady());
+  }
+
+  /// Returns the app to the auth leg after the authenticated session
+  /// ends (#37) — explicit sign-out, or a mid-session authentication
+  /// loss surfaced by the repository's auth-state stream (e.g. token
+  /// expiry detected by the interceptor).
+  ///
+  /// Emits [AppBootstrapNeedsAuth]; the router redirect moves the app to
+  /// `/auth`.
+  ///
+  /// Only meaningful from [AppBootstrapReady]; a no-op otherwise, for
+  /// the same fire-and-forget reason as [retry] — unauthenticated
+  /// signals also fire during the pre-home auth leg (a restore finding
+  /// no session), where the app is already exactly where it belongs.
+  void onSignedOut() {
+    if (state is! AppBootstrapReady) return;
+    _logger.info('Signed out; returning to auth');
     emit(const AppBootstrapNeedsAuth());
   }
 
@@ -134,7 +179,7 @@ class AppBootstrapCubit extends Cubit<AppBootstrapState> {
       );
       // Never AppBootstrapReady from bootstrap: a registered server routes
       // to the auth leg unconditionally; the authenticated → home
-      // transition is owned by the auth wiring issue (#37).
+      // transition is owned by the auth wiring (#37, [onAuthenticated]).
       emit(
         result.hasServer
             ? const AppBootstrapNeedsAuth()

--- a/packages/app_shell/test/bootstrap/app_bootstrap_cubit_auth_transitions_test.dart
+++ b/packages/app_shell/test/bootstrap/app_bootstrap_cubit_auth_transitions_test.dart
@@ -1,0 +1,137 @@
+import 'package:app_shell/app_shell.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:interfaces/orchestration.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../support/fake_platform_bootstrap.dart';
+
+class _MockServerOrchestrator extends Mock implements ServerOrchestrator {}
+
+/// Pins the #37 auth transitions on [AppBootstrapCubit]:
+/// `onAuthenticated` (NeedsAuth → Ready) and `onSignedOut`
+/// (Ready → NeedsAuth), mirroring the `onServerRegistered` guarded
+/// fire-and-forget pattern — idempotent, and no-ops from any other state.
+void main() {
+  Future<void> noopHydrated(PlatformBootstrap _) async {}
+
+  AppBootstrapCubit buildCubit({required FakePlatformBootstrap bootstrap}) =>
+      AppBootstrapCubit(
+        platformBootstrap: bootstrap,
+        hydratedStorageInitializer: noopHydrated,
+      );
+
+  /// A native-shaped bootstrap with a registered server → initialize
+  /// lands on [AppBootstrapNeedsAuth].
+  FakePlatformBootstrap serverRegistered() =>
+      FakePlatformBootstrap(orchestrator: _MockServerOrchestrator());
+
+  group('onAuthenticated()', () {
+    blocTest<AppBootstrapCubit, AppBootstrapState>(
+      'advances NeedsAuth → Ready (sign-in / sign-up / restore all arrive '
+      'here identically)',
+      build: () => buildCubit(bootstrap: serverRegistered()),
+      act: (cubit) async {
+        await cubit.initialize();
+        cubit.onAuthenticated();
+      },
+      expect: () => const [AppBootstrapNeedsAuth(), AppBootstrapReady()],
+    );
+
+    blocTest<AppBootstrapCubit, AppBootstrapState>(
+      'is idempotent — a duplicate signal from Ready is a no-op (the '
+      'repository mirror re-confirming a session must not throw or '
+      're-emit)',
+      build: () => buildCubit(bootstrap: serverRegistered()),
+      act: (cubit) async {
+        await cubit.initialize();
+        cubit.onAuthenticated();
+        cubit.onAuthenticated();
+      },
+      expect: () => const [AppBootstrapNeedsAuth(), AppBootstrapReady()],
+    );
+
+    blocTest<AppBootstrapCubit, AppBootstrapState>(
+      'is a no-op from NeedsServer — no server means no auth leg to '
+      'advance past',
+      build: () => buildCubit(
+        bootstrap: FakePlatformBootstrap(
+          outcomes: const [BootstrapResult(hasServer: false)],
+        ),
+      ),
+      act: (cubit) async {
+        await cubit.initialize();
+        cubit.onAuthenticated();
+      },
+      expect: () => const [AppBootstrapNeedsServer()],
+    );
+
+    test('is a no-op before initialize() (Initializing state)', () {
+      final cubit = buildCubit(bootstrap: FakePlatformBootstrap());
+      addTearDown(cubit.close);
+
+      cubit.onAuthenticated();
+
+      expect(cubit.state, const AppBootstrapInitializing());
+    });
+  });
+
+  group('onSignedOut()', () {
+    blocTest<AppBootstrapCubit, AppBootstrapState>(
+      'returns Ready → NeedsAuth on sign-out',
+      build: () => buildCubit(bootstrap: serverRegistered()),
+      act: (cubit) async {
+        await cubit.initialize();
+        cubit.onAuthenticated();
+        cubit.onSignedOut();
+      },
+      expect: () => const [
+        AppBootstrapNeedsAuth(),
+        AppBootstrapReady(),
+        AppBootstrapNeedsAuth(),
+      ],
+    );
+
+    blocTest<AppBootstrapCubit, AppBootstrapState>(
+      'is a no-op from NeedsAuth — an unauthenticated signal during the '
+      'auth leg (a restore finding no session) leaves the app where it '
+      'already is',
+      build: () => buildCubit(bootstrap: serverRegistered()),
+      act: (cubit) async {
+        await cubit.initialize();
+        cubit.onSignedOut();
+        cubit.onSignedOut();
+      },
+      expect: () => const [AppBootstrapNeedsAuth()],
+    );
+
+    test('is a no-op before initialize() (Initializing state)', () {
+      final cubit = buildCubit(bootstrap: FakePlatformBootstrap());
+      addTearDown(cubit.close);
+
+      cubit.onSignedOut();
+
+      expect(cubit.state, const AppBootstrapInitializing());
+    });
+  });
+
+  group('re-authentication round trip', () {
+    blocTest<AppBootstrapCubit, AppBootstrapState>(
+      'NeedsAuth → Ready → NeedsAuth → Ready (mid-session token expiry, '
+      'then a fresh sign-in)',
+      build: () => buildCubit(bootstrap: serverRegistered()),
+      act: (cubit) async {
+        await cubit.initialize();
+        cubit.onAuthenticated();
+        cubit.onSignedOut();
+        cubit.onAuthenticated();
+      },
+      expect: () => const [
+        AppBootstrapNeedsAuth(),
+        AppBootstrapReady(),
+        AppBootstrapNeedsAuth(),
+        AppBootstrapReady(),
+      ],
+    );
+  });
+}

--- a/packages/core/di/lib/di.dart
+++ b/packages/core/di/lib/di.dart
@@ -1,6 +1,7 @@
 library;
 
 export 'src/dependency_container_impl.dart';
+export 'src/orchestrator_active_server_scope.dart';
 export 'src/server_context_impl.dart';
 export 'src/server_orchestrator_impl.dart';
 export 'src/user_data_export_bundler.dart';

--- a/packages/core/di/lib/src/orchestrator_active_server_scope.dart
+++ b/packages/core/di/lib/src/orchestrator_active_server_scope.dart
@@ -1,0 +1,62 @@
+import 'dart:async';
+
+import 'package:interfaces/orchestration.dart';
+
+/// Native [ActiveServerScope] (#37): a thin, read-only adapter over the
+/// [ServerOrchestrator].
+///
+/// Maps the orchestrator's active state into [ActiveServer] snapshots by
+/// reading the active [ServerContext] — its container plus its `config`
+/// (identity + display name). Because both come from the one live context
+/// object, the pair is inherently consistent; there is no separate
+/// `activeConfig` lookup to fall out of step.
+///
+/// ## Emission semantics
+///
+/// [watchActive] replays the current value on subscribe (the seam's
+/// contract; the orchestrator's own stream has no replay) via the same
+/// `Stream.multi` pattern as `AuthRepositoryImpl.watchAuthState`. Each
+/// subsequent orchestrator emission triggers a re-read of the *current*
+/// truth rather than mapping the (possibly stale, async-delivered) event
+/// payload: after rapid successive commits this can deliver the same
+/// [ActiveServer] twice, but never a stale or torn one. Emissions are
+/// therefore not distinct — consumers keying on
+/// [ActiveServer.serverId] treat repeats as no-ops (the value's equality
+/// supports `distinct()` where wanted).
+///
+/// Owns no resources: subscriptions are per-listener and cancelled with
+/// the listener; nothing to dispose.
+class OrchestratorActiveServerScope implements ActiveServerScope {
+  OrchestratorActiveServerScope({required ServerOrchestrator orchestrator})
+    : _orchestrator = orchestrator;
+
+  final ServerOrchestrator _orchestrator;
+
+  @override
+  ActiveServer? get active {
+    final context = _orchestrator.getActiveContext();
+    if (context == null) return null;
+    final config = context.config;
+    return ActiveServer(
+      serverId: config.id,
+      displayName: config.displayName,
+      identity: config.cachedIdentity,
+      container: context.container,
+    );
+  }
+
+  @override
+  Stream<ActiveServer?> watchActive() {
+    return Stream.multi((controller) {
+      controller.add(active);
+      final sub = _orchestrator.watchActiveContext().listen(
+        // Re-read current truth at delivery time instead of mapping the
+        // event payload — see class docs, "Emission semantics".
+        (_) => controller.add(active),
+        onError: controller.addError,
+        onDone: controller.close,
+      );
+      controller.onCancel = sub.cancel;
+    });
+  }
+}

--- a/packages/core/di/lib/src/server_context_impl.dart
+++ b/packages/core/di/lib/src/server_context_impl.dart
@@ -84,6 +84,8 @@ class ServerContextImpl implements ServerContext {
   @override
   final String serverId;
 
+  @override
+  ServerConfig get config => _config;
   final ServerConfig _config;
 
   final List<ServerScopeInstaller> _installers;

--- a/packages/core/di/lib/src/server_orchestrator_impl.dart
+++ b/packages/core/di/lib/src/server_orchestrator_impl.dart
@@ -41,6 +41,17 @@ import 'server_context_impl.dart';
 /// "Concurrent orchestrator operation attempted" error. With async
 /// delivery the listener runs after the originating method returns
 /// and the lock has been released.
+///
+/// ## Config bookkeeping (#37)
+///
+/// [_configs] mirrors [_contexts] key-for-key: every path that registers
+/// a context registers its [ServerConfig], and every path that removes a
+/// context removes its config. [activeConfig] reads through
+/// [_activeServerId], so it commits together with the active pointer and
+/// the active-context emission — by the time a listener is delivered an
+/// event (async delivery, above), the config it reads is consistent with
+/// that event. The stored config is a connect-time snapshot; that is
+/// sufficient while no rename-server flow exists.
 class ServerOrchestratorImpl implements ServerOrchestrator {
   ServerOrchestratorImpl({
     required ServerRepository serverRepository,
@@ -58,6 +69,11 @@ class ServerOrchestratorImpl implements ServerOrchestrator {
   final bool _isDesktop;
 
   final Map<String, ServerContext> _contexts = {};
+
+  /// Connect-time [ServerConfig] snapshots, keyed like [_contexts] and
+  /// mutated in lockstep with it (see class docs, "Config bookkeeping").
+  final Map<String, ServerConfig> _configs = {};
+
   final Map<String, Timer> _backgroundingTimers = {};
 
   final StreamController<ServerContext?> _activeContextController =
@@ -84,6 +100,12 @@ class ServerOrchestratorImpl implements ServerOrchestrator {
 
   @override
   String? get activeServerId => _activeServerId;
+
+  @override
+  ServerConfig? get activeConfig {
+    final id = _activeServerId;
+    return id == null ? null : _configs[id];
+  }
 
   @override
   bool get isInitialized => _isInitialized;
@@ -121,6 +143,7 @@ class ServerOrchestratorImpl implements ServerOrchestrator {
           await context.background(); // active → backgrounding
           await context.suspend(); // backgrounding → monitoring
           _contexts[config.id] = context;
+          _configs[config.id] = config;
         } catch (e, st) {
           _logError('restore of server ${config.id} failed', e, st);
           await _disposeQuietly(context);
@@ -145,6 +168,7 @@ class ServerOrchestratorImpl implements ServerOrchestrator {
           // pointer. Remaining monitoring contexts stay connected.
           _logError('activating restored server $chosenActive failed', e, st);
           await _disposeQuietly(_contexts.remove(chosenActive)!);
+          _configs.remove(chosenActive);
           await _updateStateQuietly(chosenActive, ConnectionState.disconnected);
           _activeServerId = null;
         }
@@ -251,6 +275,7 @@ class ServerOrchestratorImpl implements ServerOrchestrator {
       }
 
       _contexts[serverId] = context;
+      _configs[serverId] = config;
 
       if (shouldBeActive) {
         // Demote the current active server (if a different one) before
@@ -282,6 +307,7 @@ class ServerOrchestratorImpl implements ServerOrchestrator {
                 }
               }
               await _disposeQuietly(_contexts.remove(serverId)!);
+              _configs.remove(serverId);
               rethrow;
             }
           }
@@ -350,6 +376,7 @@ class ServerOrchestratorImpl implements ServerOrchestrator {
 
       await context.dispose();
       _contexts.remove(serverId);
+      _configs.remove(serverId);
 
       await _serverRepository.updateConnectionState(
         serverId: serverId,
@@ -486,6 +513,7 @@ class ServerOrchestratorImpl implements ServerOrchestrator {
       await context.dispose();
     }
     _contexts.clear();
+    _configs.clear();
 
     await _activeContextController.close();
     await _contextsController.close();

--- a/packages/core/di/test/orchestrator_active_server_scope_test.dart
+++ b/packages/core/di/test/orchestrator_active_server_scope_test.dart
@@ -1,0 +1,258 @@
+import 'dart:async';
+
+import 'package:di/di.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:interfaces/orchestration.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/domain.dart';
+
+import 'support/orchestrator_test_fixtures.dart';
+
+class _MockServerOrchestrator extends Mock implements ServerOrchestrator {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(ConnectionState.disconnected);
+  });
+
+  group('ActiveServer', () {
+    final identity = testServerIdentity('a');
+    final container = DependencyContainerImpl();
+
+    ActiveServer build({DependencyContainer? withContainer}) => ActiveServer(
+      serverId: 'a',
+      displayName: 'Server a',
+      identity: identity,
+      container: withContainer ?? container,
+    );
+
+    test('equal for identical snapshot fields and the same container', () {
+      expect(build(), equals(build()));
+      expect(build().hashCode, build().hashCode);
+    });
+
+    test('not equal for a different container instance', () {
+      expect(
+        build(),
+        isNot(equals(build(withContainer: DependencyContainerImpl()))),
+      );
+    });
+
+    test('not equal for a different serverId', () {
+      final other = ActiveServer(
+        serverId: 'b',
+        displayName: 'Server a',
+        identity: identity,
+        container: container,
+      );
+      expect(build(), isNot(equals(other)));
+    });
+  });
+
+  group('OrchestratorActiveServerScope (unit, mocked orchestrator)', () {
+    late _MockServerOrchestrator orchestrator;
+    late StreamController<ServerContext?> activeContextController;
+    late OrchestratorActiveServerScope scope;
+
+    setUp(() {
+      orchestrator = _MockServerOrchestrator();
+      activeContextController = StreamController<ServerContext?>.broadcast();
+      when(
+        () => orchestrator.watchActiveContext(),
+      ).thenAnswer((_) => activeContextController.stream);
+      when(() => orchestrator.getActiveContext()).thenReturn(null);
+      scope = OrchestratorActiveServerScope(orchestrator: orchestrator);
+    });
+
+    tearDown(() async => activeContextController.close());
+
+    /// Stubs the orchestrator's committed truth to [id] (or clears it
+    /// when null), the way the real impl commits.
+    void commitActive(String? id, {DependencyContainer? container}) {
+      if (id == null) {
+        when(() => orchestrator.getActiveContext()).thenReturn(null);
+        return;
+      }
+      final ctx = mockServerContext(
+        id,
+        container: container ?? DependencyContainerImpl(),
+      );
+      when(() => orchestrator.getActiveContext()).thenReturn(ctx);
+    }
+
+    test('active is null when no server is active', () {
+      expect(scope.active, isNull);
+    });
+
+    test('active maps serverId, displayName, identity, and container '
+        'from the committed pair', () {
+      final container = DependencyContainerImpl();
+      commitActive('a', container: container);
+
+      final active = scope.active;
+      expect(active, isNotNull);
+      expect(active!.serverId, 'a');
+      expect(active.displayName, 'Server a');
+      expect(active.identity, testServerIdentity('a'));
+      expect(identical(active.container, container), isTrue);
+    });
+
+    test('watchActive replays the current value on subscribe — null', () async {
+      expect(await scope.watchActive().first, isNull);
+    });
+
+    test('watchActive replays the current value on subscribe — active '
+        '(late subscriber, no orchestrator emission needed)', () async {
+      commitActive('a');
+
+      final first = await scope.watchActive().first;
+      expect(first?.serverId, 'a');
+    });
+
+    test('watchActive re-reads committed truth on each orchestrator '
+        'emission', () async {
+      final emitted = <ActiveServer?>[];
+      final sub = scope.watchActive().listen(emitted.add);
+      await pumpEventQueue();
+
+      commitActive('a');
+      activeContextController.add(orchestrator.getActiveContext());
+      await pumpEventQueue();
+
+      commitActive('b');
+      activeContextController.add(orchestrator.getActiveContext());
+      await pumpEventQueue();
+
+      commitActive(null);
+      activeContextController.add(null);
+      await pumpEventQueue();
+
+      await sub.cancel();
+
+      expect(emitted.map((a) => a?.serverId).toList(), [null, 'a', 'b', null]);
+    });
+
+    test('a stale event delivery reflects current truth, never a torn '
+        'snapshot', () async {
+      // Simulate async broadcast delivery racing a rapid double-commit:
+      // the event for 'a' is delivered AFTER truth moved to 'b'.
+      commitActive('b');
+
+      final emitted = <ActiveServer?>[];
+      final sub = scope.watchActive().listen(emitted.add);
+      await pumpEventQueue();
+
+      final staleContextForA = mockServerContext(
+        'a',
+        container: DependencyContainerImpl(),
+      );
+      activeContextController.add(staleContextForA);
+      await pumpEventQueue();
+      await sub.cancel();
+
+      // Seed + stale delivery: both read the committed truth ('b').
+      expect(emitted.map((a) => a?.serverId).toList(), ['b', 'b']);
+    });
+
+    test('cancelling the subscription cancels the orchestrator '
+        'subscription', () async {
+      final sub = scope.watchActive().listen((_) {});
+      await pumpEventQueue();
+      expect(activeContextController.hasListener, isTrue);
+
+      await sub.cancel();
+      await pumpEventQueue();
+      expect(activeContextController.hasListener, isFalse);
+    });
+  });
+
+  group('OrchestratorActiveServerScope (end-to-end, real orchestrator)', () {
+    late MockServerRepository repo;
+    late MockDevicePreferencesRepository prefsRepo;
+    late ServerOrchestratorImpl orchestrator;
+    late OrchestratorActiveServerScope scope;
+
+    setUp(() {
+      repo = MockServerRepository();
+      prefsRepo = MockDevicePreferencesRepository();
+      when(() => prefsRepo.get()).thenAnswer((_) async => DevicePreferences());
+      when(() => repo.getConnectedServers()).thenAnswer((_) async => []);
+      when(
+        () => repo.updateConnectionState(
+          serverId: any(named: 'serverId'),
+          newState: any(named: 'newState'),
+        ),
+      ).thenAnswer(
+        (inv) async =>
+            testServerConfig(id: inv.namedArguments[#serverId] as String),
+      );
+      when(() => repo.updateLastActive(any(), any())).thenAnswer((_) async {});
+
+      orchestrator = ServerOrchestratorImpl(
+        serverRepository: repo,
+        preferencesRepository: prefsRepo,
+        contextFactory: (config) =>
+            mockServerContext(config.id, container: DependencyContainerImpl()),
+        isDesktopOverride: true,
+      );
+      scope = OrchestratorActiveServerScope(orchestrator: orchestrator);
+    });
+
+    tearDown(() async => orchestrator.dispose());
+
+    void stubGetServer(String id) {
+      when(
+        () => repo.getServer(id),
+      ).thenAnswer((_) async => testServerConfig(id: id));
+    }
+
+    test('a late subscriber (post-connect) receives the active server via '
+        'the replay — the returning-user scenario', () async {
+      await orchestrator.initialize();
+      stubGetServer('server-a');
+      await orchestrator.connectServer('server-a');
+
+      // Subscribe AFTER the connect: the orchestrator's own stream has no
+      // replay, so only the scope's seed can deliver this.
+      final first = await scope.watchActive().first;
+      expect(first?.serverId, 'server-a');
+      expect(first?.displayName, 'Server server-a');
+    });
+
+    test('emits the new active server after a switch', () async {
+      await orchestrator.initialize();
+      stubGetServer('server-a');
+      stubGetServer('server-b');
+      await orchestrator.connectServer('server-a');
+      await orchestrator.connectServer('server-b');
+
+      final emitted = <ActiveServer?>[];
+      final sub = scope.watchActive().listen(emitted.add);
+      await pumpEventQueue();
+
+      await orchestrator.switchActiveServer('server-b');
+      await pumpEventQueue();
+      await sub.cancel();
+
+      expect(emitted.first?.serverId, 'server-a'); // seed
+      expect(emitted.last?.serverId, 'server-b');
+    });
+
+    test('emits null when the sole active server is disconnected', () async {
+      await orchestrator.initialize();
+      stubGetServer('server-a');
+      await orchestrator.connectServer('server-a');
+
+      final emitted = <ActiveServer?>[];
+      final sub = scope.watchActive().listen(emitted.add);
+      await pumpEventQueue();
+
+      await orchestrator.disconnectServer('server-a');
+      await pumpEventQueue();
+      await sub.cancel();
+
+      expect(emitted.first?.serverId, 'server-a'); // seed
+      expect(emitted.last, isNull);
+    });
+  });
+}

--- a/packages/core/di/test/server_orchestrator_active_config_test.dart
+++ b/packages/core/di/test/server_orchestrator_active_config_test.dart
@@ -1,0 +1,174 @@
+import 'package:di/di.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/domain.dart';
+
+import 'support/orchestrator_test_fixtures.dart';
+
+/// Pins `ServerOrchestrator.activeConfig` (#37): a connect-time
+/// [ServerConfig] snapshot that commits in lockstep with `activeServerId`
+/// and is removed in lockstep with the context on every teardown path.
+void main() {
+  setUpAll(() {
+    registerFallbackValue(ConnectionState.disconnected);
+  });
+
+  late MockServerRepository repo;
+  late MockDevicePreferencesRepository prefsRepo;
+  late ServerOrchestratorImpl orchestrator;
+
+  setUp(() {
+    repo = MockServerRepository();
+    prefsRepo = MockDevicePreferencesRepository();
+    when(() => prefsRepo.get()).thenAnswer((_) async => DevicePreferences());
+    when(() => repo.getConnectedServers()).thenAnswer((_) async => []);
+    when(
+      () => repo.updateConnectionState(
+        serverId: any(named: 'serverId'),
+        newState: any(named: 'newState'),
+      ),
+    ).thenAnswer(
+      (inv) async =>
+          testServerConfig(id: inv.namedArguments[#serverId] as String),
+    );
+    when(() => repo.updateLastActive(any(), any())).thenAnswer((_) async {});
+
+    orchestrator = ServerOrchestratorImpl(
+      serverRepository: repo,
+      preferencesRepository: prefsRepo,
+      contextFactory: (config) => mockServerContext(config.id),
+      isDesktopOverride: true,
+    );
+  });
+
+  tearDown(() async => orchestrator.dispose());
+
+  void stubGetServer(String id) {
+    when(
+      () => repo.getServer(id),
+    ).thenAnswer((_) async => testServerConfig(id: id));
+  }
+
+  group('activeConfig', () {
+    test('null after initialize with no connected servers', () async {
+      await orchestrator.initialize();
+      expect(orchestrator.activeConfig, isNull);
+    });
+
+    test('reflects the connected active server', () async {
+      await orchestrator.initialize();
+      stubGetServer('server-a');
+
+      await orchestrator.connectServer('server-a');
+
+      final config = orchestrator.activeConfig;
+      expect(config, isNotNull);
+      expect(config!.id, 'server-a');
+      expect(config.displayName, 'Server server-a');
+      expect(config.id, orchestrator.activeServerId);
+    });
+
+    test('restored on initialize for a previously active server', () async {
+      when(() => repo.getConnectedServers()).thenAnswer(
+        (_) async => [
+          testServerConfig(id: 'server-a', state: ConnectionState.active),
+          testServerConfig(id: 'server-b', state: ConnectionState.monitoring),
+        ],
+      );
+
+      await orchestrator.initialize();
+
+      expect(orchestrator.activeConfig?.id, 'server-a');
+    });
+
+    test('follows switchActiveServer', () async {
+      await orchestrator.initialize();
+      stubGetServer('server-a');
+      stubGetServer('server-b');
+      await orchestrator.connectServer('server-a');
+      await orchestrator.connectServer('server-b');
+      expect(orchestrator.activeConfig?.id, 'server-a');
+
+      await orchestrator.switchActiveServer('server-b');
+
+      expect(orchestrator.activeConfig?.id, 'server-b');
+    });
+
+    test('null after disconnecting the sole active server', () async {
+      await orchestrator.initialize();
+      stubGetServer('server-a');
+      await orchestrator.connectServer('server-a');
+
+      await orchestrator.disconnectServer('server-a');
+
+      expect(orchestrator.activeConfig, isNull);
+    });
+
+    test('follows the promoted server when the active one is '
+        'disconnected', () async {
+      await orchestrator.initialize();
+      stubGetServer('server-a');
+      stubGetServer('server-b');
+      await orchestrator.connectServer('server-a');
+      await orchestrator.connectServer('server-b');
+
+      await orchestrator.disconnectServer('server-a');
+
+      expect(orchestrator.activeConfig?.id, 'server-b');
+    });
+
+    test('no stale config after a failed onboarding activation '
+        '(rollback path)', () async {
+      final failingOrchestrator = ServerOrchestratorImpl(
+        serverRepository: repo,
+        preferencesRepository: prefsRepo,
+        contextFactory: (config) {
+          final ctx = mockServerContext(config.id);
+          when(() => ctx.activate()).thenThrow(StateError('boom'));
+          return ctx;
+        },
+        isDesktopOverride: true,
+      );
+      addTearDown(failingOrchestrator.dispose);
+      await failingOrchestrator.initialize();
+
+      final identity = testServerIdentity('new');
+      registerFallbackValue(identity);
+      when(
+        () => repo.addServer(
+          displayName: any(named: 'displayName'),
+          serverUrl: any(named: 'serverUrl'),
+          bgeServerId: any(named: 'bgeServerId'),
+          identity: any(named: 'identity'),
+        ),
+      ).thenAnswer((_) async => testServerConfig(id: 'new'));
+      when(() => repo.removeServer(any())).thenAnswer((_) async {});
+      stubGetServer('new');
+
+      await expectLater(
+        failingOrchestrator.addAndActivateServer(
+          displayName: 'My Server',
+          serverUrl: 'https://bge.example.com',
+          bgeServerId: 'bge-new',
+          identity: identity,
+        ),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(failingOrchestrator.activeConfig, isNull);
+      expect(failingOrchestrator.activeServerId, isNull);
+      expect(failingOrchestrator.currentConnectedCount, 0);
+    });
+
+    test('cleared on dispose', () async {
+      await orchestrator.initialize();
+      stubGetServer('server-a');
+      await orchestrator.connectServer('server-a');
+      expect(orchestrator.activeConfig, isNotNull);
+
+      await orchestrator.dispose();
+
+      expect(orchestrator.activeConfig, isNull);
+    });
+  });
+}

--- a/packages/core/di/test/support/orchestrator_test_fixtures.dart
+++ b/packages/core/di/test/support/orchestrator_test_fixtures.dart
@@ -1,0 +1,79 @@
+import 'package:interfaces/orchestration.dart';
+import 'package:interfaces/repositories.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/domain.dart';
+
+/// Shared fixtures for the #37 orchestration tests
+/// (`orchestrator_active_server_scope_test.dart`,
+/// `server_orchestrator_active_config_test.dart`).
+///
+/// Mirrors the inline helpers of `server_orchestrator_impl_test.dart`
+/// (deliberately left untouched); a later consolidation can fold that
+/// file onto these.
+
+class MockServerRepository extends Mock implements ServerRepository {}
+
+class MockDevicePreferencesRepository extends Mock
+    implements DevicePreferencesRepository {}
+
+class MockServerContext extends Mock implements ServerContext {}
+
+ServerConfig testServerConfig({
+  required String id,
+  ConnectionState state = ConnectionState.disconnected,
+}) => ServerConfig(
+  id: id,
+  displayName: 'Server $id',
+  serverUrl: 'https://$id.example.com',
+  connectionState: state,
+  bgeServerId: 'bge-$id',
+  cachedIdentity: testServerIdentity(id),
+  lastIdentityFetchedAt: DateTime.now().toUtc(),
+);
+
+ServerIdentity testServerIdentity(String id) => ServerIdentity(
+  serverId: 'bge-$id',
+  issuer: 'https://$id.example.com',
+  wellKnownSchemaVersion: 1,
+  name: 'Test BGE Server',
+  deviceAuthorizationEndpoint: '/api/auth/device',
+  authBasePath: '/api/auth',
+  sessionEndpoint: '/api/auth/get-session',
+  signOutEndpoint: '/api/auth/sign-out',
+  passkeySupported: true,
+  twoFactorSupported: true,
+  anonymousAuthSupported: true,
+);
+
+/// A lifecycle-faithful [ServerContext] mock: state transitions mirror
+/// the real contract so orchestrator paths (activate → background →
+/// suspend) behave. [container] is stubbed when provided so
+/// `ActiveServer.container` mapping can be asserted.
+MockServerContext mockServerContext(
+  String serverId, {
+  DependencyContainer? container,
+}) {
+  final ctx = MockServerContext();
+  when(() => ctx.serverId).thenReturn(serverId);
+  when(() => ctx.config).thenReturn(testServerConfig(id: serverId));
+  when(() => ctx.state).thenReturn(ServerContextState.initializing);
+  if (container != null) {
+    when(() => ctx.container).thenReturn(container);
+  }
+  when(() => ctx.activate()).thenAnswer((_) async {
+    when(() => ctx.state).thenReturn(ServerContextState.active);
+  });
+  when(() => ctx.background()).thenAnswer((_) async {
+    when(() => ctx.state).thenReturn(ServerContextState.backgrounding);
+  });
+  when(() => ctx.suspend()).thenAnswer((_) async {
+    when(() => ctx.state).thenReturn(ServerContextState.monitoring);
+  });
+  when(() => ctx.dispose()).thenAnswer((_) async {
+    when(() => ctx.state).thenReturn(ServerContextState.disposed);
+  });
+  when(
+    () => ctx.watchState(),
+  ).thenAnswer((_) => Stream.value(ServerContextState.active));
+  return ctx;
+}

--- a/packages/core/interfaces/lib/orchestration.dart
+++ b/packages/core/interfaces/lib/orchestration.dart
@@ -1,5 +1,6 @@
 library;
 
+export 'src/orchestration/active_server_scope.dart';
 export 'src/orchestration/dependency_container.dart';
 export 'src/orchestration/server_context_state.dart';
 export 'src/orchestration/server_context.dart';

--- a/packages/core/interfaces/lib/src/orchestration/active_server_scope.dart
+++ b/packages/core/interfaces/lib/src/orchestration/active_server_scope.dart
@@ -1,0 +1,101 @@
+import 'package:models/domain.dart';
+
+import 'dependency_container.dart';
+
+/// A read-only snapshot of the currently active server, as consumers
+/// outside the orchestration layer see it (#37).
+///
+/// This is deliberately narrower than [ServerContext]: no lifecycle
+/// surface (`activate` / `suspend` / `dispose`), only what the widget
+/// layer and per-server service consumers actually need —
+///
+/// - [container] to resolve per-server services (`AuthRepository`,
+///   `FeedbackTransport` in #97, …);
+/// - [identity] and [displayName] for auth UI (`AuthScreen` renders the
+///   strategies the server advertises and attributes the form to the
+///   server by name);
+/// - [serverId] for per-server bookkeeping (e.g. tagging queued feedback
+///   reports in #97, keying widget rebuilds on server switches).
+///
+/// Values are snapshots taken when the server was connected (sourced from
+/// the active [ServerContext]'s `config` on native); a rename-server flow
+/// does not exist yet, so staleness is not a concern in alpha.
+class ActiveServer {
+  const ActiveServer({
+    required this.serverId,
+    required this.displayName,
+    required this.identity,
+    required this.container,
+  });
+
+  /// Client-local server id ([ServerConfig.id] on native).
+  final String serverId;
+
+  /// Human-readable server name, shown by auth UI for attribution.
+  final String displayName;
+
+  /// The server's last-known identity document (advertised auth
+  /// strategies, endpoint paths).
+  final ServerIdentity identity;
+
+  /// The per-server dependency injection scope. Resolve per-server
+  /// services via `container.get<T>()`.
+  final DependencyContainer container;
+
+  /// Value equality over the snapshot fields; the [container] compares by
+  /// identity (it is a live scope, not a value). Two emissions for the
+  /// same connected server therefore compare equal, letting consumers
+  /// dedupe with `distinct()` if they care.
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ActiveServer &&
+          other.serverId == serverId &&
+          other.displayName == displayName &&
+          other.identity == identity &&
+          identical(other.container, container);
+
+  @override
+  int get hashCode =>
+      Object.hash(serverId, displayName, identity, identityHashCode(container));
+
+  @override
+  String toString() =>
+      'ActiveServer(serverId: $serverId, displayName: $displayName)';
+}
+
+/// The platform-neutral "which server is active" seam (#37).
+///
+/// The shared shell (`app_shell`) provisions per-server consumers (the
+/// auth bloc, #97's feedback transport resolver, future per-server
+/// services) from this interface alone — never from `kIsWeb` branches or
+/// the orchestrator directly. Each platform's composition root supplies
+/// the backing:
+///
+/// - **Native**: `OrchestratorActiveServerScope` in `core/di`, a thin
+///   adapter over [ServerOrchestrator.watchActiveContext] that re-reads the
+///   active [ServerContext]'s `config` on each emission.
+/// - **Web** (#96): a one-shot holder emitting the single origin-scoped
+///   container — web has no orchestrator by design (#31), and this seam
+///   is intentionally not a degenerate one.
+///
+/// ## Contract
+///
+/// - [watchActive] **replays the current value on subscribe** (matching
+///   the `watchAuthState` / `watchState` convention). This is required:
+///   the underlying orchestrator stream has no replay, and the shell
+///   subscribes after bootstrap has already activated a restored server —
+///   without replay a returning user would never see their server.
+/// - Emissions are **not** guaranteed distinct; consumers that key work
+///   on the server (e.g. a bloc provider keyed by [ActiveServer.serverId])
+///   should treat repeats as no-ops or apply `distinct()`.
+/// - `null` means no server is active (pre-onboarding, or between a
+///   disconnect and a promotion).
+abstract interface class ActiveServerScope {
+  /// The currently active server, or null when none is active.
+  ActiveServer? get active;
+
+  /// Stream of active-server changes. Replays the current value on
+  /// subscribe.
+  Stream<ActiveServer?> watchActive();
+}

--- a/packages/core/interfaces/lib/src/orchestration/server_context.dart
+++ b/packages/core/interfaces/lib/src/orchestration/server_context.dart
@@ -1,3 +1,5 @@
+import 'package:models/domain.dart';
+
 import 'dependency_container.dart';
 import 'server_context_state.dart';
 
@@ -9,6 +11,20 @@ import 'server_context_state.dart';
 abstract class ServerContext {
   /// Local server id matching the [ServerConfig.id] this context represents.
   String get serverId;
+
+  /// The [ServerConfig] this context was created for.
+  ///
+  /// A connect-time snapshot, retained for the context's whole life. The
+  /// authoritative source of the active server's identity/display name for
+  /// the native `ActiveServerScope` adapter, which reads it straight off the
+  /// live active context (`getActiveContext().config`) — so its snapshot
+  /// cannot drift from the context it came from (#37).
+  ///
+  /// ([ServerOrchestrator.activeConfig] is a separate getter backed by its
+  /// own snapshot map; the implementation keeps that map in lockstep with
+  /// the contexts.) Sufficient while no rename-server flow exists; a stale
+  /// [ServerConfig.connectionState] here is not read off this path.
+  ServerConfig get config;
 
   /// Current lifecycle state.
   ServerContextState get state;

--- a/packages/core/interfaces/lib/src/orchestration/server_orchestrator.dart
+++ b/packages/core/interfaces/lib/src/orchestration/server_orchestrator.dart
@@ -21,6 +21,21 @@ abstract class ServerOrchestrator {
   /// Null only before [initialize] completes.
   String? get activeServerId;
 
+  /// The [ServerConfig] of the currently active server; null when no
+  /// server is active (#37).
+  ///
+  /// A read-only snapshot taken when the server was connected. Commits
+  /// together with [activeServerId] and the [watchActiveContext]
+  /// emission, so a listener delivered an active-context event reads a
+  /// config consistent with that event. Backed by parallel config
+  /// bookkeeping in the implementation (a snapshot map keyed by
+  /// [activeServerId]), kept in lockstep with the live contexts.
+  ///
+  /// Note the native `ActiveServerScope` adapter does not read this getter:
+  /// it builds its `ActiveServer` value from the active [ServerContext]'s
+  /// own `config`. Both are connect-time snapshots of the same config.
+  ServerConfig? get activeConfig;
+
   /// Whether [initialize] has completed successfully.
   bool get isInitialized;
 

--- a/packages/core/interfaces/lib/src/repositories/auth_repository.dart
+++ b/packages/core/interfaces/lib/src/repositories/auth_repository.dart
@@ -39,7 +39,15 @@ abstract class AuthRepository {
 
   /// Signs out and clears the local session.
   ///
-  /// Best-effort server call — local state is always cleared.
+  /// Best-effort server call. The repository's in-memory auth state
+  /// ALWAYS transitions to [AuthStateUnauthenticated] — unconditionally,
+  /// even when clearing the persisted session material fails. In that
+  /// case an [AuthSignOutPersistenceException] is thrown, but only after
+  /// the state transition has been observed by [watchAuthState], so the
+  /// stream can never re-assert a session the user just ended (#37). The
+  /// residual risk of a failed persisted clear is the surviving token
+  /// restoring a session on the next cold start, where sign-out can be
+  /// repeated.
   Future<void> signOut();
 
   /// Returns the locally cached session without a network call.
@@ -154,4 +162,21 @@ final class AuthServerException extends AuthException {
     super.cause,
   });
   final int? statusCode;
+}
+
+/// Sign-out could not clear the locally persisted session material (#37).
+///
+/// Thrown by [AuthRepository.signOut] only AFTER the repository's
+/// in-memory auth state has transitioned to [AuthStateUnauthenticated] —
+/// the sign-out is effective for this process regardless, and
+/// [AuthRepository.watchAuthState] can never re-assert the ended session.
+/// The residual risk is the persisted token surviving until the next cold
+/// start, where the restored session can be signed out again. [cause]
+/// carries the underlying storage fault.
+final class AuthSignOutPersistenceException extends AuthException {
+  const AuthSignOutPersistenceException({
+    super.message =
+        'Signed out, but the stored session material could not be cleared.',
+    super.cause,
+  });
 }

--- a/packages/core/observability/test/redaction/redaction_test.dart
+++ b/packages/core/observability/test/redaction/redaction_test.dart
@@ -3,9 +3,6 @@ import 'package:test/test.dart';
 
 void main() {
   group('Redaction.redactName', () {
-    // Behaviour pinned to the original helpers promoted out of
-    // packages/features/auth/lib/src/bloc/auth_event.dart. Any change
-    // here is a behavioural change for auth event logging too.
     test('empty string stays empty', () {
       expect(Redaction.redactName(''), '');
     });
@@ -89,7 +86,12 @@ void main() {
 
     test('custom keep counts and mask char', () {
       expect(
-        Redaction.maskMiddle('1234567890', keepStart: 2, keepEnd: 3, maskChar: '#'),
+        Redaction.maskMiddle(
+          '1234567890',
+          keepStart: 2,
+          keepEnd: 3,
+          maskChar: '#',
+        ),
         '12#####890',
       );
     });

--- a/packages/features/auth/lib/auth.dart
+++ b/packages/features/auth/lib/auth.dart
@@ -1,5 +1,7 @@
 library;
 
+export 'l10n/auth_localizations.dart';
+
 export 'src/bloc/auth_bloc.dart';
 export 'src/bloc/auth_event.dart';
 export 'src/bloc/auth_bloc_state.dart';
@@ -9,4 +11,5 @@ export 'src/widgets/login_form.dart';
 export 'src/widgets/register_form.dart';
 export 'src/widgets/oidc_strategy_button.dart';
 
+export 'src/screens/auth_gate.dart';
 export 'src/screens/auth_screen.dart';

--- a/packages/features/auth/lib/l10n/intl_en.arb
+++ b/packages/features/auth/lib/l10n/intl_en.arb
@@ -1,87 +1,184 @@
 {
   "@@locale": "en",
-
   "authSignInTitle": "Sign In",
-  "@authSignInTitle": { "description": "Title for the sign-in form" },
-
+  "@authSignInTitle": {
+    "description": "Title for the sign-in form"
+  },
   "authRegisterTitle": "Create Account",
-  "@authRegisterTitle": { "description": "Title for the registration form" },
-
+  "@authRegisterTitle": {
+    "description": "Title for the registration form"
+  },
   "authSwitchToRegister": "Don't have an account? Register",
-  "@authSwitchToRegister": { "description": "Link to switch to registration form" },
-
+  "@authSwitchToRegister": {
+    "description": "Link to switch to registration form"
+  },
   "authSwitchToSignIn": "Already have an account? Sign in",
-  "@authSwitchToSignIn": { "description": "Link to switch to sign-in form" },
-
+  "@authSwitchToSignIn": {
+    "description": "Link to switch to sign-in form"
+  },
   "authEmailLabel": "Email",
-  "@authEmailLabel": { "description": "Email field label" },
-
+  "@authEmailLabel": {
+    "description": "Email field label"
+  },
   "authEmailHint": "Enter your email address",
-  "@authEmailHint": { "description": "Email field hint text" },
-
+  "@authEmailHint": {
+    "description": "Email field hint text"
+  },
   "authPasswordLabel": "Password",
-  "@authPasswordLabel": { "description": "Password field label" },
-
+  "@authPasswordLabel": {
+    "description": "Password field label"
+  },
   "authPasswordHint": "Enter your password",
-  "@authPasswordHint": { "description": "Password field hint text" },
-
+  "@authPasswordHint": {
+    "description": "Password field hint text"
+  },
+  "authPasswordCreateHint": "Create a password",
+  "@authPasswordCreateHint": {
+    "description": "Password field hint text on the registration form"
+  },
   "authUsernameLabel": "Username",
-  "@authUsernameLabel": { "description": "Username field label" },
-
+  "@authUsernameLabel": {
+    "description": "Username field label"
+  },
   "authUsernameHint": "Choose a username",
-  "@authUsernameHint": { "description": "Username field hint text" },
-
+  "@authUsernameHint": {
+    "description": "Username field hint text"
+  },
   "authFirstNameLabel": "First Name",
-  "@authFirstNameLabel": { "description": "First name field label" },
-
+  "@authFirstNameLabel": {
+    "description": "First name field label"
+  },
   "authLastNameLabel": "Last Name",
-  "@authLastNameLabel": { "description": "Last name field label" },
-
+  "@authLastNameLabel": {
+    "description": "Last name field label"
+  },
   "authSignInButton": "Sign In",
-  "@authSignInButton": { "description": "Sign-in submit button label" },
-
+  "@authSignInButton": {
+    "description": "Sign-in submit button label"
+  },
   "authRegisterButton": "Create Account",
-  "@authRegisterButton": { "description": "Registration submit button label" },
-
+  "@authRegisterButton": {
+    "description": "Registration submit button label"
+  },
   "authLoadingLabel": "Signing in, please wait",
-  "@authLoadingLabel": { "description": "Semantic label for loading indicator" },
-
+  "@authLoadingLabel": {
+    "description": "Semantic label for the sign-in loading indicator"
+  },
+  "authRegisterLoadingLabel": "Creating account, please wait",
+  "@authRegisterLoadingLabel": {
+    "description": "Semantic label for the registration loading indicator"
+  },
   "authOrDivider": "or",
-  "@authOrDivider": { "description": "Divider between email/password and OIDC options" },
-
+  "@authOrDivider": {
+    "description": "Divider between email/password and OIDC options"
+  },
   "authContinueWith": "Continue with {provider}",
   "@authContinueWith": {
     "description": "OIDC button label",
-    "placeholders": { "provider": { "type": "String" } }
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      }
+    }
   },
-
+  "authOidcComingSoon": "OIDC sign-in with {provider} — coming soon",
+  "@authOidcComingSoon": {
+    "description": "Placeholder shown when an OIDC button is tapped before the flow exists",
+    "placeholders": {
+      "provider": {
+        "type": "String"
+      }
+    }
+  },
   "authErrorRequired": "This field is required",
-  "@authErrorRequired": { "description": "Validation error for empty required field" },
-
+  "@authErrorRequired": {
+    "description": "Validation error for empty required field"
+  },
   "authErrorInvalidEmail": "Enter a valid email address",
-  "@authErrorInvalidEmail": { "description": "Validation error for bad email format" },
-
+  "@authErrorInvalidEmail": {
+    "description": "Validation error for bad email format"
+  },
   "authErrorPasswordTooShort": "Password must be at least {minLength} characters",
   "@authErrorPasswordTooShort": {
     "description": "Validation error for short password",
-    "placeholders": { "minLength": { "type": "int" } }
+    "placeholders": {
+      "minLength": {
+        "type": "int"
+      }
+    }
   },
-
   "authErrorUsernameTooShort": "Username must be at least {minLength} characters",
   "@authErrorUsernameTooShort": {
     "description": "Validation error for short username",
-    "placeholders": { "minLength": { "type": "int" } }
+    "placeholders": {
+      "minLength": {
+        "type": "int"
+      }
+    }
   },
-
+  "authErrorInvalidCredentials": "Incorrect email or password.",
+  "@authErrorInvalidCredentials": {
+    "description": "Submission error: sign-in rejected (401/403)"
+  },
+  "authErrorEmailExists": "An account with this email already exists.",
+  "@authErrorEmailExists": {
+    "description": "Submission error: registration email already taken"
+  },
+  "authErrorNetwork": "Could not reach the server. Check your connection.",
+  "@authErrorNetwork": {
+    "description": "Submission error: connectivity failure or timeout"
+  },
+  "authErrorServer": "Something went wrong on the server. Please try again.",
+  "@authErrorServer": {
+    "description": "Submission error: unexpected server failure"
+  },
   "authPasswordVisibilityShow": "Show password",
-  "@authPasswordVisibilityShow": { "description": "Semantic label to show password" },
-
+  "@authPasswordVisibilityShow": {
+    "description": "Semantic label to show password"
+  },
   "authPasswordVisibilityHide": "Hide password",
-  "@authPasswordVisibilityHide": { "description": "Semantic label to hide password" },
-
+  "@authPasswordVisibilityHide": {
+    "description": "Semantic label to hide password"
+  },
   "authServerLabel": "Server",
-  "@authServerLabel": { "description": "Label showing which server the user is signing into" },
-
+  "@authServerLabel": {
+    "description": "Label showing which server the user is signing into"
+  },
   "authRegistrationDisabled": "Registration is currently disabled on this server.",
-  "@authRegistrationDisabled": { "description": "Error when server disables sign-up" }
+  "@authRegistrationDisabled": {
+    "description": "Error when server disables sign-up"
+  },
+  "authNoStrategiesMessage": "This server has no authentication methods configured. Please contact the server administrator.",
+  "@authNoStrategiesMessage": {
+    "description": "Shown when the server advertises no usable auth strategies"
+  },
+  "authSwitchedToSignInAnnouncement": "Switched to sign in form",
+  "@authSwitchedToSignInAnnouncement": {
+    "description": "Screen-reader announcement on switching to the sign-in form"
+  },
+  "authSwitchedToRegisterAnnouncement": "Switched to create account form",
+  "@authSwitchedToRegisterAnnouncement": {
+    "description": "Screen-reader announcement on switching to the registration form"
+  },
+  "authSessionUnreachableTitle": "Can't reach {serverName}",
+  "@authSessionUnreachableTitle": {
+    "description": "Title of the session-restore failure view (#37): the stored session could not be verified because the server is unreachable",
+    "placeholders": {
+      "serverName": {
+        "type": "String"
+      }
+    }
+  },
+  "authSessionUnreachableBody": "Your session could not be verified. Check your connection and try again.",
+  "@authSessionUnreachableBody": {
+    "description": "Body of the session-restore failure view (#37)"
+  },
+  "authRetryButton": "Try Again",
+  "@authRetryButton": {
+    "description": "Retry button on the session-restore failure view"
+  },
+  "authSignOutButton": "Sign Out",
+  "@authSignOutButton": {
+    "description": "Sign-out control label (#37)"
+  }
 }

--- a/packages/features/auth/lib/src/bloc/auth_bloc.dart
+++ b/packages/features/auth/lib/src/bloc/auth_bloc.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 
+import 'package:bloc_concurrency/bloc_concurrency.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:interfaces/repositories.dart';
 
@@ -10,15 +11,50 @@ import 'auth_bloc_state.dart';
 ///
 /// Receives an [AuthRepository] scoped to the active server. When the active
 /// server changes, the parent widget tree should rebuild with a fresh
-/// [AuthBloc] bound to the new server's repository.
+/// [AuthBloc] bound to the new server's repository (#37: keyed on the
+/// `ActiveServer.serverId` from the `ActiveServerScope` seam).
+///
+/// ## Phases (#37)
+///
+/// The startup session check ("restore") uses dedicated states —
+/// [AuthSessionCheckInProgress] / [AuthSessionCheckFailed] — so the auth
+/// gate can render splash / retry without widget-local memory. Interactive
+/// operations (sign-in, register, sign-out) use [AuthLoading] and the
+/// sealed [AuthOperationFailure] kinds, which the auth form renders inline.
+///
+/// ## Rejected vs. indeterminate (#37 review)
+///
+/// A session check distinguishes two failure modes:
+/// - **Rejected** — the server refused the stored session (401 clears the
+///   token and yields null; a 403 or other credential rejection maps to
+///   [AuthInvalidCredentialsException]). The session is genuinely gone →
+///   [AuthUnauthenticated] → sign-in form.
+/// - **Indeterminate** — the check could not complete (offline, timeout,
+///   5xx, or an unexpected fault such as a locked keychain thrown by token
+///   retrieval). We don't know → [AuthSessionCheckFailed] → retryable
+///   "can't reach server" view, never the form (#98 upgrades this to
+///   optimistic offline restore).
+///
+/// ## Concurrency
+///
+/// All operation handlers use `droppable()`: while one is in flight,
+/// further events of the same type are dropped (not queued), so a
+/// double-tapped "Try Again" or submit cannot run overlapping
+/// getSession/signIn calls whose out-of-order completion would clobber the
+/// correct terminal state.
+///
+/// ## i18n
+///
+/// This bloc emits no display strings — failures are semantic kinds and
+/// the widget layer owns localization (`AuthLocalizations`).
 class AuthBloc extends Bloc<AuthEvent, AuthBlocState> {
   AuthBloc({required AuthRepository authRepository})
     : _authRepository = authRepository,
       super(const AuthInitial()) {
-    on<AuthSessionCheckRequested>(_onSessionCheck);
-    on<AuthSignInRequested>(_onSignIn);
-    on<AuthRegisterRequested>(_onRegister);
-    on<AuthSignOutRequested>(_onSignOut);
+    on<AuthSessionCheckRequested>(_onSessionCheck, transformer: droppable());
+    on<AuthSignInRequested>(_onSignIn, transformer: droppable());
+    on<AuthRegisterRequested>(_onRegister, transformer: droppable());
+    on<AuthSignOutRequested>(_onSignOut, transformer: droppable());
     on<AuthRepositoryStateChanged>(_onRepositoryStateChanged);
 
     // Mirror repository-level state changes (e.g. token expiry detected by
@@ -35,7 +71,7 @@ class AuthBloc extends Bloc<AuthEvent, AuthBlocState> {
     AuthSessionCheckRequested event,
     Emitter<AuthBlocState> emit,
   ) async {
-    emit(const AuthLoading());
+    emit(const AuthSessionCheckInProgress());
     try {
       final session = await _authRepository.getSession();
       emit(
@@ -43,8 +79,21 @@ class AuthBloc extends Bloc<AuthEvent, AuthBlocState> {
             ? AuthAuthenticated(session: session)
             : const AuthUnauthenticated(),
       );
+    } on AuthInvalidCredentialsException {
+      // Rejected, not indeterminate: the server refused the stored session
+      // (e.g. 403 on a banned/stale session, which the repository maps to
+      // this type). The session is gone — go to the sign-in form, not the
+      // retry-forever unreachable view.
+      emit(const AuthUnauthenticated());
     } on AuthException catch (e) {
-      emit(AuthFailure(message: e.message));
+      // Indeterminate (network, timeout, 5xx). Offer retry.
+      emit(AuthSessionCheckFailed(e));
+    } on Object catch (e) {
+      // Unexpected non-auth fault — e.g. a PlatformException from a locked
+      // keychain during token retrieval. Still indeterminate (we couldn't
+      // verify), so surface the retryable view rather than stranding the
+      // gate on an endless splash.
+      emit(AuthSessionCheckFailed(e));
     }
   }
 
@@ -60,15 +109,11 @@ class AuthBloc extends Bloc<AuthEvent, AuthBlocState> {
       );
       emit(AuthAuthenticated(session: session));
     } on AuthInvalidCredentialsException {
-      emit(const AuthFailure(message: 'Incorrect email or password.'));
+      emit(const AuthFailureInvalidCredentials());
     } on AuthNetworkException {
-      emit(
-        const AuthFailure(
-          message: 'Could not reach the server. Check your connection.',
-        ),
-      );
+      emit(const AuthFailureNetwork());
     } on AuthException catch (e) {
-      emit(AuthFailure(message: e.message));
+      emit(AuthFailureServer(e));
     }
   }
 
@@ -87,26 +132,13 @@ class AuthBloc extends Bloc<AuthEvent, AuthBlocState> {
       );
       emit(AuthAuthenticated(session: session));
     } on AuthRegistrationDisabledException {
-      emit(
-        const AuthFailure(
-          message: 'Registration is currently disabled on this server.',
-        ),
-      );
+      emit(const AuthFailureRegistrationDisabled());
     } on AuthEmailAlreadyExistsException {
-      emit(
-        const AuthFailure(
-          message: 'An account with this email already exists.',
-          field: 'email',
-        ),
-      );
+      emit(const AuthFailureEmailAlreadyExists());
     } on AuthNetworkException {
-      emit(
-        const AuthFailure(
-          message: 'Could not reach the server. Check your connection.',
-        ),
-      );
+      emit(const AuthFailureNetwork());
     } on AuthException catch (e) {
-      emit(AuthFailure(message: e.message));
+      emit(AuthFailureServer(e));
     }
   }
 
@@ -115,7 +147,20 @@ class AuthBloc extends Bloc<AuthEvent, AuthBlocState> {
     Emitter<AuthBlocState> emit,
   ) async {
     emit(const AuthLoading());
-    await _authRepository.signOut();
+    try {
+      await _authRepository.signOut();
+    } on Object catch (error, stackTrace) {
+      // Sign-out is intent-to-leave: it must ALWAYS reach
+      // AuthUnauthenticated so the gate flips, regardless of what failed.
+      // (This deliberately differs from the sign-in/register handlers,
+      // where a failure keeps the user on the form to retry — sign-out has
+      // nowhere better to land.) The repository already guarantees its
+      // in-memory state is unauthenticated before any throw
+      // (AuthSignOutPersistenceException), so the mirror cannot resurrect
+      // the session. Any error — typed or not — is surfaced via addError
+      // for the crash channel, then we flip.
+      addError(error, stackTrace);
+    }
     emit(const AuthUnauthenticated());
   }
 
@@ -123,6 +168,13 @@ class AuthBloc extends Bloc<AuthEvent, AuthBlocState> {
     AuthRepositoryStateChanged event,
     Emitter<AuthBlocState> emit,
   ) {
+    // Never override an in-flight startup check: its own handler owns the
+    // terminal emit, and a stray repo Unauthenticated (e.g. the 401-clear
+    // from that very getSession, or an interceptor 401 on another request)
+    // must not flip the gate into the sign-in form mid-check — defeating
+    // the indeterminate-never-shows-the-form invariant (#37 review).
+    if (state is AuthSessionCheckInProgress) return;
+
     switch (event.repoState) {
       case AuthStateAuthenticated(:final session):
         if (state is! AuthAuthenticated) {

--- a/packages/features/auth/lib/src/bloc/auth_bloc_state.dart
+++ b/packages/features/auth/lib/src/bloc/auth_bloc_state.dart
@@ -1,19 +1,38 @@
 import 'package:equatable/equatable.dart';
 import 'package:models/dto.dart';
 
+/// States for `AuthBloc` (#37).
+///
+/// Failures carry *kinds* (and diagnostic payloads excluded from
+/// equality), never display strings — localization is the widget layer's
+/// job, keeping the bloc free of any locale concern (#33; same convention
+/// as `ServerOnboardingState`).
 sealed class AuthBlocState extends Equatable {
   const AuthBlocState();
 
   @override
-  List<Object?> get props => [];
+  List<Object?> get props => const [];
 }
 
 final class AuthInitial extends AuthBlocState {
   const AuthInitial();
 }
 
+/// An interactive auth operation (sign-in, register, sign-out) is in
+/// flight. Rendered as inline progress by the auth form — distinct from
+/// [AuthSessionCheckInProgress], which happens before any form is shown.
 final class AuthLoading extends AuthBlocState {
   const AuthLoading();
+}
+
+/// The startup session check (restore) is in flight (#37).
+///
+/// Distinct from [AuthLoading]: during the session check no form is on
+/// screen — the auth gate renders the splash, continuous with the
+/// bootstrap splash. Encoding the phase in the state keeps the gate a
+/// pure function of bloc state (no widget-local restore latch).
+final class AuthSessionCheckInProgress extends AuthBlocState {
+  const AuthSessionCheckInProgress();
 }
 
 final class AuthAuthenticated extends AuthBlocState {
@@ -28,12 +47,58 @@ final class AuthUnauthenticated extends AuthBlocState {
   const AuthUnauthenticated();
 }
 
-/// An auth operation failed. [field] hints which form field caused it, if any.
-final class AuthFailure extends AuthBlocState {
-  const AuthFailure({required this.message, this.field});
-  final String message;
-  final String? field;
+/// The startup session check could not be completed (#37).
+///
+/// The repository's `getSession` never throws for an auth rejection — a
+/// 401 clears the stored token and returns null (→
+/// [AuthUnauthenticated]) — so reaching this state means the stored
+/// session is INDETERMINATE (offline, timeout, server error), not
+/// rejected. The auth gate renders a retryable "can't reach the server"
+/// view, never the sign-in form (which would wrongly suggest the stored
+/// session is gone); retry re-dispatches the session check. True
+/// offline-first restore (enter on a cached session, revalidate on
+/// reconnect) is #98.
+final class AuthSessionCheckFailed extends AuthBlocState {
+  const AuthSessionCheckFailed([this.cause]);
 
-  @override
-  List<Object?> get props => [message, field];
+  /// The underlying `AuthException` — retained for the feedback pipeline
+  /// (logging/reporting), excluded from equality so tests can match on
+  /// the state alone. Never for display.
+  final Object? cause;
+}
+
+/// Why an interactive auth operation (sign-in / register) failed. Each
+/// kind maps to one localized message in the widget layer.
+sealed class AuthOperationFailure extends AuthBlocState {
+  const AuthOperationFailure();
+}
+
+/// Sign-in rejected: wrong email or password (401/403).
+final class AuthFailureInvalidCredentials extends AuthOperationFailure {
+  const AuthFailureInvalidCredentials();
+}
+
+/// Registration rejected: the email is already taken (409). Implies the
+/// email field — the widget layer attaches the localized error there.
+final class AuthFailureEmailAlreadyExists extends AuthOperationFailure {
+  const AuthFailureEmailAlreadyExists();
+}
+
+/// Registration rejected: the server disables sign-up.
+final class AuthFailureRegistrationDisabled extends AuthOperationFailure {
+  const AuthFailureRegistrationDisabled();
+}
+
+/// Connectivity failure or timeout reaching the server.
+final class AuthFailureNetwork extends AuthOperationFailure {
+  const AuthFailureNetwork();
+}
+
+/// Anything unanticipated (unexpected status, malformed body, …). The
+/// original error is retained for the feedback pipeline, but excluded
+/// from equality so tests can match on the state alone.
+final class AuthFailureServer extends AuthOperationFailure {
+  const AuthFailureServer([this.cause]);
+
+  final Object? cause;
 }

--- a/packages/features/auth/lib/src/screens/auth_gate.dart
+++ b/packages/features/auth/lib/src/screens/auth_gate.dart
@@ -1,0 +1,146 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:models/domain.dart';
+
+import '../../l10n/auth_localizations.dart';
+import '../bloc/auth_bloc.dart';
+import '../bloc/auth_event.dart';
+import '../bloc/auth_bloc_state.dart';
+import 'auth_screen.dart';
+
+/// The `/auth` route's state machine (#37): a pure function of
+/// [AuthBloc] state with no widget-local memory.
+///
+/// - [AuthInitial] / [AuthSessionCheckInProgress] → [splash] (continuous
+///   with the bootstrap splash; the session restore is in flight).
+/// - [AuthAuthenticated] → [splash] — the shell's top-level listener has
+///   already advanced the bootstrap cubit, so the router is about to
+///   redirect to home; the gate holds splash for the intervening
+///   microtask instead of flashing the form.
+/// - [AuthSessionCheckFailed] → [SessionUnreachableView] — the stored
+///   session is indeterminate (offline / timeout / server error), never
+///   rejected, so showing the sign-in form would wrongly suggest it is
+///   gone. Retry re-dispatches the session check; true offline-first
+///   restore is #98.
+/// - [AuthUnauthenticated] / [AuthLoading] / [AuthOperationFailure] →
+///   [AuthScreen] — no session (or an interactive attempt in flight /
+///   failed); the screen owns its own inline progress and live-region
+///   error snack bar.
+///
+/// The splash is injected rather than imported: it lives in `app_shell`,
+/// which depends on this feature — never the reverse.
+class AuthGate extends StatelessWidget {
+  const AuthGate({
+    super.key,
+    required this.identity,
+    required this.serverDisplayName,
+    required this.splash,
+  });
+
+  /// The active server's identity — drives which strategies [AuthScreen]
+  /// renders.
+  final ServerIdentity identity;
+
+  /// Human-readable server name, for attribution on the form and the
+  /// unreachable view.
+  final String serverDisplayName;
+
+  /// Rendered while the session check is unresolved (and for the redirect
+  /// microtask after authentication). The shell passes its
+  /// `SplashScreen` so cold start reads as one continuous splash.
+  final Widget splash;
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<AuthBloc, AuthBlocState>(
+      builder: (context, state) => switch (state) {
+        AuthInitial() ||
+        AuthSessionCheckInProgress() ||
+        AuthAuthenticated() => splash,
+        AuthSessionCheckFailed() => SessionUnreachableView(
+          serverDisplayName: serverDisplayName,
+          onRetry: () =>
+              context.read<AuthBloc>().add(const AuthSessionCheckRequested()),
+        ),
+        AuthLoading() || AuthUnauthenticated() || AuthOperationFailure() =>
+          AuthScreen(identity: identity, serverDisplayName: serverDisplayName),
+      },
+    );
+  }
+}
+
+/// Rendered when the startup session check cannot reach the server (#37).
+///
+/// Accessibility (mirroring the bootstrap error screen's pattern):
+/// - the title + body are a single live region so screen readers announce
+///   the failure when it appears;
+/// - the retry button is autofocused for keyboard users and carries an
+///   explicit button semantic.
+class SessionUnreachableView extends StatelessWidget {
+  const SessionUnreachableView({
+    super.key,
+    required this.serverDisplayName,
+    required this.onRetry,
+  });
+
+  final String serverDisplayName;
+  final VoidCallback onRetry;
+
+  @override
+  Widget build(BuildContext context) {
+    final l10n = AuthLocalizations.of(context);
+    final theme = Theme.of(context);
+
+    return Scaffold(
+      body: SafeArea(
+        child: Center(
+          child: SingleChildScrollView(
+            padding: const EdgeInsets.all(24),
+            child: ConstrainedBox(
+              constraints: const BoxConstraints(maxWidth: 480),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Icon(
+                    Icons.cloud_off_outlined,
+                    size: 48,
+                    color: theme.colorScheme.onSurfaceVariant,
+                  ),
+                  const SizedBox(height: 16),
+                  Semantics(
+                    liveRegion: true,
+                    child: Column(
+                      children: [
+                        Text(
+                          l10n.authSessionUnreachableTitle(serverDisplayName),
+                          style: theme.textTheme.headlineSmall,
+                          textAlign: TextAlign.center,
+                        ),
+                        const SizedBox(height: 8),
+                        Text(
+                          l10n.authSessionUnreachableBody,
+                          style: theme.textTheme.bodyMedium,
+                          textAlign: TextAlign.center,
+                        ),
+                      ],
+                    ),
+                  ),
+                  const SizedBox(height: 24),
+                  Semantics(
+                    button: true,
+                    child: FilledButton(
+                      autofocus: true,
+                      onPressed: onRetry,
+                      child: Text(l10n.authRetryButton),
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/packages/features/auth/lib/src/screens/auth_screen.dart
+++ b/packages/features/auth/lib/src/screens/auth_screen.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:models/domain.dart';
 import 'package:flutter/semantics.dart';
 
+import '../../l10n/auth_localizations.dart';
 import '../bloc/auth_bloc.dart';
 import '../bloc/auth_bloc_state.dart';
 import '../widgets/login_form.dart';
@@ -20,6 +21,11 @@ import '../widgets/oidc_strategy_button.dart';
 /// - Focus is managed between sign-in/register mode switches
 /// - Server name displayed so screen readers can identify which server
 ///   the user is authenticating against
+///
+/// i18n (#37): all copy comes from [AuthLocalizations]; the bloc emits
+/// semantic failure kinds ([AuthOperationFailure]) which
+/// [_localizedFailure] maps to localized messages here — never in the
+/// bloc.
 ///
 /// Callers are responsible for navigating away when the bloc emits
 /// [AuthAuthenticated] — typically via a [BlocListener] in the router.
@@ -90,12 +96,13 @@ class _AuthScreenState extends State<AuthScreen> {
   }
 
   Widget _buildHeader(BuildContext context, ColorScheme colorScheme) {
+    final l10n = AuthLocalizations.of(context);
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
         // Server attribution — important when user manages multiple servers
         Semantics(
-          label: 'Server: ${widget.serverDisplayName}',
+          label: '${l10n.authServerLabel}: ${widget.serverDisplayName}',
           child: Row(
             children: [
               Icon(
@@ -118,7 +125,7 @@ class _AuthScreenState extends State<AuthScreen> {
         ),
         const SizedBox(height: 12),
         Text(
-          _isSignIn ? 'Sign In' : 'Create Account',
+          _isSignIn ? l10n.authSignInTitle : l10n.authRegisterTitle,
           style: Theme.of(
             context,
           ).textTheme.headlineMedium?.copyWith(fontWeight: FontWeight.bold),
@@ -170,7 +177,7 @@ class _AuthScreenState extends State<AuthScreen> {
         Padding(
           padding: const EdgeInsets.symmetric(horizontal: 16),
           child: Text(
-            'or',
+            AuthLocalizations.of(context).authOrDivider,
             style: Theme.of(context).textTheme.bodySmall?.copyWith(
               color: Theme.of(context).colorScheme.onSurfaceVariant,
             ),
@@ -187,8 +194,7 @@ class _AuthScreenState extends State<AuthScreen> {
       child: Padding(
         padding: const EdgeInsets.all(16),
         child: Text(
-          'This server has no authentication methods configured. '
-          'Please contact the server administrator.',
+          AuthLocalizations.of(context).authNoStrategiesMessage,
           style: Theme.of(context).textTheme.bodyMedium,
           textAlign: TextAlign.center,
         ),
@@ -197,12 +203,13 @@ class _AuthScreenState extends State<AuthScreen> {
   }
 
   void _handleStateChange(BuildContext context, AuthBlocState state) {
-    if (state is AuthFailure) {
+    if (state is AuthOperationFailure) {
+      final message = _localizedFailure(AuthLocalizations.of(context), state);
       ScaffoldMessenger.of(context)
         ..hideCurrentSnackBar()
         ..showSnackBar(
           SnackBar(
-            content: Semantics(liveRegion: true, child: Text(state.message)),
+            content: Semantics(liveRegion: true, child: Text(message)),
             backgroundColor: Theme.of(context).colorScheme.error,
             behavior: SnackBarBehavior.floating,
           ),
@@ -210,13 +217,28 @@ class _AuthScreenState extends State<AuthScreen> {
     }
   }
 
+  /// The single place the sealed failure kinds become user-facing copy.
+  /// Exhaustive: a new kind fails compilation here until it gets a
+  /// localized message.
+  String _localizedFailure(AuthLocalizations l10n, AuthOperationFailure f) =>
+      switch (f) {
+        AuthFailureInvalidCredentials() => l10n.authErrorInvalidCredentials,
+        AuthFailureEmailAlreadyExists() => l10n.authErrorEmailExists,
+        AuthFailureRegistrationDisabled() => l10n.authRegistrationDisabled,
+        AuthFailureNetwork() => l10n.authErrorNetwork,
+        AuthFailureServer() => l10n.authErrorServer,
+      };
+
   void _switchMode({required bool signIn}) {
+    final l10n = AuthLocalizations.of(context);
     setState(() => _isSignIn = signIn);
     // Announce mode change to screen readers
     SemanticsService.sendAnnouncement(
       View.of(context),
-      signIn ? 'Switched to sign in form' : 'Switched to create account form',
-      TextDirection.ltr,
+      signIn
+          ? l10n.authSwitchedToSignInAnnouncement
+          : l10n.authSwitchedToRegisterAnnouncement,
+      Directionality.of(context),
     );
   }
 
@@ -225,7 +247,9 @@ class _AuthScreenState extends State<AuthScreen> {
     // browser integration. For now this is a placeholder.
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text('OIDC sign-in with ${strategy.providerId} — coming soon'),
+        content: Text(
+          AuthLocalizations.of(context).authOidcComingSoon(strategy.providerId),
+        ),
       ),
     );
   }

--- a/packages/features/auth/lib/src/widgets/login_form.dart
+++ b/packages/features/auth/lib/src/widgets/login_form.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
+import '../../l10n/auth_localizations.dart';
 import '../bloc/auth_bloc.dart';
 import '../bloc/auth_event.dart';
 import '../bloc/auth_bloc_state.dart';
@@ -12,6 +13,9 @@ import 'auth_text_field.dart';
 /// Submits [AuthSignInRequested] to the ancestor [AuthBloc].
 /// Disables all inputs and shows a loading indicator while [AuthLoading]
 /// is active. Keyboard users can submit with Enter on the password field.
+///
+/// i18n (#37): all copy — labels, hints, validation messages, button and
+/// loading semantics — comes from [AuthLocalizations].
 class LoginForm extends StatefulWidget {
   const LoginForm({super.key, this.onSwitchToRegister});
 
@@ -67,6 +71,7 @@ class _LoginFormState extends State<LoginForm> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AuthLocalizations.of(context);
 
     return BlocBuilder<AuthBloc, AuthBlocState>(
       builder: (context, state) {
@@ -81,42 +86,43 @@ class _LoginFormState extends State<LoginForm> {
               children: [
                 AuthTextField(
                   formControlName: 'email',
-                  label: 'Email', // TODO: wire AuthLocalizations
-                  hint: 'Enter your email address',
+                  label: l10n.authEmailLabel,
+                  hint: l10n.authEmailHint,
                   keyboardType: TextInputType.emailAddress,
                   autofillHints: const [AutofillHints.email],
                   textInputAction: TextInputAction.next,
                   enabled: !isLoading,
                   autofocus: true,
                   validationMessages: {
-                    ValidationMessage.required: (_) => 'Email is required',
-                    ValidationMessage.email: (_) =>
-                        'Enter a valid email address',
+                    ValidationMessage.required: (_) => l10n.authErrorRequired,
+                    ValidationMessage.email: (_) => l10n.authErrorInvalidEmail,
                   },
                 ),
                 const SizedBox(height: 16),
                 AuthTextField(
                   formControlName: 'password',
-                  label: 'Password',
-                  hint: 'Enter your password',
+                  label: l10n.authPasswordLabel,
+                  hint: l10n.authPasswordHint,
                   isPassword: true,
                   autofillHints: const [AutofillHints.password],
                   textInputAction: TextInputAction.done,
                   enabled: !isLoading,
                   onSubmitted: () => _submit(context),
                   validationMessages: {
-                    ValidationMessage.required: (_) => 'Password is required',
-                    ValidationMessage.minLength: (e) {
-                      final min = (e as Map)['requiredLength'] as int;
-                      return 'Password must be at least $min characters';
-                    },
+                    ValidationMessage.required: (_) => l10n.authErrorRequired,
+                    ValidationMessage.minLength: (e) =>
+                        l10n.authErrorPasswordTooShort(
+                          (e as Map)['requiredLength'] as int,
+                        ),
                   },
                 ),
                 const SizedBox(height: 24),
                 Semantics(
                   button: true,
                   enabled: !isLoading,
-                  label: isLoading ? 'Signing in, please wait' : 'Sign In',
+                  label: isLoading
+                      ? l10n.authLoadingLabel
+                      : l10n.authSignInButton,
                   child: FilledButton(
                     onPressed: isLoading ? null : () => _submit(context),
                     child: isLoading
@@ -127,14 +133,14 @@ class _LoginFormState extends State<LoginForm> {
                               color: theme.colorScheme.onPrimary,
                             ),
                           )
-                        : const Text('Sign In'),
+                        : Text(l10n.authSignInButton),
                   ),
                 ),
                 if (widget.onSwitchToRegister != null) ...[
                   const SizedBox(height: 16),
                   TextButton(
                     onPressed: isLoading ? null : widget.onSwitchToRegister,
-                    child: const Text("Don't have an account? Register"),
+                    child: Text(l10n.authSwitchToRegister),
                   ),
                 ],
               ],

--- a/packages/features/auth/lib/src/widgets/register_form.dart
+++ b/packages/features/auth/lib/src/widgets/register_form.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:reactive_forms/reactive_forms.dart';
 
+import '../../l10n/auth_localizations.dart';
 import '../bloc/auth_bloc.dart';
 import '../bloc/auth_event.dart';
 import '../bloc/auth_bloc_state.dart';
@@ -11,6 +12,9 @@ import 'auth_text_field.dart';
 ///
 /// Only rendered when the server's [EmailAndPasswordStrategy.signUpDisabled]
 /// is false. Submits [AuthRegisterRequested] to the ancestor [AuthBloc].
+///
+/// i18n (#37): all copy — labels, hints, validation messages, button and
+/// loading semantics — comes from [AuthLocalizations].
 class RegisterForm extends StatefulWidget {
   const RegisterForm({super.key, this.onSwitchToSignIn});
 
@@ -82,6 +86,7 @@ class _RegisterFormState extends State<RegisterForm> {
   @override
   Widget build(BuildContext context) {
     final theme = Theme.of(context);
+    final l10n = AuthLocalizations.of(context);
 
     return BlocBuilder<AuthBloc, AuthBlocState>(
       builder: (context, state) {
@@ -96,33 +101,32 @@ class _RegisterFormState extends State<RegisterForm> {
               children: [
                 AuthTextField(
                   formControlName: 'email',
-                  label: 'Email',
-                  hint: 'Enter your email address',
+                  label: l10n.authEmailLabel,
+                  hint: l10n.authEmailHint,
                   keyboardType: TextInputType.emailAddress,
                   autofillHints: const [AutofillHints.email],
                   textInputAction: TextInputAction.next,
                   enabled: !isLoading,
                   autofocus: true,
                   validationMessages: {
-                    ValidationMessage.required: (_) => 'Email is required',
-                    ValidationMessage.email: (_) =>
-                        'Enter a valid email address',
+                    ValidationMessage.required: (_) => l10n.authErrorRequired,
+                    ValidationMessage.email: (_) => l10n.authErrorInvalidEmail,
                   },
                 ),
                 const SizedBox(height: 16),
                 AuthTextField(
                   formControlName: 'username',
-                  label: 'Username',
-                  hint: 'Choose a username',
+                  label: l10n.authUsernameLabel,
+                  hint: l10n.authUsernameHint,
                   autofillHints: const [AutofillHints.username],
                   textInputAction: TextInputAction.next,
                   enabled: !isLoading,
                   validationMessages: {
-                    ValidationMessage.required: (_) => 'Username is required',
-                    ValidationMessage.minLength: (e) {
-                      final min = (e as Map)['requiredLength'] as int;
-                      return 'Username must be at least $min characters';
-                    },
+                    ValidationMessage.required: (_) => l10n.authErrorRequired,
+                    ValidationMessage.minLength: (e) =>
+                        l10n.authErrorUsernameTooShort(
+                          (e as Map)['requiredLength'] as int,
+                        ),
                   },
                 ),
                 const SizedBox(height: 16),
@@ -132,7 +136,7 @@ class _RegisterFormState extends State<RegisterForm> {
                     Expanded(
                       child: AuthTextField(
                         formControlName: 'firstName',
-                        label: 'First Name',
+                        label: l10n.authFirstNameLabel,
                         autofillHints: const [AutofillHints.givenName],
                         textInputAction: TextInputAction.next,
                         enabled: !isLoading,
@@ -143,7 +147,7 @@ class _RegisterFormState extends State<RegisterForm> {
                     Expanded(
                       child: AuthTextField(
                         formControlName: 'lastName',
-                        label: 'Last Name',
+                        label: l10n.authLastNameLabel,
                         autofillHints: const [AutofillHints.familyName],
                         textInputAction: TextInputAction.next,
                         enabled: !isLoading,
@@ -155,19 +159,19 @@ class _RegisterFormState extends State<RegisterForm> {
                 const SizedBox(height: 16),
                 AuthTextField(
                   formControlName: 'password',
-                  label: 'Password',
-                  hint: 'Create a password',
+                  label: l10n.authPasswordLabel,
+                  hint: l10n.authPasswordCreateHint,
                   isPassword: true,
                   autofillHints: const [AutofillHints.newPassword],
                   textInputAction: TextInputAction.done,
                   enabled: !isLoading,
                   onSubmitted: () => _submit(context),
                   validationMessages: {
-                    ValidationMessage.required: (_) => 'Password is required',
-                    ValidationMessage.minLength: (e) {
-                      final min = (e as Map)['requiredLength'] as int;
-                      return 'Password must be at least $min characters';
-                    },
+                    ValidationMessage.required: (_) => l10n.authErrorRequired,
+                    ValidationMessage.minLength: (e) =>
+                        l10n.authErrorPasswordTooShort(
+                          (e as Map)['requiredLength'] as int,
+                        ),
                   },
                 ),
                 const SizedBox(height: 24),
@@ -175,8 +179,8 @@ class _RegisterFormState extends State<RegisterForm> {
                   button: true,
                   enabled: !isLoading,
                   label: isLoading
-                      ? 'Creating account, please wait'
-                      : 'Create Account',
+                      ? l10n.authRegisterLoadingLabel
+                      : l10n.authRegisterButton,
                   child: FilledButton(
                     onPressed: isLoading ? null : () => _submit(context),
                     child: isLoading
@@ -187,14 +191,14 @@ class _RegisterFormState extends State<RegisterForm> {
                               color: theme.colorScheme.onPrimary,
                             ),
                           )
-                        : const Text('Create Account'),
+                        : Text(l10n.authRegisterButton),
                   ),
                 ),
                 if (widget.onSwitchToSignIn != null) ...[
                   const SizedBox(height: 16),
                   TextButton(
                     onPressed: isLoading ? null : widget.onSwitchToSignIn,
-                    child: const Text('Already have an account? Sign in'),
+                    child: Text(l10n.authSwitchToSignIn),
                   ),
                 ],
               ],

--- a/packages/features/auth/pubspec.yaml
+++ b/packages/features/auth/pubspec.yaml
@@ -1,3 +1,4 @@
+# packages/features/auth/pubspec.yaml
 name: auth
 description: "Authentication feature — Bloc, states, and events"
 publish_to: none
@@ -23,6 +24,7 @@ dependencies:
     path: ../../ui/widgets
 
   flutter_bloc: ^9.1.1
+  bloc_concurrency: ^0.3.0
   equatable: ^2.0.6
   reactive_forms: ^18.1.1
   intl: ^0.20.2

--- a/packages/features/auth/test/auth/auth_screen_test.dart
+++ b/packages/features/auth/test/auth/auth_screen_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:models/domain.dart';
 
+import 'package:auth/l10n/auth_localizations.dart';
 import 'package:auth/src/bloc/auth_event.dart';
 import 'package:auth/src/bloc/auth_bloc_state.dart';
 import 'package:auth/src/bloc/auth_bloc.dart';
@@ -50,7 +51,12 @@ ServerIdentity _identity({
   ],
 );
 
+// #37 i18n: AuthScreen resolves all copy from AuthLocalizations, so the
+// harness must provide the delegates; assertions keep matching the
+// English template values.
 Widget _wrap(Widget child, MockAuthBloc bloc) => MaterialApp(
+  localizationsDelegates: AuthLocalizations.localizationsDelegates,
+  supportedLocales: AuthLocalizations.supportedLocales,
   home: BlocProvider<AuthBloc>.value(value: bloc, child: child),
 );
 
@@ -185,12 +191,14 @@ void main() {
     });
 
     group('error handling', () {
-      testWidgets('shows SnackBar on AuthFailure', (tester) async {
+      testWidgets('shows SnackBar on an operation failure kind', (
+        tester,
+      ) async {
         whenListen(
           mockBloc,
           Stream.fromIterable([
             const AuthInitial(),
-            const AuthFailure(message: 'Incorrect email or password.'),
+            const AuthFailureInvalidCredentials(),
           ]),
           initialState: const AuthInitial(),
         );
@@ -200,6 +208,7 @@ void main() {
         );
         await tester.pumpAndSettle();
 
+        // The screen maps the kind to the localized message.
         expect(find.text('Incorrect email or password.'), findsOneWidget);
       });
     });

--- a/packages/features/auth/test/bloc/auth_bloc_test.dart
+++ b/packages/features/auth/test/bloc/auth_bloc_test.dart
@@ -30,27 +30,35 @@ void main() {
   group('AuthBloc', () {
     group('AuthSessionCheckRequested', () {
       blocTest<AuthBloc, AuthBlocState>(
-        'emits [loading, authenticated] when session exists',
+        'emits [session check in progress, authenticated] when session '
+        'exists',
         build: () {
           when(() => mockRepo.getSession()).thenAnswer((_) async => _session());
           return AuthBloc(authRepository: mockRepo);
         },
         act: (b) => b.add(const AuthSessionCheckRequested()),
-        expect: () => [const AuthLoading(), isA<AuthAuthenticated>()],
+        expect: () => [
+          const AuthSessionCheckInProgress(),
+          isA<AuthAuthenticated>(),
+        ],
       );
 
       blocTest<AuthBloc, AuthBlocState>(
-        'emits [loading, unauthenticated] when no session',
+        'emits [session check in progress, unauthenticated] when no session',
         build: () {
           when(() => mockRepo.getSession()).thenAnswer((_) async => null);
           return AuthBloc(authRepository: mockRepo);
         },
         act: (b) => b.add(const AuthSessionCheckRequested()),
-        expect: () => [const AuthLoading(), const AuthUnauthenticated()],
+        expect: () => [
+          const AuthSessionCheckInProgress(),
+          const AuthUnauthenticated(),
+        ],
       );
 
       blocTest<AuthBloc, AuthBlocState>(
-        'emits [loading, failure] on network error',
+        'emits [session check in progress, session check failed] on a '
+        'network error — indeterminate, never the sign-in form (#37)',
         build: () {
           when(
             () => mockRepo.getSession(),
@@ -58,7 +66,95 @@ void main() {
           return AuthBloc(authRepository: mockRepo);
         },
         act: (b) => b.add(const AuthSessionCheckRequested()),
-        expect: () => [const AuthLoading(), isA<AuthFailure>()],
+        expect: () => [
+          const AuthSessionCheckInProgress(),
+          const AuthSessionCheckFailed(),
+        ],
+        verify: (b) => expect(
+          (b.state as AuthSessionCheckFailed).cause,
+          isA<AuthNetworkException>(),
+        ),
+      );
+
+      blocTest<AuthBloc, AuthBlocState>(
+        'emits [session check in progress, session check failed] on a '
+        'server error — a 5xx cannot verify the session either',
+        build: () {
+          when(() => mockRepo.getSession()).thenThrow(
+            const AuthServerException(
+              message: 'Server error 503.',
+              statusCode: 503,
+            ),
+          );
+          return AuthBloc(authRepository: mockRepo);
+        },
+        act: (b) => b.add(const AuthSessionCheckRequested()),
+        expect: () => [
+          const AuthSessionCheckInProgress(),
+          const AuthSessionCheckFailed(),
+        ],
+      );
+
+      blocTest<AuthBloc, AuthBlocState>(
+        'emits [session check in progress, unauthenticated] on a rejected '
+        'session (403 → invalid-credentials) — gone, not indeterminate; '
+        'goes to the form, never the retry view (#37 review)',
+        build: () {
+          when(
+            () => mockRepo.getSession(),
+          ).thenThrow(const AuthInvalidCredentialsException());
+          return AuthBloc(authRepository: mockRepo);
+        },
+        act: (b) => b.add(const AuthSessionCheckRequested()),
+        expect: () => [
+          const AuthSessionCheckInProgress(),
+          const AuthUnauthenticated(),
+        ],
+      );
+
+      blocTest<AuthBloc, AuthBlocState>(
+        'emits [session check in progress, session check failed] on an '
+        'unexpected non-auth fault (e.g. locked keychain) — indeterminate, '
+        'never an endless splash (#37 review)',
+        build: () {
+          when(
+            () => mockRepo.getSession(),
+          ).thenThrow(StateError('keychain locked'));
+          return AuthBloc(authRepository: mockRepo);
+        },
+        act: (b) => b.add(const AuthSessionCheckRequested()),
+        expect: () => [
+          const AuthSessionCheckInProgress(),
+          const AuthSessionCheckFailed(),
+        ],
+        verify: (b) => expect(
+          (b.state as AuthSessionCheckFailed).cause,
+          isA<StateError>(),
+        ),
+      );
+
+      blocTest<AuthBloc, AuthBlocState>(
+        'drops a second concurrent session check while the first is in '
+        'flight (droppable) — no overlapping getSession (#37 review)',
+        build: () {
+          var calls = 0;
+          when(() => mockRepo.getSession()).thenAnswer((_) async {
+            calls++;
+            await Future<void>.delayed(const Duration(milliseconds: 20));
+            return calls == 1 ? _session() : null;
+          });
+          return AuthBloc(authRepository: mockRepo);
+        },
+        act: (b) {
+          b.add(const AuthSessionCheckRequested());
+          b.add(const AuthSessionCheckRequested());
+        },
+        wait: const Duration(milliseconds: 60),
+        expect: () => [
+          const AuthSessionCheckInProgress(),
+          isA<AuthAuthenticated>(),
+        ],
+        verify: (_) => verify(() => mockRepo.getSession()).called(1),
       );
     });
 
@@ -81,7 +177,8 @@ void main() {
       );
 
       blocTest<AuthBloc, AuthBlocState>(
-        'emits failure on invalid credentials',
+        'emits the invalid-credentials kind on rejection — no display '
+        'strings in the bloc (#37 i18n)',
         build: () {
           when(
             () => mockRepo.signIn(
@@ -94,13 +191,14 @@ void main() {
         act: (b) => b.add(
           const AuthSignInRequested(email: 'a@b.com', password: 'wrong'),
         ),
-        expect: () => [const AuthLoading(), isA<AuthFailure>()],
-        verify: (b) =>
-            expect((b.state as AuthFailure).message, contains('Incorrect')),
+        expect: () => [
+          const AuthLoading(),
+          const AuthFailureInvalidCredentials(),
+        ],
       );
 
       blocTest<AuthBloc, AuthBlocState>(
-        'emits failure on network error',
+        'emits the network kind on a connectivity failure',
         build: () {
           when(
             () => mockRepo.signIn(
@@ -112,9 +210,29 @@ void main() {
         },
         act: (b) =>
             b.add(const AuthSignInRequested(email: 'a@b.com', password: 'p')),
-        expect: () => [const AuthLoading(), isA<AuthFailure>()],
-        verify: (b) =>
-            expect((b.state as AuthFailure).message, contains('server')),
+        expect: () => [const AuthLoading(), const AuthFailureNetwork()],
+      );
+
+      blocTest<AuthBloc, AuthBlocState>(
+        'emits the server kind (cause retained) on an unexpected failure',
+        build: () {
+          when(
+            () => mockRepo.signIn(
+              email: any(named: 'email'),
+              password: any(named: 'password'),
+            ),
+          ).thenThrow(
+            const AuthServerException(message: 'boom', statusCode: 500),
+          );
+          return AuthBloc(authRepository: mockRepo);
+        },
+        act: (b) =>
+            b.add(const AuthSignInRequested(email: 'a@b.com', password: 'p')),
+        expect: () => [const AuthLoading(), const AuthFailureServer()],
+        verify: (b) => expect(
+          (b.state as AuthFailureServer).cause,
+          isA<AuthServerException>(),
+        ),
       );
     });
 
@@ -144,7 +262,8 @@ void main() {
       );
 
       blocTest<AuthBloc, AuthBlocState>(
-        'emits failure with email field on duplicate email',
+        'emits the email-exists kind on duplicate email — the kind implies '
+        'the email field, no stringly-typed field name (#37 i18n)',
         build: () {
           when(
             () => mockRepo.signUp(
@@ -164,11 +283,15 @@ void main() {
             username: 'u',
           ),
         ),
-        verify: (b) => expect((b.state as AuthFailure).field, 'email'),
+        expect: () => [
+          const AuthLoading(),
+          const AuthFailureEmailAlreadyExists(),
+        ],
       );
 
       blocTest<AuthBloc, AuthBlocState>(
-        'emits failure when registration disabled',
+        'emits the registration-disabled kind when the server disables '
+        'sign-up',
         build: () {
           when(
             () => mockRepo.signUp(
@@ -188,7 +311,10 @@ void main() {
             username: 'u',
           ),
         ),
-        expect: () => [const AuthLoading(), isA<AuthFailure>()],
+        expect: () => [
+          const AuthLoading(),
+          const AuthFailureRegistrationDisabled(),
+        ],
       );
     });
 
@@ -203,6 +329,67 @@ void main() {
         expect: () => [const AuthLoading(), const AuthUnauthenticated()],
         verify: (_) => verify(() => mockRepo.signOut()).called(1),
       );
+
+      blocTest<AuthBloc, AuthBlocState>(
+        'still emits [loading, unauthenticated] on '
+        'AuthSignOutPersistenceException — the repo has already '
+        'transitioned to unauthenticated per contract; the error is '
+        'surfaced via addError, not swallowed (#37)',
+        build: () {
+          when(() => mockRepo.signOut()).thenThrow(
+            const AuthSignOutPersistenceException(
+              cause: 'secure storage clear failed',
+            ),
+          );
+          return AuthBloc(authRepository: mockRepo);
+        },
+        act: (b) => b.add(const AuthSignOutRequested()),
+        expect: () => [const AuthLoading(), const AuthUnauthenticated()],
+        errors: () => [isA<AuthSignOutPersistenceException>()],
+      );
+
+      blocTest<AuthBloc, AuthBlocState>(
+        'a non-AuthException from signOut still flips to unauthenticated — '
+        'sign-out is intent-to-leave, so the gate must flip regardless; '
+        'the error is surfaced via addError (#37 review)',
+        build: () {
+          when(
+            () => mockRepo.signOut(),
+          ).thenThrow(StateError('unexpected in signOut path'));
+          return AuthBloc(authRepository: mockRepo);
+        },
+        act: (b) => b.add(const AuthSignOutRequested()),
+        expect: () => [const AuthLoading(), const AuthUnauthenticated()],
+        errors: () => [isA<StateError>()],
+      );
+
+      blocTest<AuthBloc, AuthBlocState>(
+        'no resurrection: a failed persisted clear followed by the '
+        "repository's (fixed-contract) unauthenticated mirror emission "
+        'lands and STAYS on unauthenticated — never authenticated '
+        '(#37 review regression)',
+        build: () {
+          final repoStates = Stream<AuthState>.fromIterable(const [
+            AuthStateUnauthenticated(),
+          ]);
+          when(() => mockRepo.watchAuthState()).thenAnswer((_) => repoStates);
+          when(() => mockRepo.signOut()).thenThrow(
+            const AuthSignOutPersistenceException(
+              cause: 'secure storage clear failed',
+            ),
+          );
+          return AuthBloc(authRepository: mockRepo);
+        },
+        act: (b) async {
+          b.add(const AuthSignOutRequested());
+          // Let the sign-out handler and the mirrored repo emission both
+          // settle, in whichever order they interleave.
+          await Future<void>.delayed(Duration.zero);
+        },
+        expect: () => isNot(contains(isA<AuthAuthenticated>())),
+        errors: () => [isA<AuthSignOutPersistenceException>()],
+        verify: (b) => expect(b.state, const AuthUnauthenticated()),
+      );
     });
 
     group('repository state mirroring', () {
@@ -215,6 +402,30 @@ void main() {
           return AuthBloc(authRepository: mockRepo);
         },
         expect: () => [const AuthUnauthenticated()],
+      );
+
+      blocTest<AuthBloc, AuthBlocState>(
+        'does not clobber an in-flight session check — a stray repo '
+        'Unauthenticated during the check is ignored; the check owns the '
+        'terminal emit (#37 review, indeterminate-never-shows-form)',
+        build: () {
+          when(() => mockRepo.getSession()).thenAnswer((_) async {
+            // While the check is in flight, the repo mirrors an
+            // Unauthenticated (e.g. an interceptor 401 on another request).
+            await Future<void>.delayed(const Duration(milliseconds: 10));
+            throw const AuthNetworkException(message: 'offline');
+          });
+          return AuthBloc(authRepository: mockRepo);
+        },
+        act: (b) {
+          b.add(const AuthSessionCheckRequested());
+          b.add(const AuthRepositoryStateChanged(AuthStateUnauthenticated()));
+        },
+        wait: const Duration(milliseconds: 30),
+        expect: () => [
+          const AuthSessionCheckInProgress(),
+          const AuthSessionCheckFailed(),
+        ],
       );
     });
   });

--- a/packages/features/auth/test/widgets/auth_gate_test.dart
+++ b/packages/features/auth/test/widgets/auth_gate_test.dart
@@ -1,0 +1,172 @@
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/domain.dart';
+import 'package:models/dto.dart';
+
+import 'package:auth/l10n/auth_localizations.dart';
+import 'package:auth/src/bloc/auth_bloc.dart';
+import 'package:auth/src/bloc/auth_event.dart';
+import 'package:auth/src/bloc/auth_bloc_state.dart';
+import 'package:auth/src/screens/auth_gate.dart';
+import 'package:auth/src/screens/auth_screen.dart';
+
+class MockAuthBloc extends MockBloc<AuthEvent, AuthBlocState>
+    implements AuthBloc {}
+
+const _kSplashKey = Key('test_splash');
+const _kAuthBase = '/api/auth';
+
+ServerIdentity _identity() => ServerIdentity(
+  serverId: 'server-uuid-1',
+  issuer: 'https://api.example.com',
+  wellKnownSchemaVersion: 1,
+  name: 'Test BGE Server',
+  deviceAuthorizationEndpoint: '$_kAuthBase/device',
+  authBasePath: _kAuthBase,
+  sessionEndpoint: '$_kAuthBase/get-session',
+  signOutEndpoint: '$_kAuthBase/sign-out',
+  passkeySupported: false,
+  twoFactorSupported: false,
+  anonymousAuthSupported: false,
+  strategies: [
+    const EmailAndPasswordStrategy(
+      signUpDisabled: false,
+      signInEndpoint: '$_kAuthBase/sign-in/email',
+      signUpEndpoint: '$_kAuthBase/sign-up/email',
+    ),
+  ],
+);
+
+AuthResponse _session() => AuthResponse(
+  token: 'tok-abc',
+  user: User(id: 'u1', username: 'testuser'),
+  expiresAt: DateTime(2099).toUtc(),
+);
+
+Widget _wrap(MockAuthBloc bloc) => MaterialApp(
+  localizationsDelegates: AuthLocalizations.localizationsDelegates,
+  supportedLocales: AuthLocalizations.supportedLocales,
+  home: BlocProvider<AuthBloc>.value(
+    value: bloc,
+    child: AuthGate(
+      identity: _identity(),
+      serverDisplayName: 'My Server',
+      splash: const SizedBox(key: _kSplashKey),
+    ),
+  ),
+);
+
+/// Pins the #37 gate state machine: a pure function of [AuthBloc] state
+/// with no widget-local memory — splash while the restore is unresolved
+/// (and for the post-auth redirect microtask), a retryable unreachable
+/// view for an indeterminate session check, and the form for everything
+/// interactive. The sign-in form must NEVER appear during the restore
+/// phase (the no-flicker requirement).
+void main() {
+  setUpAll(() {
+    registerFallbackValue(const AuthSessionCheckRequested());
+    registerFallbackValue(const AuthInitial());
+  });
+
+  late MockAuthBloc mockBloc;
+
+  setUp(() {
+    mockBloc = MockAuthBloc();
+  });
+
+  Future<void> pumpWithState(WidgetTester tester, AuthBlocState state) async {
+    when(() => mockBloc.state).thenReturn(state);
+    await tester.pumpWidget(_wrap(mockBloc));
+  }
+
+  group('AuthGate', () {
+    testWidgets('renders splash for AuthInitial — no form flash', (
+      tester,
+    ) async {
+      await pumpWithState(tester, const AuthInitial());
+
+      expect(find.byKey(_kSplashKey), findsOneWidget);
+      expect(find.byType(AuthScreen), findsNothing);
+    });
+
+    testWidgets('renders splash while the session check is in flight', (
+      tester,
+    ) async {
+      await pumpWithState(tester, const AuthSessionCheckInProgress());
+
+      expect(find.byKey(_kSplashKey), findsOneWidget);
+      expect(find.byType(AuthScreen), findsNothing);
+    });
+
+    testWidgets('renders splash for AuthAuthenticated — the router is about '
+        'to redirect; the gate holds splash for the microtask', (tester) async {
+      await pumpWithState(tester, AuthAuthenticated(session: _session()));
+
+      expect(find.byKey(_kSplashKey), findsOneWidget);
+      expect(find.byType(AuthScreen), findsNothing);
+    });
+
+    testWidgets('renders the unreachable view for AuthSessionCheckFailed — '
+        'never the sign-in form for an indeterminate session', (tester) async {
+      await pumpWithState(tester, const AuthSessionCheckFailed());
+
+      expect(find.byType(SessionUnreachableView), findsOneWidget);
+      expect(find.textContaining('My Server'), findsOneWidget);
+      expect(find.byType(AuthScreen), findsNothing);
+      expect(find.byKey(_kSplashKey), findsNothing);
+    });
+
+    testWidgets('retry re-dispatches the session check', (tester) async {
+      await pumpWithState(tester, const AuthSessionCheckFailed());
+
+      await tester.tap(find.widgetWithText(FilledButton, 'Try Again'));
+      await tester.pump();
+
+      verify(() => mockBloc.add(const AuthSessionCheckRequested())).called(1);
+    });
+
+    testWidgets('renders AuthScreen for AuthUnauthenticated', (tester) async {
+      await pumpWithState(tester, const AuthUnauthenticated());
+
+      expect(find.byType(AuthScreen), findsOneWidget);
+      expect(find.byKey(_kSplashKey), findsNothing);
+    });
+
+    testWidgets('renders AuthScreen (not splash) for interactive '
+        'AuthLoading — the form owns its own progress', (tester) async {
+      await pumpWithState(tester, const AuthLoading());
+
+      expect(find.byType(AuthScreen), findsOneWidget);
+      expect(find.byKey(_kSplashKey), findsNothing);
+    });
+
+    testWidgets('renders AuthScreen for an interactive failure kind — the '
+        'form stays up with its live-region snack bar', (tester) async {
+      await pumpWithState(tester, const AuthFailureInvalidCredentials());
+
+      expect(find.byType(AuthScreen), findsOneWidget);
+      expect(find.byType(SessionUnreachableView), findsNothing);
+    });
+
+    group('SessionUnreachableView accessibility', () {
+      testWidgets('announces the failure via a live region and autofocuses '
+          'retry for keyboard users', (tester) async {
+        await pumpWithState(tester, const AuthSessionCheckFailed());
+        final handle = tester.ensureSemantics();
+        await tester.pump();
+
+        expect(
+          find.bySemanticsLabel(RegExp('Try Again', caseSensitive: false)),
+          findsWidgets,
+        );
+        final button = tester.widget<FilledButton>(find.byType(FilledButton));
+        expect(button.autofocus, isTrue);
+
+        handle.dispose();
+      });
+    });
+  });
+}

--- a/packages/features/auth/test/widgets/login_form_test.dart
+++ b/packages/features/auth/test/widgets/login_form_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
+import 'package:auth/l10n/auth_localizations.dart';
 import 'package:auth/src/bloc/auth_bloc.dart';
 import 'package:auth/src/bloc/auth_event.dart';
 import 'package:auth/src/bloc/auth_bloc_state.dart';
@@ -12,7 +13,12 @@ import 'package:auth/src/widgets/login_form.dart';
 class MockAuthBloc extends MockBloc<AuthEvent, AuthBlocState>
     implements AuthBloc {}
 
+// #37 i18n: the form resolves all copy from AuthLocalizations, so the
+// harness must provide the delegates; assertions keep matching the
+// English template values.
 Widget _wrap(Widget child, MockAuthBloc bloc) => MaterialApp(
+  localizationsDelegates: AuthLocalizations.localizationsDelegates,
+  supportedLocales: AuthLocalizations.supportedLocales,
   home: Scaffold(
     body: BlocProvider<AuthBloc>.value(value: bloc, child: child),
   ),

--- a/packages/features/auth/test/widgets/register_form_test.dart
+++ b/packages/features/auth/test/widgets/register_form_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
+import 'package:auth/l10n/auth_localizations.dart';
 import 'package:auth/src/bloc/auth_bloc.dart';
 import 'package:auth/src/bloc/auth_event.dart';
 import 'package:auth/src/bloc/auth_bloc_state.dart';
@@ -12,7 +13,12 @@ import 'package:auth/src/widgets/register_form.dart';
 class MockAuthBloc extends MockBloc<AuthEvent, AuthBlocState>
     implements AuthBloc {}
 
+// #37 i18n: the form resolves all copy from AuthLocalizations, so the
+// harness must provide the delegates; assertions keep matching the
+// English template values.
 Widget _wrap(Widget child, MockAuthBloc bloc) => MaterialApp(
+  localizationsDelegates: AuthLocalizations.localizationsDelegates,
+  supportedLocales: AuthLocalizations.supportedLocales,
   home: Scaffold(
     body: BlocProvider<AuthBloc>.value(value: bloc, child: child),
   ),

--- a/packages/network/dio_network/lib/src/auth/auth_repository_impl.dart
+++ b/packages/network/dio_network/lib/src/auth/auth_repository_impl.dart
@@ -7,6 +7,7 @@ import 'package:interfaces/repositories.dart';
 import 'package:models/domain.dart';
 import 'package:models/dto.dart';
 
+import '../network/token_interceptor.dart';
 import 'token_storage_service.dart';
 
 /// Dio-based [AuthRepository] for mobile and desktop.
@@ -169,13 +170,76 @@ class AuthRepositoryImpl implements AuthRepository, Disposable {
 
   @override
   Future<void> signOut() async {
+    // Capture the token BEFORE latching. clear() below sets the sign-out
+    // latch synchronously, ahead of TokenInterceptor's async retrieve() — so
+    // if the best-effort POST relied on the interceptor it would be sent
+    // WITHOUT an Authorization header, and the server could not revoke the
+    // session. Passing the token explicitly keeps the request authenticated
+    // regardless of latch timing (PR #99 review).
+    //
+    // Best-effort: a keychain read failure must not abort sign-out, whose
+    // unauthenticated transition is unconditional (see AuthRepository.signOut
+    // contract). On failure the POST simply goes out unauthenticated.
+    String? token;
     try {
-      await _dio.post<void>(_identity.signOutEndpoint);
-    } catch (_) {
-      // best-effort
-    } finally {
+      token = (await _tokenStorage.retrieve())?.token;
+    } on Object {
+      token = null;
+    }
+
+    // Best-effort server call, fire-and-forget: its result is discarded,
+    // so we must not block the local sign-out on it — awaiting would make
+    // the user watch a spinner for the full Dio timeout on an unreachable
+    // server (#37 review #9). The helper is Future<void> and swallows both
+    // synchronous throws and async rejections.
+    unawaited(_bestEffortSignOutPost(token));
+
+    try {
       await _tokenStorage.clear();
+    } on Object catch (error, stackTrace) {
+      // The persisted token could not be cleared. Rethrow as the typed,
+      // contract-covered exception (stack preserved). The `finally` runs
+      // before it propagates, so callers and the state stream observe the
+      // unauthenticated transition FIRST. TokenStorageService.clear() sets
+      // its sign-out latch BEFORE the failing delete, so retrieve() — and
+      // therefore the TokenInterceptor's Authorization header and any
+      // same-process getSession() — already report no token: a surviving
+      // token can be resurrected neither at the HTTP layer nor in state
+      // within this process (PR #99 review). The latch is in-memory only, so
+      // the residual risk is the surviving token restoring a session on the
+      // next cold start, where sign-out can be repeated (see the
+      // AuthRepository.signOut contract).
+      Error.throwWithStackTrace(
+        AuthSignOutPersistenceException(cause: error),
+        stackTrace,
+      );
+    } finally {
       _setState(const AuthStateUnauthenticated());
+    }
+  }
+
+  /// Fire-and-forget sign-out POST. Never throws: a synchronous throw or
+  /// an async rejection is swallowed (best-effort by design). Typed
+  /// `Future<void>` so it satisfies [unawaited].
+  ///
+  /// Carries [token] as an explicit `Authorization` header and opts out of
+  /// [TokenInterceptor]-managed auth: the sign-out latch set by clear() wins
+  /// the race against the interceptor's async token read, so relying on the
+  /// interceptor would send this request unauthenticated (PR #99 review).
+  /// A null [token] (already signed out / nothing stored) posts without auth.
+  Future<void> _bestEffortSignOutPost(String? token) async {
+    try {
+      await _dio.post<void>(
+        _identity.signOutEndpoint,
+        options: token == null
+            ? null
+            : Options(
+                headers: {'Authorization': 'Bearer $token'},
+                extra: {TokenInterceptor.skipAuthKey: true},
+              ),
+      );
+    } on Object {
+      // discarded
     }
   }
 

--- a/packages/network/dio_network/lib/src/auth/token_storage_service.dart
+++ b/packages/network/dio_network/lib/src/auth/token_storage_service.dart
@@ -8,6 +8,28 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 /// Keys are namespaced by local server ID to prevent cross-server collisions.
 /// Only the token string and expiry are persisted — the full [AuthResponse]
 /// is reconstructed after a [getSession] network call.
+///
+/// ## Sign-out latch (#37 / PR #99)
+///
+/// This service is the single token-material source read by BOTH
+/// `AuthRepositoryImpl` and the per-server `TokenInterceptor`. [clear] sets
+/// a process-lifetime latch so that, if the underlying keychain delete
+/// throws and the token physically survives, [retrieve] (and therefore
+/// [hasToken], the interceptor's `Authorization` attachment, and any
+/// same-process `getSession`) all report "no token" immediately. This makes
+/// the "sign-out is effective for this process" guarantee hold at the HTTP
+/// layer, not just in the repository's in-memory auth state — an
+/// unauthenticated user can no longer keep making authenticated requests
+/// because a persisted clear failed. The latch is lifted only when a new
+/// token is [store]d (a fresh sign-in/up), which supersedes the prior
+/// session.
+///
+/// The latch is in-memory and process-scoped: it is NOT persisted. A token
+/// that survived a failed delete therefore remains on disk, and a fresh
+/// [TokenStorageService] on the next cold start reads it again. The residual
+/// risk is that surviving token restoring a session on the next launch,
+/// where sign-out can simply be repeated — matching the
+/// `AuthRepository.signOut` contract.
 class TokenStorageService {
   TokenStorageService({
     required String serverId,
@@ -20,6 +42,10 @@ class TokenStorageService {
 
   static const String _prefix = 'bge_session';
 
+  /// Process-lifetime latch set by [clear]; see the class docs. When true,
+  /// [retrieve] returns null regardless of persisted state.
+  bool _clearedThisProcess = false;
+
   String get _key => '${_prefix}_$_serverId';
 
   Future<void> store({
@@ -31,9 +57,16 @@ class TokenStorageService {
       'expires_at': expiresAt.toUtc().toIso8601String(),
     });
     await _storage.write(key: _key, value: payload);
+    // A newly stored token supersedes any prior sign-out: lift the latch.
+    _clearedThisProcess = false;
   }
 
   Future<StoredToken?> retrieve() async {
+    // Honor the sign-out latch even if the persisted delete failed and the
+    // token physically survives — no consumer (repository or interceptor)
+    // may resurrect it within this process.
+    if (_clearedThisProcess) return null;
+
     final raw = await _storage.read(key: _key);
     if (raw == null) return null;
     try {
@@ -48,7 +81,15 @@ class TokenStorageService {
     }
   }
 
-  Future<void> clear() => _storage.delete(key: _key);
+  /// Deletes the persisted token and latches this service into a
+  /// "signed-out" state for the process lifetime (see class docs). The
+  /// latch is set FIRST, so even if the underlying delete throws, [retrieve]
+  /// already reports no token; the delete error still propagates so callers
+  /// can surface a persistence failure.
+  Future<void> clear() async {
+    _clearedThisProcess = true;
+    await _storage.delete(key: _key);
+  }
 
   Future<bool> hasToken() async => (await retrieve()) != null;
 }

--- a/packages/network/dio_network/test/auth/auth_repository_impl_sign_out_test.dart
+++ b/packages/network/dio_network/test/auth/auth_repository_impl_sign_out_test.dart
@@ -1,0 +1,280 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:interfaces/repositories.dart';
+import 'package:models/domain.dart';
+
+import 'package:dio_network/src/auth/auth_repository_impl.dart';
+import 'package:dio_network/src/auth/token_storage_service.dart';
+import 'package:dio_network/src/network/token_interceptor.dart';
+
+class MockDio extends Mock implements Dio {}
+
+class MockTokenStorage extends Mock implements TokenStorageService {}
+
+const _kAuthBase = '/api/auth';
+
+ServerIdentity _identity() => ServerIdentity(
+  serverId: 'server-uuid-1',
+  issuer: 'https://api.example.com',
+  wellKnownSchemaVersion: 1,
+  name: 'Test BGE Server',
+  deviceAuthorizationEndpoint: '$_kAuthBase/device',
+  authBasePath: _kAuthBase,
+  sessionEndpoint: '$_kAuthBase/get-session',
+  signOutEndpoint: '$_kAuthBase/sign-out',
+  passkeySupported: true,
+  twoFactorSupported: true,
+  anonymousAuthSupported: true,
+  strategies: [
+    const EmailAndPasswordStrategy(
+      signUpDisabled: false,
+      signInEndpoint: '$_kAuthBase/sign-in/email',
+      signUpEndpoint: '$_kAuthBase/sign-up/email',
+    ),
+  ],
+);
+
+/// Pins the [AuthRepository.signOut] persistence invariant (#37 review):
+/// the in-memory transition to [AuthStateUnauthenticated] is
+/// UNCONDITIONAL — it happens even when clearing the persisted token
+/// fails — and the failure surfaces as [AuthSignOutPersistenceException]
+/// with the underlying fault as [AuthException.cause]. Without this,
+/// `watchAuthState` could re-assert a session the user just ended (the
+/// sign-out resurrection hole).
+void main() {
+  late MockDio mockDio;
+  late MockTokenStorage mockStorage;
+  late AuthRepositoryImpl repo;
+
+  setUp(() {
+    mockDio = MockDio();
+    mockStorage = MockTokenStorage();
+    repo = AuthRepositoryImpl(
+      identity: _identity(),
+      tokenStorage: mockStorage,
+      dio: mockDio,
+    );
+    // signOut() reads the token (to authenticate the best-effort POST)
+    // before latching; default to none, overridden where a token matters.
+    when(() => mockStorage.retrieve()).thenAnswer((_) async => null);
+  });
+
+  tearDown(() async => repo.onDispose());
+
+  void stubSignOutPostOk() =>
+      when(
+        () => mockDio.post<void>(
+          '$_kAuthBase/sign-out',
+          options: any(named: 'options'),
+        ),
+      ).thenAnswer(
+        (_) async => Response<void>(
+          statusCode: 200,
+          requestOptions: RequestOptions(path: ''),
+        ),
+      );
+
+  void stubSignOutPostFails() =>
+      when(
+        () => mockDio.post<void>(
+          '$_kAuthBase/sign-out',
+          options: any(named: 'options'),
+        ),
+      ).thenThrow(
+        DioException(
+          type: DioExceptionType.connectionError,
+          requestOptions: RequestOptions(path: ''),
+        ),
+      );
+
+  group('signOut() persistence invariant', () {
+    test('happy path: completes and transitions to unauthenticated', () async {
+      stubSignOutPostOk();
+      when(() => mockStorage.clear()).thenAnswer((_) async {});
+
+      await repo.signOut();
+
+      expect(
+        await repo.watchAuthState().first,
+        const AuthStateUnauthenticated(),
+      );
+      verify(() => mockStorage.clear()).called(1);
+    });
+
+    test('a failed server call alone does not throw — best-effort — and '
+        'still transitions to unauthenticated', () async {
+      stubSignOutPostFails();
+      when(() => mockStorage.clear()).thenAnswer((_) async {});
+
+      await expectLater(repo.signOut(), completes);
+
+      expect(
+        await repo.watchAuthState().first,
+        const AuthStateUnauthenticated(),
+      );
+    });
+
+    test('a failed storage clear throws AuthSignOutPersistenceException '
+        'with the fault preserved as cause — AND the state has still '
+        'transitioned to unauthenticated', () async {
+      stubSignOutPostOk();
+      final storageFault = StateError('keychain unavailable');
+      when(() => mockStorage.clear()).thenThrow(storageFault);
+
+      final emissions = <AuthState>[];
+      final sub = repo.watchAuthState().listen(emissions.add);
+      await pumpEventQueue();
+
+      await expectLater(
+        repo.signOut(),
+        throwsA(
+          isA<AuthSignOutPersistenceException>().having(
+            (e) => e.cause,
+            'cause',
+            same(storageFault),
+          ),
+        ),
+      );
+      await pumpEventQueue();
+      await sub.cancel();
+
+      // The live stream saw the transition despite the throw…
+      expect(emissions.last, const AuthStateUnauthenticated());
+      // …and the repository's replayed current state agrees: a mirror
+      // subscribing later can only confirm the sign-out, never resurrect
+      // the ended session.
+      expect(
+        await repo.watchAuthState().first,
+        const AuthStateUnauthenticated(),
+      );
+    });
+
+    test('server call AND storage clear both failing still yields the '
+        'typed exception and the unauthenticated transition', () async {
+      stubSignOutPostFails();
+      final storageFault = StateError('keychain unavailable');
+      when(() => mockStorage.clear()).thenThrow(storageFault);
+
+      await expectLater(
+        repo.signOut(),
+        throwsA(isA<AuthSignOutPersistenceException>()),
+      );
+
+      expect(
+        await repo.watchAuthState().first,
+        const AuthStateUnauthenticated(),
+      );
+    });
+
+    test('an ended (authenticated → signed-out) session is never '
+        're-asserted by the stream after a failed clear', () async {
+      // Reach an authenticated state first, via a stored token + a valid
+      // session response.
+      when(() => mockStorage.retrieve()).thenAnswer(
+        (_) async => StoredToken(
+          token: 'session-tok-abc',
+          expiresAt: DateTime(2099).toUtc(),
+        ),
+      );
+      when(
+        () => mockStorage.store(
+          token: any(named: 'token'),
+          expiresAt: any(named: 'expiresAt'),
+        ),
+      ).thenAnswer((_) async {});
+      when(
+        () => mockDio.get<Map<String, dynamic>>('$_kAuthBase/get-session'),
+      ).thenAnswer(
+        (_) async => Response(
+          data: {
+            'session': {
+              'id': 'sess-1',
+              'token': 'session-tok-abc',
+              'expires_at': '2099-01-01T00:00:00.000Z',
+              'user_id': 'user-1',
+            },
+            'user': {'id': 'user-1', 'username': 'testuser'},
+          },
+          statusCode: 200,
+          requestOptions: RequestOptions(path: ''),
+        ),
+      );
+      await repo.getSession();
+      expect(await repo.watchAuthState().first, isA<AuthStateAuthenticated>());
+
+      stubSignOutPostOk();
+      when(
+        () => mockStorage.clear(),
+      ).thenThrow(StateError('keychain unavailable'));
+
+      final emissions = <AuthState>[];
+      final sub = repo.watchAuthState().listen(emissions.add);
+      await pumpEventQueue();
+
+      await expectLater(
+        repo.signOut(),
+        throwsA(isA<AuthSignOutPersistenceException>()),
+      );
+      await pumpEventQueue();
+      await sub.cancel();
+
+      // Replay (authenticated) + the sign-out transition — and nothing
+      // authenticated ever again after it.
+      final afterSignOut = emissions.skipWhile(
+        (s) => s is! AuthStateUnauthenticated,
+      );
+      expect(afterSignOut, isNotEmpty);
+      expect(afterSignOut.whereType<AuthStateAuthenticated>(), isEmpty);
+    });
+
+    test('the best-effort sign-out POST carries the captured token '
+        'explicitly, so the latch set by clear() cannot strip its '
+        'Authorization header (PR #99 review)', () async {
+      when(() => mockStorage.retrieve()).thenAnswer(
+        (_) async =>
+            StoredToken(token: 'live-tok', expiresAt: DateTime(2099).toUtc()),
+      );
+      when(() => mockStorage.clear()).thenAnswer((_) async {});
+      stubSignOutPostOk();
+
+      await repo.signOut();
+      // The POST is fire-and-forget; let it reach the Dio call.
+      await pumpEventQueue();
+
+      final captured =
+          verify(
+                () => mockDio.post<void>(
+                  '$_kAuthBase/sign-out',
+                  options: captureAny(named: 'options'),
+                ),
+              ).captured.single
+              as Options;
+
+      // Authenticated by the captured token, and opting out of the
+      // interceptor so latch timing is irrelevant.
+      expect(captured.headers?['Authorization'], 'Bearer live-tok');
+      expect(captured.extra?[TokenInterceptor.skipAuthKey], isTrue);
+    });
+
+    test('a keychain read failure while capturing the token does NOT abort '
+        'sign-out — clear() still runs and the state transitions to '
+        'unauthenticated (PR #99 review)', () async {
+      // Capturing the token for the best-effort POST reads storage; a read
+      // fault must not skip the unconditional local sign-out.
+      when(
+        () => mockStorage.retrieve(),
+      ).thenThrow(StateError('keychain locked'));
+      when(() => mockStorage.clear()).thenAnswer((_) async {});
+      stubSignOutPostOk();
+
+      await expectLater(repo.signOut(), completes);
+
+      verify(() => mockStorage.clear()).called(1);
+      expect(
+        await repo.watchAuthState().first,
+        const AuthStateUnauthenticated(),
+      );
+    });
+  });
+}

--- a/packages/network/dio_network/test/auth/auth_repository_impl_test.dart
+++ b/packages/network/dio_network/test/auth/auth_repository_impl_test.dart
@@ -246,6 +246,9 @@ void main() {
     group('signOut()', () {
       test('clears token regardless of server response', () async {
         stubClear();
+        // signOut() reads the token to authenticate the best-effort POST
+        // before latching; none stored here.
+        when(() => mockStorage.retrieve()).thenAnswer((_) async => null);
         when(() => mockDio.post<void>(any())).thenThrow(
           DioException(
             type: DioExceptionType.connectionError,

--- a/packages/network/dio_network/test/auth/token_storage_service_test.dart
+++ b/packages/network/dio_network/test/auth/token_storage_service_test.dart
@@ -1,125 +1,70 @@
-import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 import 'package:dio_network/src/auth/token_storage_service.dart';
 
-class MockSecureStorage extends Mock implements FlutterSecureStorage {}
+class _MockSecureStorage extends Mock implements FlutterSecureStorage {}
 
 void main() {
-  late MockSecureStorage mockStorage;
-  late TokenStorageService service;
+  late _MockSecureStorage secure;
+  late TokenStorageService storage;
 
-  const kServerId = 'local-server-abc';
-  const kKey = 'bge_session_local-server-abc';
-  final kExpiry = DateTime(2099, 1, 1).toUtc();
-  final kExpired = DateTime(2000, 1, 1).toUtc();
+  const key = 'bge_session_server-1';
+
+  String payload() =>
+      '{"token":"tok-abc","expires_at":"2099-01-01T00:00:00.000Z"}';
 
   setUp(() {
-    mockStorage = MockSecureStorage();
-    service = TokenStorageService(serverId: kServerId, storage: mockStorage);
+    secure = _MockSecureStorage();
+    storage = TokenStorageService(serverId: 'server-1', storage: secure);
+    when(
+      () => secure.write(
+        key: any(named: 'key'),
+        value: any(named: 'value'),
+      ),
+    ).thenAnswer((_) async {});
+    when(() => secure.delete(key: any(named: 'key'))).thenAnswer((_) async {});
   });
 
-  group('TokenStorageService', () {
-    group('store', () {
-      test('writes JSON-encoded payload under namespaced key', () async {
-        when(
-          () => mockStorage.write(
-            key: kKey,
-            value: any(named: 'value'),
-          ),
-        ).thenAnswer((_) async {});
+  group('sign-out latch (#37 / PR #99)', () {
+    test('retrieve returns null after clear, even if the token physically '
+        'survives a failed delete', () async {
+      when(() => secure.read(key: key)).thenAnswer((_) async => payload());
+      when(
+        () => secure.delete(key: any(named: 'key')),
+      ).thenThrow(StateError('keychain unavailable'));
 
-        await service.store(token: 'tok_abc', expiresAt: kExpiry);
+      // Token is present before sign-out.
+      expect(await storage.retrieve(), isNotNull);
 
-        final captured =
-            verify(
-                  () => mockStorage.write(
-                    key: kKey,
-                    value: captureAny(named: 'value'),
-                  ),
-                ).captured.single
-                as String;
+      // clear() latches first, then the delete throws.
+      await expectLater(storage.clear(), throwsA(isA<StateError>()));
 
-        expect(captured, contains('tok_abc'));
-        expect(captured, contains('2099'));
-      });
+      // Despite the surviving persisted token, retrieve reports none — so
+      // neither the interceptor's Authorization header nor getSession can
+      // resurrect it.
+      expect(await storage.retrieve(), isNull);
+      expect(await storage.hasToken(), isFalse);
     });
 
-    group('retrieve', () {
-      test('returns null when no entry exists', () async {
-        when(() => mockStorage.read(key: kKey)).thenAnswer((_) async => null);
-        expect(await service.retrieve(), isNull);
-      });
+    test('retrieve returns null after a successful clear', () async {
+      when(() => secure.read(key: key)).thenAnswer((_) async => payload());
 
-      test('returns StoredToken with correct fields', () async {
-        final payload =
-            '{"token":"tok_abc","expires_at":"${kExpiry.toIso8601String()}"}';
-        when(
-          () => mockStorage.read(key: kKey),
-        ).thenAnswer((_) async => payload);
+      await storage.clear();
 
-        final result = await service.retrieve();
-        expect(result?.token, 'tok_abc');
-        expect(result?.isExpired, isFalse);
-      });
-
-      test('isExpired true when past expiry', () async {
-        final payload =
-            '{"token":"old","expires_at":"${kExpired.toIso8601String()}"}';
-        when(
-          () => mockStorage.read(key: kKey),
-        ).thenAnswer((_) async => payload);
-
-        expect((await service.retrieve())?.isExpired, isTrue);
-      });
-
-      test('clears and returns null on corrupted entry', () async {
-        when(
-          () => mockStorage.read(key: kKey),
-        ).thenAnswer((_) async => 'not-json{{{');
-        when(() => mockStorage.delete(key: kKey)).thenAnswer((_) async {});
-
-        expect(await service.retrieve(), isNull);
-        verify(() => mockStorage.delete(key: kKey)).called(1);
-      });
+      expect(await storage.retrieve(), isNull);
     });
 
-    group('clear', () {
-      test('deletes the namespaced key', () async {
-        when(() => mockStorage.delete(key: kKey)).thenAnswer((_) async {});
-        await service.clear();
-        verify(() => mockStorage.delete(key: kKey)).called(1);
-      });
-    });
+    test('storing a new token lifts the latch (fresh sign-in supersedes '
+        'the prior sign-out)', () async {
+      when(() => secure.read(key: key)).thenAnswer((_) async => payload());
+      await storage.clear();
+      expect(await storage.retrieve(), isNull);
 
-    group('key isolation', () {
-      test('different server IDs use different keys', () async {
-        final other = TokenStorageService(
-          serverId: 'other-server',
-          storage: mockStorage,
-        );
+      await storage.store(token: 'tok-abc', expiresAt: DateTime(2099).toUtc());
 
-        when(
-          () => mockStorage.write(
-            key: any(named: 'key'),
-            value: any(named: 'value'),
-          ),
-        ).thenAnswer((_) async {});
-
-        await service.store(token: 'a', expiresAt: kExpiry);
-        await other.store(token: 'b', expiresAt: kExpiry);
-
-        final keys = verify(
-          () => mockStorage.write(
-            key: captureAny(named: 'key'),
-            value: any(named: 'value'),
-          ),
-        ).captured;
-
-        expect(keys[0], 'bge_session_local-server-abc');
-        expect(keys[1], 'bge_session_other-server');
-      });
+      expect(await storage.retrieve(), isNotNull);
     });
   });
 }

--- a/packages/network/dio_network/test/network/token_interceptor_test.dart
+++ b/packages/network/dio_network/test/network/token_interceptor_test.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:dio/dio.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -9,6 +10,8 @@ import 'package:dio_network/src/auth/token_storage_service.dart';
 import 'package:dio_network/src/network/token_interceptor.dart';
 
 class _MockTokenStorage extends Mock implements TokenStorageService {}
+
+class _MockSecureStorage extends Mock implements FlutterSecureStorage {}
 
 /// Captures the outgoing [RequestOptions] without hitting the network.
 class _CapturingAdapter implements HttpClientAdapter {
@@ -102,6 +105,63 @@ void main() {
       await dio.get<dynamic>('/protected');
 
       expect(adapter.captured?.headers.containsKey('Authorization'), isFalse);
+    });
+  });
+
+  // Closes the original PR #99 gap: the interceptor authenticated purely off
+  // TokenStorageService.retrieve(), so a token surviving a failed clear() kept
+  // being attached after sign-out. With the latch inside the shared store, the
+  // interceptor stops attaching it the moment clear() is called — even when the
+  // persisted delete throws and the token physically survives on disk.
+  group('TokenInterceptor honors the shared sign-out latch (PR #99)', () {
+    late _MockSecureStorage secure;
+    late TokenStorageService realStorage;
+    late _CapturingAdapter latchAdapter;
+    late Dio latchDio;
+
+    const validPayload =
+        '{"token":"survivor","expires_at":"2099-01-01T00:00:00.000Z"}';
+
+    setUp(() {
+      secure = _MockSecureStorage();
+      realStorage = TokenStorageService(serverId: 'server-1', storage: secure);
+      latchAdapter = _CapturingAdapter();
+      latchDio =
+          Dio(
+              BaseOptions(
+                baseUrl: 'https://api.example.com',
+                validateStatus: (_) => true,
+              ),
+            )
+            ..httpClientAdapter = latchAdapter
+            ..interceptors.add(TokenInterceptor(tokenStorage: realStorage));
+
+      when(
+        () => secure.read(key: any(named: 'key')),
+      ).thenAnswer((_) async => validPayload);
+    });
+
+    test('stops attaching a surviving token after a failed clear', () async {
+      // The persisted delete fails, so the token physically survives on disk.
+      when(
+        () => secure.delete(key: any(named: 'key')),
+      ).thenThrow(StateError('keychain unavailable'));
+
+      // Sanity: before sign-out the interceptor attaches the bearer token.
+      await latchDio.get<dynamic>('/protected');
+      expect(latchAdapter.captured?.headers['Authorization'], 'Bearer survivor');
+
+      // Sign-out clears the store; the delete throws but the latch is set.
+      await expectLater(realStorage.clear(), throwsA(isA<StateError>()));
+
+      // Even though the token still reads from the keychain, the latched store
+      // reports none — so no Authorization header is attached.
+      latchAdapter.captured = null;
+      await latchDio.get<dynamic>('/protected');
+      expect(
+        latchAdapter.captured?.headers.containsKey('Authorization'),
+        isFalse,
+      );
     });
   });
 }

--- a/packages/network/web_network/test/auth/web_auth_repository_impl_sign_out_test.dart
+++ b/packages/network/web_network/test/auth/web_auth_repository_impl_sign_out_test.dart
@@ -1,0 +1,125 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:interfaces/repositories.dart';
+import 'package:models/domain.dart';
+
+import 'package:web_network/src/auth/web_auth_repository_impl.dart';
+
+class MockDio extends Mock implements Dio {}
+
+const _kAuthBase = '/api/auth';
+
+ServerIdentity _identity() => ServerIdentity(
+  serverId: 'server-uuid-1',
+  issuer: 'https://api.example.com',
+  wellKnownSchemaVersion: 1,
+  name: 'Test BGE Server',
+  deviceAuthorizationEndpoint: '$_kAuthBase/device',
+  authBasePath: _kAuthBase,
+  sessionEndpoint: '$_kAuthBase/get-session',
+  signOutEndpoint: '$_kAuthBase/sign-out',
+  passkeySupported: true,
+  twoFactorSupported: true,
+  anonymousAuthSupported: true,
+);
+
+/// Pins the web side of the [AuthRepository.signOut] contract (#37
+/// review). [WebAuthRepositoryImpl] has no persisted session material of
+/// its own (the browser owns the httpOnly cookie), so — unlike the native
+/// impl — its sign-out has nothing that can fail persistence:
+/// it NEVER throws, and the in-memory transition to
+/// [AuthStateUnauthenticated] is unconditional (`finally`). These tests
+/// lock that in so a future refactor cannot reintroduce a path where the
+/// state stream re-asserts an ended session.
+void main() {
+  late MockDio mockDio;
+  late WebAuthRepositoryImpl repo;
+
+  setUp(() {
+    mockDio = MockDio();
+    repo = WebAuthRepositoryImpl(identity: _identity(), dio: mockDio);
+  });
+
+  tearDown(() async => repo.onDispose());
+
+  group('signOut() invariant (web)', () {
+    test('completes and transitions to unauthenticated on success', () async {
+      when(() => mockDio.post<void>('$_kAuthBase/sign-out')).thenAnswer(
+        (_) async => Response<void>(
+          statusCode: 200,
+          requestOptions: RequestOptions(path: ''),
+        ),
+      );
+
+      await expectLater(repo.signOut(), completes);
+
+      expect(
+        await repo.watchAuthState().first,
+        const AuthStateUnauthenticated(),
+      );
+    });
+
+    test('a failed server call does not throw — best-effort — and still '
+        'transitions to unauthenticated', () async {
+      when(() => mockDio.post<void>('$_kAuthBase/sign-out')).thenThrow(
+        DioException(
+          type: DioExceptionType.connectionError,
+          requestOptions: RequestOptions(path: ''),
+        ),
+      );
+
+      await expectLater(repo.signOut(), completes);
+
+      expect(
+        await repo.watchAuthState().first,
+        const AuthStateUnauthenticated(),
+      );
+    });
+
+    test('an ended (authenticated → signed-out) session is never '
+        're-asserted by the stream, even when the server call fails', () async {
+      // Reach an authenticated state first via the session endpoint.
+      when(
+        () => mockDio.get<Map<String, dynamic>>('$_kAuthBase/get-session'),
+      ).thenAnswer(
+        (_) async => Response(
+          data: {
+            'session': {
+              'id': 'sess-1',
+              'token': 'session-tok-abc',
+              'expires_at': '2099-01-01T00:00:00.000Z',
+              'user_id': 'user-1',
+            },
+            'user': {'id': 'user-1', 'username': 'testuser'},
+          },
+          statusCode: 200,
+          requestOptions: RequestOptions(path: ''),
+        ),
+      );
+      await repo.getSession();
+      expect(await repo.watchAuthState().first, isA<AuthStateAuthenticated>());
+
+      when(() => mockDio.post<void>('$_kAuthBase/sign-out')).thenThrow(
+        DioException(
+          type: DioExceptionType.connectionError,
+          requestOptions: RequestOptions(path: ''),
+        ),
+      );
+
+      final emissions = <AuthState>[];
+      final sub = repo.watchAuthState().listen(emissions.add);
+      await pumpEventQueue();
+
+      await expectLater(repo.signOut(), completes);
+      await pumpEventQueue();
+      await sub.cancel();
+
+      final afterSignOut = emissions.skipWhile(
+        (s) => s is! AuthStateUnauthenticated,
+      );
+      expect(afterSignOut, isNotEmpty);
+      expect(afterSignOut.whereType<AuthStateAuthenticated>(), isEmpty);
+    });
+  });
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -121,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.2.1"
+  bloc_concurrency:
+    dependency: transitive
+    description:
+      name: bloc_concurrency
+      sha256: "86b7b17a0a78f77fca0d7c030632b59b593b22acea2d96972588f40d4ef53a94"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   bloc_test:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -98,7 +98,7 @@ melos:
         flutter: false
 
     test:
-      run: melos exec -c 1 -- "flutter test --coverage --test-randomize-ordering-seed random"
+      run: melos exec -c 4 -- "flutter test --coverage --test-randomize-ordering-seed random"
       description: Run all Flutter tests in workspace
       packageFilters:
         dirExists: test


### PR DESCRIPTION
## Summary by Sourcery

Implement authenticated app flow wiring around a new ActiveServerScope, refining auth state semantics and sign-out guarantees, and localizing auth UI copy.

New Features:
- Add AuthGate and SessionUnreachableView to drive the `/auth` route from AuthBloc state, including a retryable unreachable-session view for indeterminate restores.
- Wire auth UI and error reporting through AuthLocalizations, migrating forms and auth screen to fully localized labels, messages, and announcements.

Bug Fixes:
- Prevent resurrecting a signed-out session by latching sign-out in AuthRepositoryImpl and enforcing unconditional unauthenticated transitions even on persistence failures.
- Ensure sign-out on both native and web always transitions to unauthenticated, surfacing persistence issues via typed exceptions or best-effort semantics without reasserting ended sessions.
- Avoid clobbering in-flight auth session checks and overlapping auth operations through droppable event transformers and state-guarded repository mirroring.

Enhancements:
- Refine AuthBloc state model with explicit session-check states, typed operation failure kinds, droppable concurrency, and repository state mirroring safeguards.
- Introduce ActiveServerScope and native OrchestratorActiveServerScope to expose the active server identity and container consistently from the orchestrator.
- Extend ServerOrchestrator with activeConfig tracking kept in lockstep with contexts, and expose ServerConfig snapshots through ServerContext.

Build:
- Add bloc_concurrency dependency for AuthBloc event transformers.

Documentation:
- Document auth phases, failure modes, sign-out persistence guarantees, and orchestration config bookkeeping in bloc, repository, orchestrator, and bootstrap cubit APIs.

Tests:
- Add extensive unit and widget tests for auth bloc behavior, auth gate rendering, localized auth screen/forms, bootstrap auth transitions, sign-out persistence semantics on native and web, and orchestrator active config / ActiveServerScope behavior.