### PR TITLE
feat: web auth path, resolves #96

### DIFF
--- a/docs/dev/web-proxy.md
+++ b/docs/dev/web-proxy.md
@@ -1,0 +1,124 @@
+# Local web testing via a dev reverse proxy
+
+The web client reads its API base from the **browser origin**
+(`Uri.base.origin`, via `WebDioFactory.currentOrigin`), and auth uses
+httpOnly, same-origin session cookies (BetterAuth). In production the client is
+served from the backend origin, so this "just works." In development the
+Flutter web dev server and the NestJS backend run on different ports — two
+origins — which breaks the cookie model.
+
+A small reverse proxy fixes this by giving the browser **one origin** and
+routing by path. **No client code changes are required** — this is purely local
+tooling. `tool/dev_proxy/dev_proxy.mjs` is a zero-dependency Node script (built-in
+modules only; Node 18+).
+
+## Topology
+
+```
+browser ──▶ http://localhost:8080  (the proxy — open THIS)
+                 │
+                 ├─ /api/*         ─▶ NestJS backend        (:33333)
+                 ├─ /.well-known/* ─▶ NestJS backend        (:33333)
+                 └─ everything else ─▶ Flutter web dev server (:5000)
+                    (assets + hot-restart websocket)
+```
+
+## Prerequisites
+
+- Node 18+ (`node --version`).
+- The NestJS backend running locally (default `:33333`).
+- One trusted-origin change on the backend — see [Backend config](#backend-config-required).
+
+## Run it (three terminals)
+
+**1 — Backend** (in the NestJS repo):
+
+```sh
+npm run start:dev        # serves on :33333
+```
+
+**2 — Flutter web dev server.** Use the `web-server` device (not `chrome`) so
+Flutter does **not** auto-open a browser at `:5000`; you open the proxy origin
+yourself.
+
+```sh
+BGE_WEB_PORT=5000 melos exec --scope=browser -- \
+  flutter run -d web-server --web-hostname=localhost --web-port=5000
+```
+
+**3 — Proxy**, then browse to `http://localhost:8080`:
+
+```sh
+node tool/dev_proxy/dev_proxy.mjs
+```
+
+Hot restart still works: press `R` (or `r`) in terminal 2 — the injected client
+reconnects through the proxy's websocket passthrough. A manual browser refresh
+also works, since assets are served live through the proxy.
+
+### Optional melos shortcuts
+
+The root `pubspec.yaml` defines matching melos scripts:
+
+```sh
+melos run web            # terminal 2 — Flutter web dev server (fixed port)
+melos run web:proxy      # terminal 3 — the dev reverse proxy
+```
+
+Or run both in one terminal (Ctrl-C stops both); prefer the two-terminal form
+above when you want independent logs:
+
+```sh
+melos run web:server     # proxy + web dev server together
+```
+
+## Environment variables
+
+All optional; sensible defaults baked in.
+
+| Variable            | Default | Meaning                                  |
+| ------------------- | ------- | ---------------------------------------- |
+| `BGE_PROXY_PORT`    | `8080`  | Origin the browser opens.                |
+| `BGE_WEB_PORT`      | `5000`  | Flutter web dev server port.             |
+| `BGE_BACKEND_PORT`  | `33333`  | NestJS backend port.                     |
+
+Keep `BGE_WEB_PORT` in sync between the Flutter command and the proxy. A fixed
+proxy port also keeps the backend's trusted-origin allow-list stable.
+
+## Backend config (required)
+
+Because the browser origin is now `http://localhost:8080`, the backend must
+trust it or sign-in requests fail origin/CSRF checks even though routing works:
+
+- **Trusted origin / baseURL** includes `http://localhost:8080` (BetterAuth
+  `trustedOrigins` / `baseURL`).
+- **Session cookie is host-only** — no explicit `Domain` attribute — so it binds
+  to `localhost:8080`. `SameSite=Lax` (or `Strict`) is fine because, from the
+  browser's point of view, every request is same-origin. `Secure` is OK too:
+  Chrome treats `localhost` as a secure context.
+
+The `issuer` field in the well-known document is informational — the client
+builds request URLs from `Uri.base.origin`, not from `issuer` — so an `issuer`
+that names a different port is cosmetic for the alpha.
+
+## Extending the routes
+
+Backend paths live in `BACKEND_PREFIXES` in `dev_proxy.mjs`. Add a prefix when
+the backend gains surface outside `/api` and `/.well-known` — for example
+`'/socket.io'` when the realtime (Socket.io) features land, so the websocket
+upgrade is routed to the backend rather than the Flutter dev server.
+
+## Troubleshooting
+
+- **`502 ... unreachable`** — the named upstream isn't up. Check the backend
+  (terminal 1) or the Flutter dev server (terminal 2) and the ports.
+- **Blank page / assets 404** — you opened `:5000` instead of the proxy. Open
+  `http://localhost:8080`.
+- **Sign-in returns 401/403 but `/.well-known` loads** — routing is fine; the
+  backend isn't trusting `http://localhost:8080` yet (see
+  [Backend config](#backend-config-required)).
+- **Cookie set but not sent back** — the cookie likely has an explicit `Domain`
+  or `SameSite=None` without `Secure`. Prefer a host-only `SameSite=Lax` cookie
+  in dev.
+- **Hot restart doesn't reconnect** — confirm you launched with `-d web-server`;
+  the websocket passthrough only matters for that device.

--- a/packages/app_shell/lib/src/widgets/feedback_review_screen.dart
+++ b/packages/app_shell/lib/src/widgets/feedback_review_screen.dart
@@ -1,4 +1,3 @@
-// packages/app_shell/lib/src/widgets/feedback_review_screen.dart
 import 'package:flutter/material.dart';
 import 'package:observability/observability.dart';
 

--- a/packages/app_shell/test/widgets/feedback_review_screen_test.dart
+++ b/packages/app_shell/test/widgets/feedback_review_screen_test.dart
@@ -1,4 +1,3 @@
-// packages/app_shell/test/widgets/feedback_review_screen_test.dart
 import 'package:app_shell/app_shell.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/network/web_network/CHANGELOG.md
+++ b/packages/network/web_network/CHANGELOG.md
@@ -1,3 +1,18 @@
+## Unreleased
+
+* `WebActiveServerScope`: a constant single-value `ActiveServerScope` holding
+  the serving origin's `ActiveServer`. `active` is always non-null and
+  `watchActive()` replays it to each subscriber then stays open — the
+  intentional "not a degenerate orchestrator" shape for the single-origin web
+  model (no orchestrator, no server switching) (#96).
+* `bootstrapWebServerScope`: the web composition entry point. Resolves the
+  origin, fetches its `ServerIdentity` through the `WellKnownClient` seam
+  (reusing `WellKnownClientImpl`), populates an isolated per-server container
+  via `registerServerNetworkWeb`, and returns the single-origin scope with
+  `serverId`/`displayName` sourced from the identity. Well-known failures
+  propagate unchanged for the shell to surface as a retryable bootstrap
+  failure (#96).
+
 ## 0.0.1
 
 * TODO: Describe initial release.

--- a/packages/network/web_network/lib/src/orchestration/bootstrap_web_server_scope.dart
+++ b/packages/network/web_network/lib/src/orchestration/bootstrap_web_server_scope.dart
@@ -1,0 +1,69 @@
+import 'package:di/di.dart' show DependencyContainerImpl;
+import 'package:dio_network/dio_network.dart' show WellKnownClientImpl;
+import 'package:interfaces/orchestration.dart';
+import 'package:network_interface/network_interface.dart' show WellKnownClient;
+
+import '../network/register_server_network_web.dart';
+import '../network/web_dio_factory.dart';
+import 'web_active_server_scope.dart';
+
+/// Fetches the serving origin's identity and assembles the web server scope
+/// (#96).
+///
+/// Web has no orchestrator, no MetaDB, and no persisted `ServerConfig`: the
+/// browser can only talk to the origin in the address bar. This helper is the
+/// web composition root's single entry point —
+///
+/// 1. resolves the origin via [originProvider] (the browser address bar in
+///    production; injected in tests because `Uri.base` has no origin on the
+///    VM);
+/// 2. fetches `/.well-known/bge-identity` from that origin through the
+///    platform-neutral [WellKnownClient] seam, reusing [WellKnownClientImpl]
+///    (the document is unauthenticated and same-origin, so no cookie or token
+///    is attached);
+/// 3. builds an isolated per-server [DependencyContainer] and populates it via
+///    [registerServerNetworkWeb] (shared `Dio` + `AuthRepository`, no token
+///    storage — the browser owns the session cookie);
+/// 4. returns a [WebActiveServerScope] holding the single origin
+///    [ActiveServer], with [ActiveServer.serverId] and
+///    [ActiveServer.displayName] sourced from the fetched identity
+///    (`serverId` is the server-vended UUID; native instead uses the
+///    client-local `ServerConfig.id` — both are opaque keying values).
+///
+/// The fetch runs before the container is created, so a failure leaks nothing.
+/// Well-known failures (`WellKnownException` subtypes) propagate unchanged: the
+/// web bootstrap (slice 2) lets them surface as the shared retryable
+/// bootstrap-failure state rather than a "needs server" state — web always has
+/// exactly one server by construction.
+///
+/// [wellKnownClient] and [originProvider] are injection seams for tests; both
+/// default to production behavior.
+Future<ActiveServerScope> bootstrapWebServerScope({
+  WellKnownClient? wellKnownClient,
+  String Function() originProvider = WebDioFactory.currentOrigin,
+}) async {
+  final origin = originProvider();
+
+  // runs only from WebPlatformBootstrap.initialize(), a browser-only path.
+  // On web, Dio uses the browser (Fetch/XHR) adapter, which owns no HttpClient
+  // or socket pool — Dio.close() is effectively a no-op.
+  final client = wellKnownClient ?? WellKnownClientImpl();
+
+  final identity = await client.fetchIdentity(origin);
+
+  final container = DependencyContainerImpl();
+  registerServerNetworkWeb(
+    container: container,
+    identity: identity,
+    originProvider: originProvider,
+  );
+
+  return WebActiveServerScope(
+    ActiveServer(
+      serverId: identity.serverId,
+      displayName: identity.name,
+      identity: identity,
+      container: container,
+    ),
+  );
+}

--- a/packages/network/web_network/lib/src/orchestration/web_active_server_scope.dart
+++ b/packages/network/web_network/lib/src/orchestration/web_active_server_scope.dart
@@ -1,0 +1,37 @@
+import 'dart:async';
+
+import 'package:interfaces/orchestration.dart';
+
+/// Web [ActiveServerScope] (#96): a constant, single-value holder.
+///
+/// Web has no orchestrator and no server switching in alpha — the browser
+/// talks to exactly one origin, whose identity is fetched at bootstrap
+/// ([bootstrapWebServerScope]). This scope therefore holds a single
+/// [ActiveServer] fixed at construction: [active] is always non-null, and
+/// [watchActive] replays that one value to every subscriber and then stays
+/// open without ever emitting again.
+///
+/// This is the intentional "not a degenerate orchestrator" shape the seam
+/// docs describe. Sign-out is handled by the auth bloc resolved from the
+/// server's [ActiveServer.container]; it never clears the active server, so
+/// there is deliberately no path that emits `null`.
+class WebActiveServerScope implements ActiveServerScope {
+  /// Creates a scope that always reports [_active] as the active server.
+  WebActiveServerScope(this._active);
+
+  final ActiveServer _active;
+
+  @override
+  ActiveServer? get active => _active;
+
+  @override
+  Stream<ActiveServer?> watchActive() {
+    return Stream.multi((controller) {
+      // Replay the one value on subscribe (the seam's contract), then leave
+      // the stream open: there is no upstream and never a second emission,
+      // so the controller closes only when the listener cancels. Uses the
+      // same Stream.multi replay pattern as OrchestratorActiveServerScope.
+      controller.add(_active);
+    });
+  }
+}

--- a/packages/network/web_network/lib/web_network.dart
+++ b/packages/network/web_network/lib/web_network.dart
@@ -3,3 +3,5 @@ library;
 export 'src/auth/web_auth_repository_impl.dart';
 export 'src/network/register_server_network_web.dart';
 export 'src/network/web_dio_factory.dart';
+export 'src/orchestration/bootstrap_web_server_scope.dart';
+export 'src/orchestration/web_active_server_scope.dart';

--- a/packages/network/web_network/test/orchestration/bootstrap_web_server_scope_test.dart
+++ b/packages/network/web_network/test/orchestration/bootstrap_web_server_scope_test.dart
@@ -1,0 +1,133 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:interfaces/orchestration.dart';
+import 'package:interfaces/repositories.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:models/domain.dart';
+import 'package:network_interface/network_interface.dart';
+import 'package:web_network/src/auth/web_auth_repository_impl.dart';
+import 'package:web_network/src/orchestration/bootstrap_web_server_scope.dart';
+
+class _MockWellKnownClient extends Mock implements WellKnownClient {}
+
+const _kOrigin = 'https://bge.example.com';
+const _kAuthBase = '/api/auth';
+
+ServerIdentity _identity() => ServerIdentity(
+  serverId: 'server-uuid-1',
+  issuer: _kOrigin,
+  wellKnownSchemaVersion: 1,
+  name: 'Test BGE Server',
+  deviceAuthorizationEndpoint: '$_kAuthBase/device',
+  authBasePath: _kAuthBase,
+  sessionEndpoint: '$_kAuthBase/get-session',
+  signOutEndpoint: '$_kAuthBase/sign-out',
+  passkeySupported: false,
+  twoFactorSupported: false,
+  anonymousAuthSupported: false,
+  strategies: const [
+    EmailAndPasswordStrategy(
+      signUpDisabled: false,
+      signInEndpoint: '$_kAuthBase/sign-in/email',
+      signUpEndpoint: '$_kAuthBase/sign-up/email',
+    ),
+  ],
+);
+
+void main() {
+  late _MockWellKnownClient wellKnownClient;
+  // Assigned by successful runs so tearDown can dispose the created scope's
+  // container; stays null when the fetch fails.
+  ActiveServerScope? scope;
+
+  setUp(() {
+    wellKnownClient = _MockWellKnownClient();
+    scope = null;
+  });
+
+  tearDown(() async {
+    await scope?.active?.container.dispose();
+  });
+
+  Future<ActiveServerScope> bootstrap() => bootstrapWebServerScope(
+    wellKnownClient: wellKnownClient,
+    // Uri.base has no origin on the VM, so the origin is injected; production
+    // defaults to WebDioFactory.currentOrigin (the browser address bar).
+    originProvider: () => _kOrigin,
+  );
+
+  void stubFetchSuccess() => when(
+    () => wellKnownClient.fetchIdentity(any()),
+  ).thenAnswer((_) async => _identity());
+
+  group('bootstrapWebServerScope', () {
+    test('fetches the origin identity and returns a scope with a non-null '
+        'active server', () async {
+      stubFetchSuccess();
+
+      scope = await bootstrap();
+
+      expect(scope!.active, isNotNull);
+      verify(() => wellKnownClient.fetchIdentity(_kOrigin)).called(1);
+    });
+
+    test('sources the active server id and display name from the fetched '
+        'identity', () async {
+      stubFetchSuccess();
+
+      scope = await bootstrap();
+
+      final active = scope!.active!;
+      expect(active.serverId, 'server-uuid-1');
+      expect(active.displayName, 'Test BGE Server');
+      expect(active.identity, _identity());
+    });
+
+    test(
+      'populates the scope container with a resolvable AuthRepository',
+      () async {
+        stubFetchSuccess();
+
+        scope = await bootstrap();
+
+        expect(
+          scope!.active!.container.get<AuthRepository>(),
+          isA<WebAuthRepositoryImpl>(),
+        );
+      },
+    );
+
+    test(
+      'builds the server Dio against the same origin used for the fetch',
+      () async {
+        stubFetchSuccess();
+
+        scope = await bootstrap();
+
+        final dio = scope!.active!.container.get<Dio>();
+        expect(dio.options.baseUrl, _kOrigin);
+        verify(() => wellKnownClient.fetchIdentity(_kOrigin)).called(1);
+      },
+    );
+
+    test(
+      'propagates well-known fetch failures unchanged (no scope built)',
+      () async {
+        when(() => wellKnownClient.fetchIdentity(any())).thenThrow(
+          const WellKnownUnreachableException(
+            serverUrl: _kOrigin,
+            message: 'boom',
+          ),
+        );
+
+        await expectLater(
+          bootstrap(),
+          throwsA(isA<WellKnownUnreachableException>()),
+        );
+        // The fetch runs before any container is created, so a failure leaks
+        // nothing: `scope` stays null and tearDown disposes nothing.
+        expect(scope, isNull);
+      },
+    );
+  });
+}

--- a/packages/network/web_network/test/orchestration/web_active_server_scope_test.dart
+++ b/packages/network/web_network/test/orchestration/web_active_server_scope_test.dart
@@ -1,0 +1,85 @@
+import 'package:di/di.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:interfaces/orchestration.dart';
+import 'package:models/domain.dart';
+import 'package:web_network/src/orchestration/web_active_server_scope.dart';
+
+const _kAuthBase = '/api/auth';
+
+ServerIdentity _identity() => ServerIdentity(
+  serverId: 'server-uuid-1',
+  issuer: 'https://bge.example.com',
+  wellKnownSchemaVersion: 1,
+  name: 'Test BGE Server',
+  deviceAuthorizationEndpoint: '$_kAuthBase/device',
+  authBasePath: _kAuthBase,
+  sessionEndpoint: '$_kAuthBase/get-session',
+  signOutEndpoint: '$_kAuthBase/sign-out',
+  passkeySupported: false,
+  twoFactorSupported: false,
+  anonymousAuthSupported: false,
+  strategies: const [
+    EmailAndPasswordStrategy(
+      signUpDisabled: false,
+      signInEndpoint: '$_kAuthBase/sign-in/email',
+      signUpEndpoint: '$_kAuthBase/sign-up/email',
+    ),
+  ],
+);
+
+void main() {
+  late DependencyContainerImpl container;
+  late ActiveServer server;
+  late WebActiveServerScope scope;
+
+  setUp(() {
+    container = DependencyContainerImpl();
+    server = ActiveServer(
+      serverId: 'server-uuid-1',
+      displayName: 'Test BGE Server',
+      identity: _identity(),
+      container: container,
+    );
+    scope = WebActiveServerScope(server);
+  });
+
+  tearDown(() async {
+    await container.dispose();
+  });
+
+  group('WebActiveServerScope', () {
+    test('active exposes the fixed server (never null)', () {
+      expect(scope.active, same(server));
+    });
+
+    test('watchActive replays the current value on subscribe', () async {
+      await expectLater(scope.watchActive().first, completion(same(server)));
+    });
+
+    test('watchActive replays independently to each subscriber', () async {
+      expect(await scope.watchActive().first, same(server));
+      // A second, independent subscription also receives the replay.
+      expect(await scope.watchActive().first, same(server));
+    });
+
+    test('watchActive emits once and stays open — never null, never '
+        'completes', () async {
+      final events = <ActiveServer?>[];
+      var done = false;
+      final sub = scope.watchActive().listen(
+        events.add,
+        onDone: () => done = true,
+      );
+
+      // Give the event queue time to deliver any (unexpected) further event
+      // or a stream close.
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      expect(events, hasLength(1));
+      expect(events.single, same(server));
+      expect(done, isFalse);
+
+      await sub.cancel();
+    });
+  });
+}

--- a/packages/platform/native_platform/pubspec.yaml
+++ b/packages/platform/native_platform/pubspec.yaml
@@ -41,11 +41,11 @@ dependencies:
   hydrated_bloc: ^11.0.0
   package_info_plus: ^10.2.0
   path_provider: ^2.1.3
+  logging: ^1.3.0
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  logging: ^1.3.0
   mocktail: ^1.0.5
   flutter_lints: ^6.0.0
   very_good_analysis: ^10.2.0

--- a/packages/platform/web/CHANGELOG.md
+++ b/packages/platform/web/CHANGELOG.md
@@ -1,3 +1,15 @@
+## Unreleased
+
+* `WebPlatformBootstrap.initialize` now fetches the origin identity and returns
+  the single-origin `ActiveServerScope` in its `BootstrapResult`, lighting up
+  the shared shell's auth subtree on web. Added an injectable
+  `serverScopeBuilder` seam (defaults to `bootstrapWebServerScope`); the const
+  production constructor is preserved. A well-known fetch failure propagates as
+  the shared retryable bootstrap-failure state — web never routes to a "needs
+  server" state (#96).
+* Depend on `web_network` for the cookie-based network stack and origin
+  well-known fetch (#96).
+
 ## 0.0.1
 
 Initial internal release (#31).

--- a/packages/platform/web/lib/src/web_platform_bootstrap.dart
+++ b/packages/platform/web/lib/src/web_platform_bootstrap.dart
@@ -4,6 +4,7 @@ import 'package:hydrated_bloc/hydrated_bloc.dart';
 import 'package:interfaces/orchestration.dart';
 import 'package:observability/observability.dart';
 import 'package:url_strategy/url_strategy.dart';
+import 'package:web_network/web_network.dart';
 
 import 'web_root_module.dart';
 
@@ -17,18 +18,28 @@ void configureWebUrlStrategy() => setPathUrlStrategy();
 /// The browser can only talk to the origin in the address bar: a server is
 /// present by construction, there is no MetaDB, no server switching, and no
 /// orchestration (confirmed #31 design). Auth is cookie-owned via
-/// `web_network`; #37 wires it, fetching the origin's [ServerIdentity]
-/// from its well-known document. A local data layer for web (drift/wasm
-/// via `web_storage`) is designed separately in #63.
+/// `web_network`; [initialize] fetches the origin's [ServerIdentity] from
+/// its well-known document and assembles the single-origin scope (#96). A
+/// local data layer for web (drift/wasm via `web_storage`) is designed
+/// separately in #63.
 class WebPlatformBootstrap implements PlatformBootstrap {
   const WebPlatformBootstrap({
     Future<void> Function(DependencyContainer container)? rootModule,
-  }) : _rootModule = rootModule;
+    Future<ActiveServerScope> Function()? serverScopeBuilder,
+  }) : _rootModule = rootModule,
+       _serverScopeBuilder = serverScopeBuilder;
 
   /// Injectable root-module seam (#69); null → [registerWebRootModule].
   /// Nullable field rather than a defaulted one so the constructor stays
   /// const for production callers.
   final Future<void> Function(DependencyContainer container)? _rootModule;
+
+  /// Injectable web-server-scope seam (#96); null → [bootstrapWebServerScope].
+  /// Nullable rather than defaulted so the constructor stays const for
+  /// production callers, and so bootstrap/cubit tests can supply a fake scope
+  /// without the live same-origin well-known fetch (`Uri.base` has no origin
+  /// on the VM).
+  final Future<ActiveServerScope> Function()? _serverScopeBuilder;
 
   /// Builds the web root container (#72): a fresh, isolated
   /// [DependencyContainerImpl] populated by the injected root module
@@ -85,9 +96,25 @@ class WebPlatformBootstrap implements PlatformBootstrap {
   @override
   LogSink createLogSink() => PrintLogSink();
 
+  /// Fetches the serving origin's identity and assembles the single-origin
+  /// server scope (#96), returning it in the [BootstrapResult].
+  ///
+  /// Web has exactly one server — the origin in the address bar — so there
+  /// is no MetaDB to open and no orchestrator to construct: [hasServer] is
+  /// always `true` and `orchestrator` is always `null`. The scope comes from
+  /// [_serverScopeBuilder] (production: [bootstrapWebServerScope], which
+  /// fetches `/.well-known/bge-identity` from the origin and wires the
+  /// cookie-based network stack).
+  ///
+  /// A well-known fetch failure propagates unchanged;
+  /// `runBgeApp`/`AppBootstrapCubit` surface it as the shared retryable
+  /// bootstrap-failure state. Web never routes to a "needs server" state — a
+  /// server exists by construction, and `/server-add` is unreachable.
   @override
-  Future<BootstrapResult> initialize() async =>
-      const BootstrapResult(hasServer: true);
+  Future<BootstrapResult> initialize() async {
+    final scope = await (_serverScopeBuilder ?? bootstrapWebServerScope)();
+    return BootstrapResult(hasServer: true, activeServerScope: scope);
+  }
 
   @override
   bool get supportsReset => false;

--- a/packages/platform/web/pubspec.yaml
+++ b/packages/platform/web/pubspec.yaml
@@ -25,20 +25,19 @@ dependencies:
     path: ../../core/observability
   connectivity_platform:
     path: ../connectivity_platform
+  web_network:
+    path: ../../network/web_network
 
   # Web-specific
   url_strategy: ^0.3.0
   hydrated_bloc: ^11.0.0
-
-  # Client version (BuildInfo, #35). package_info_plus is wasm-safe
-  # (js_interop) and reads Flutter's generated version.json on web,
-  # which derives from the app pubspec `version:` — the same source of
-  # truth as the native manifests.
   package_info_plus: ^10.2.0
 
 dev_dependencies:
   network_interface:
     path: ../../network/network_interface
+  auth:
+    path: ../../features/auth
   flutter_test:
     sdk: flutter
   very_good_analysis: ^10.2.0

--- a/packages/platform/web/test/web_auth_shell_integration_test.dart
+++ b/packages/platform/web/test/web_auth_shell_integration_test.dart
@@ -100,6 +100,10 @@ class _FakeAuthRepository implements AuthRepository {
     _currentState = next;
     if (!_controller.isClosed) _controller.add(next);
   }
+
+  /// Closes the broadcast controller so tests can tear the fake down without
+  /// leaking the sink across cases.
+  Future<void> dispose() => _controller.close();
 }
 
 const _kAuthBase = '/api/auth';
@@ -166,6 +170,7 @@ void main() {
   testWidgets('the real web bootstrap + WebActiveServerScope drive the shell '
       'to the home placeholder when a session is restored', (tester) async {
     final repo = _FakeAuthRepository(initialSession: _sampleSession());
+    addTearDown(repo.dispose);
     final cubit = buildCubit(repo);
     addTearDown(cubit.close);
 
@@ -181,6 +186,7 @@ void main() {
     tester,
   ) async {
     final repo = _FakeAuthRepository(); // no session
+    addTearDown(repo.dispose);
     final cubit = buildCubit(repo);
     addTearDown(cubit.close);
 

--- a/packages/platform/web/test/web_auth_shell_integration_test.dart
+++ b/packages/platform/web/test/web_auth_shell_integration_test.dart
@@ -1,0 +1,194 @@
+import 'dart:async';
+
+import 'package:app_shell/app_shell.dart';
+import 'package:auth/auth.dart';
+import 'package:di/di.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:interfaces/orchestration.dart';
+import 'package:interfaces/repositories.dart';
+import 'package:models/domain.dart';
+import 'package:models/dto.dart';
+import 'package:web_network/web_network.dart';
+import 'package:web_platform/web.dart';
+
+/// End-to-end wiring test for the web auth path (#96), tying the two
+/// production pieces together through the real shell:
+///
+/// - the real [WebPlatformBootstrap.initialize] (slice 2), whose injected
+///   `serverScopeBuilder` yields
+/// - the real [WebActiveServerScope] (slice 1), which the branch-free
+///   `BgeApp` auth subtree provisions the auth bloc from.
+///
+/// The generic "shell provisions the bloc from a web-shaped BootstrapResult"
+/// behavior is already covered in `app_shell`
+/// (`bge_app_auth_wiring_test.dart`); this test's distinct value is proving
+/// the *concrete* web bootstrap + web scope types integrate with the real
+/// shell — no `kIsWeb`, no hand-rolled scope stand-in.
+///
+/// Only the leaf [AuthRepository] is faked, so the auth bloc's startup
+/// session check is deterministic and offline. The real
+/// `bootstrapWebServerScope` / `registerServerNetworkWeb` / cookie transport
+/// are exercised by their own unit tests; here the scope's container simply
+/// carries a scriptable session so the gate resolves without a network.
+///
+/// `AppBootstrapCubit._attempt` calls only `initialize()` on the bootstrap
+/// (the hydrated-storage initializer is overridden with a no-op), so the
+/// real `WebPlatformBootstrap` never touches `createRootContainer`,
+/// `package_info`, or any plugin here.
+
+/// Per-server [AuthRepository] with scriptable session state, backing the
+/// auth bloc the shell provisions from the scope. Mirrors the canonical fake
+/// in `app_shell`'s auth-wiring test: seed the current state, then pipe
+/// subsequent transitions so sign-out/sign-in are observable.
+class _FakeAuthRepository implements AuthRepository {
+  _FakeAuthRepository({AuthResponse? initialSession})
+    : _session = initialSession;
+
+  AuthResponse? _session;
+  AuthState _currentState = const AuthStateUnknown();
+  final _controller = StreamController<AuthState>.broadcast();
+
+  @override
+  Future<AuthResponse?> getSession() async => _session;
+
+  @override
+  Future<void> signOut() async {
+    _session = null;
+    _setState(const AuthStateUnauthenticated());
+  }
+
+  @override
+  Future<AuthResponse> signIn({
+    required String email,
+    required String password,
+  }) async {
+    _session = _sampleSession();
+    _setState(AuthStateAuthenticated(session: _session!));
+    return _session!;
+  }
+
+  @override
+  Future<AuthResponse> signUp({
+    required String email,
+    required String password,
+    required String username,
+    String? firstName,
+    String? lastName,
+  }) async {
+    _session = _sampleSession();
+    _setState(AuthStateAuthenticated(session: _session!));
+    return _session!;
+  }
+
+  @override
+  Future<AuthResponse?> getCachedSession() async => _session;
+
+  @override
+  Stream<AuthState> watchAuthState() {
+    return Stream.multi((controller) {
+      controller.add(_currentState);
+      final sub = _controller.stream.listen(
+        controller.add,
+        onError: controller.addError,
+        onDone: controller.close,
+      );
+      controller.onCancel = sub.cancel;
+    });
+  }
+
+  void _setState(AuthState next) {
+    _currentState = next;
+    if (!_controller.isClosed) _controller.add(next);
+  }
+}
+
+const _kAuthBase = '/api/auth';
+
+ServerIdentity _identity() => ServerIdentity(
+  serverId: 'server-uuid-1',
+  issuer: 'https://bge.example.com',
+  wellKnownSchemaVersion: 1,
+  name: 'Test BGE Server',
+  deviceAuthorizationEndpoint: '$_kAuthBase/device',
+  authBasePath: _kAuthBase,
+  sessionEndpoint: '$_kAuthBase/get-session',
+  signOutEndpoint: '$_kAuthBase/sign-out',
+  passkeySupported: false,
+  twoFactorSupported: false,
+  anonymousAuthSupported: false,
+  strategies: const [
+    EmailAndPasswordStrategy(
+      signUpDisabled: false,
+      signInEndpoint: '$_kAuthBase/sign-in/email',
+      signUpEndpoint: '$_kAuthBase/sign-up/email',
+    ),
+  ],
+);
+
+AuthResponse _sampleSession() => AuthResponse(
+  token: 'tok-abc',
+  user: AuthUser(
+    id: 'u1',
+    username: 'tester',
+    email: 'u1@example.com',
+    emailVerified: true,
+    createdAt: DateTime(2099),
+    updatedAt: DateTime(2099),
+  ),
+  expiresAt: DateTime(2099).toUtc(),
+);
+
+/// Builds the origin [ActiveServer] the way the web path does — a fresh
+/// per-server container carrying the (here faked) [AuthRepository].
+ActiveServer _activeServer(AuthRepository repo) {
+  final container = DependencyContainerImpl()
+    ..registerSingleton<AuthRepository>(repo);
+  return ActiveServer(
+    serverId: 'server-uuid-1',
+    displayName: 'Test BGE Server',
+    identity: _identity(),
+    container: container,
+  );
+}
+
+void main() {
+  Future<void> noopHydrated(PlatformBootstrap _) async {}
+
+  // Real web bootstrap + real WebActiveServerScope; only the AuthRepository
+  // inside the scope's container is faked.
+  AppBootstrapCubit buildCubit(_FakeAuthRepository repo) => AppBootstrapCubit(
+    platformBootstrap: WebPlatformBootstrap(
+      serverScopeBuilder: () async => WebActiveServerScope(_activeServer(repo)),
+    ),
+    hydratedStorageInitializer: noopHydrated,
+  );
+
+  testWidgets('the real web bootstrap + WebActiveServerScope drive the shell '
+      'to the home placeholder when a session is restored', (tester) async {
+    final repo = _FakeAuthRepository(initialSession: _sampleSession());
+    final cubit = buildCubit(repo);
+    addTearDown(cubit.close);
+
+    await tester.pumpWidget(BgeApp(bootstrapCubit: cubit));
+    await cubit.initialize();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(HomePlaceholderScreen), findsOneWidget);
+    expect(find.byType(AuthScreen), findsNothing);
+  });
+
+  testWidgets('… and land on the auth screen when there is no session', (
+    tester,
+  ) async {
+    final repo = _FakeAuthRepository(); // no session
+    final cubit = buildCubit(repo);
+    addTearDown(cubit.close);
+
+    await tester.pumpWidget(BgeApp(bootstrapCubit: cubit));
+    await cubit.initialize();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AuthScreen), findsOneWidget);
+    expect(find.byType(HomePlaceholderScreen), findsNothing);
+  });
+}

--- a/packages/platform/web/test/web_platform_bootstrap_test.dart
+++ b/packages/platform/web/test/web_platform_bootstrap_test.dart
@@ -1,17 +1,24 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:interfaces/orchestration.dart';
 import 'package:web_platform/web.dart';
+
+/// A stand-in [ActiveServerScope] for the [WebPlatformBootstrap.initialize]
+/// seam tests. The production builder ([bootstrapWebServerScope]) performs a
+/// live same-origin well-known fetch, which is unavailable on the test VM
+/// (and `Uri.base` has no origin there) — the constant-holder semantics of
+/// the real web scope are covered by `web_network`'s own tests. These tests
+/// only assert that `initialize` returns whatever the builder produces.
+class _FakeActiveServerScope implements ActiveServerScope {
+  @override
+  ActiveServer? get active => null;
+
+  @override
+  Stream<ActiveServer?> watchActive() => const Stream.empty();
+}
 
 void main() {
   group('WebPlatformBootstrap', () {
     const bootstrap = WebPlatformBootstrap();
-
-    test('a server is present by construction (the serving origin) and '
-        'there is no orchestrator', () async {
-      final result = await bootstrap.initialize();
-
-      expect(result.hasServer, isTrue);
-      expect(result.orchestrator, isNull);
-    });
 
     test('never supports the destructive reset', () {
       expect(bootstrap.supportsReset, isFalse);
@@ -20,5 +27,34 @@ void main() {
     test('reset() throws UnsupportedError', () async {
       await expectLater(bootstrap.reset(), throwsUnsupportedError);
     });
+  });
+
+  group('WebPlatformBootstrap.initialize', () {
+    test('a server is present by construction (the serving origin), there '
+        'is no orchestrator, and the scope comes from the builder', () async {
+      final scope = _FakeActiveServerScope();
+      final bootstrap = WebPlatformBootstrap(
+        serverScopeBuilder: () async => scope,
+      );
+
+      final result = await bootstrap.initialize();
+
+      expect(result.hasServer, isTrue);
+      expect(result.orchestrator, isNull);
+      expect(result.activeServerScope, same(scope));
+    });
+
+    test(
+      'propagates a scope-builder failure unchanged — the shell surfaces '
+      'it as the retryable bootstrap-failure state, never "needs server"',
+      () async {
+        final bootstrap = WebPlatformBootstrap(
+          serverScopeBuilder: () async =>
+              throw StateError('well-known unreachable'),
+        );
+
+        await expectLater(bootstrap.initialize(), throwsStateError);
+      },
+    );
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -145,10 +145,16 @@ melos:
 
     # Individual app runners
     web:
-      run: melos exec -c 1 -- flutter run -d chrome
-      description: Run the browser application
-      packageFilters:
-        scope: "browser"
+      run: melos exec -c 1 --scope="browser" -- "flutter run -d web-server --web-hostname=localhost --web-port=${BGE_WEB_PORT:-5000} --no-dds"
+      description: "Serve the web app on a fixed port for the dev proxy (override with BGE_WEB_PORT; open the proxy origin, not this port)."
+
+    web:proxy:
+      run: node tool/dev_proxy/dev_proxy.mjs
+      description: "Run the zero-dep dev reverse proxy (open http://localhost:8080). Ports: BGE_PROXY_PORT/BGE_WEB_PORT/BGE_BACKEND_PORT."
+
+    web:server:
+      run: 'node tool/dev_proxy/dev_proxy.mjs & PROXY_PID=$!; trap "kill $PROXY_PID 2>/dev/null" EXIT INT TERM; melos run web'
+      description: "Run the proxy and web dev server together in one terminal (Ctrl-C stops both). Use the separate `web` + `web:proxy` scripts if you want independent logs."
 
     mobile:
       run: melos exec -c 1 -- flutter run

--- a/tool/dev_proxy/dev_proxy.mjs
+++ b/tool/dev_proxy/dev_proxy.mjs
@@ -29,10 +29,11 @@ const BACKEND_PORT = Number(process.env.BGE_BACKEND_PORT ?? 33_333); // bge back
 // sub-path of it, so '/apifoo' does NOT match '/api'.
 const BACKEND_PREFIXES = ['/api', '/.well-known'];
 
+// Callers normalize req.url once (see the handlers), so this takes a definite
+// string.
 function upstreamPortFor(url) {
-  const path = url ?? '/';
   const matchesBackend = BACKEND_PREFIXES.some(
-    (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+    (prefix) => url === prefix || url.startsWith(`${prefix}/`),
   );
   return matchesBackend ? BACKEND_PORT : WEB_PORT;
 }
@@ -41,20 +42,23 @@ function upstreamPortFor(url) {
 // forwarded verbatim so BetterAuth's origin checks and the cookie domain stay
 // consistent with what the browser actually sees.
 const server = http.createServer((req, res) => {
-  const port = upstreamPortFor(req.url);
+  // Node types req.url as string | undefined; normalize once and use the
+  // normalized value for routing, logging, and the upstream request path.
+  const url = req.url ?? '/';
+  const port = upstreamPortFor(url);
 
   // Suppress the .js asset noise, but match on the path only — asset URLs
   // routinely carry a query (main.dart.js?v=…), which endsWith('.js') misses.
-  const pathOnly = req.url.split('?')[0];
+  const pathOnly = url.split('?')[0];
   if (!pathOnly.endsWith('.js')) {
-    process.stdout.write(`[bge dev proxy] ${req.method} ${req.url} -> :${port}\n`);
+    process.stdout.write(`[bge dev proxy] ${req.method} ${url} -> :${port}\n`);
   }
   const upstream = http.request(
     {
       host: 'localhost',
       port,
       method: req.method,
-      path: req.url,
+      path: url,
       headers: req.headers,
     },
     (upstreamRes) => {
@@ -88,9 +92,10 @@ const server = http.createServer((req, res) => {
 // Upgrade/Connection headers are forwarded untouched (req.headers verbatim),
 // which is what makes the switch succeed.
 server.on('upgrade', (req, clientSocket, head) => {
-  const port = upstreamPortFor(req.url);
+  const url = req.url ?? '/';
+  const port = upstreamPortFor(url);
   const upstream = net.connect(port, 'localhost', () => {
-    const requestLine = `${req.method} ${req.url} HTTP/1.1\r\n`;
+    const requestLine = `${req.method ?? 'GET'} ${url} HTTP/1.1\r\n`;
     const headerLines = Object.entries(req.headers)
       .map(([key, value]) => `${key}: ${value}`)
       .join('\r\n');

--- a/tool/dev_proxy/dev_proxy.mjs
+++ b/tool/dev_proxy/dev_proxy.mjs
@@ -71,10 +71,11 @@ const server = http.createServer((req, res) => {
   );
 
   upstream.on('error', (error) => {
-    // Only synthesize a 502 while the response is still unstarted; once
-    // headers are sent, writeHead() would throw ERR_HTTP_HEADERS_SENT and
-    // crash the proxy, so destroy the socket instead.
-    if (res.headersSent) {
+    // Only synthesize a 502 while the response is still live and unstarted;
+    // once headers are sent writeHead() throws ERR_HTTP_HEADERS_SENT, and if
+    // the client already went away there is nothing to answer — destroy the
+    // socket instead. (Aborting the upstream below also lands here.)
+    if (res.headersSent || res.destroyed) {
       res.destroy();
       return;
     }
@@ -83,23 +84,35 @@ const server = http.createServer((req, res) => {
     res.end(`[bge dev proxy] ${target} (:${port}) unreachable: ${error.message}\n`);
   });
 
+  // Client went away (tab close / navigation) before the response finished:
+  // don't leave the upstream request hanging (accumulates sockets and noise).
+  res.on('close', () => {
+    if (!res.writableFinished) upstream.destroy();
+  });
+
   req.pipe(upstream);
 });
 
 // WebSocket upgrades (Flutter's hot-restart / DWDS channel). Node routes
 // upgrade requests here instead of the normal handler, so we open a raw TCP
 // socket to the chosen upstream, replay the handshake, and pipe both ways. The
-// Upgrade/Connection headers are forwarded untouched (req.headers verbatim),
-// which is what makes the switch succeed.
+// Upgrade/Connection headers are forwarded untouched, which is what makes the
+// switch succeed.
 server.on('upgrade', (req, clientSocket, head) => {
   const url = req.url ?? '/';
   const port = upstreamPortFor(url);
   const upstream = net.connect(port, 'localhost', () => {
     const requestLine = `${req.method ?? 'GET'} ${url} HTTP/1.1\r\n`;
-    const headerLines = Object.entries(req.headers)
-      .map(([key, value]) => `${key}: ${value}`)
-      .join('\r\n');
-    upstream.write(`${requestLine}${headerLines}\r\n\r\n`);
+    // Forward the exact header lines Node received. rawHeaders is a flat
+    // [k, v, k, v, …] list, so it preserves duplicated headers (e.g. multiple
+    // sec-websocket-protocol) and never string-joins array values or emits
+    // "undefined", unlike Object.entries(req.headers).
+    const raw = req.rawHeaders;
+    let headerLines = '';
+    for (let i = 0; i < raw.length; i += 2) {
+      headerLines += `${raw[i]}: ${raw[i + 1]}\r\n`;
+    }
+    upstream.write(`${requestLine}${headerLines}\r\n`);
     if (head && head.length) upstream.write(head);
     upstream.pipe(clientSocket);
     clientSocket.pipe(upstream);

--- a/tool/dev_proxy/dev_proxy.mjs
+++ b/tool/dev_proxy/dev_proxy.mjs
@@ -1,0 +1,115 @@
+// Zero-dependency dev reverse proxy for local web (browser) testing.
+//
+// Why this exists: the web client derives its API base from the browser
+// origin (Uri.base.origin, via WebDioFactory.currentOrigin). BetterAuth uses
+// httpOnly, same-origin session cookies. In development the Flutter web dev
+// server and the NestJS backend run on different ports, so without a proxy the
+// browser would treat them as different origins and the cookie model breaks.
+//
+// This proxy gives the browser ONE origin and fans out by path:
+//   /api/*         and  /.well-known/*   -> NestJS backend   (BGE_BACKEND_PORT)
+//   everything else (assets + hot-restart websocket) -> Flutter dev server (BGE_WEB_PORT)
+//
+// Open the browser at the PROXY origin (http://localhost:${BGE_PROXY_PORT}),
+// never the Flutter dev server directly. No client code changes are required —
+// this is purely local tooling.
+//
+// Requires Node 18+ (built-in modules only; nothing to install).
+
+import http from 'node:http';
+import net from 'node:net';
+
+const PROXY_PORT = Number(process.env.BGE_PROXY_PORT ?? 8080);
+const WEB_PORT = Number(process.env.BGE_WEB_PORT ?? 5000); // flutter dev server
+const BACKEND_PORT = Number(process.env.BGE_BACKEND_PORT ?? 33_333); // bge backend default port
+
+// Path prefixes routed to the backend. Extend if the backend serves auth or
+// other API surface outside these (e.g. add '/socket.io' when the realtime
+// features land). A request matches a prefix when it equals it exactly or is a
+// sub-path of it, so '/apifoo' does NOT match '/api'.
+const BACKEND_PREFIXES = ['/api', '/.well-known'];
+
+function upstreamPortFor(url) {
+  const path = url ?? '/';
+  const matchesBackend = BACKEND_PREFIXES.some(
+    (prefix) => path === prefix || path.startsWith(`${prefix}/`),
+  );
+  return matchesBackend ? BACKEND_PORT : WEB_PORT;
+}
+
+// Plain HTTP requests. The incoming Host header (localhost:${PROXY_PORT}) is
+// forwarded verbatim so BetterAuth's origin checks and the cookie domain stay
+// consistent with what the browser actually sees.
+const server = http.createServer((req, res) => {
+  const port = upstreamPortFor(req.url);
+
+  // Suppress the .js asset noise, but match on the path only — asset URLs
+  // routinely carry a query (main.dart.js?v=…), which endsWith('.js') misses.
+  const pathOnly = req.url.split('?')[0];
+  if (!pathOnly.endsWith('.js')) {
+    process.stdout.write(`[bge dev proxy] ${req.method} ${req.url} -> :${port}\n`);
+  }
+  const upstream = http.request(
+    {
+      host: 'localhost',
+      port,
+      method: req.method,
+      path: req.url,
+      headers: req.headers,
+    },
+    (upstreamRes) => {
+      res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
+      upstreamRes.pipe(res);
+      // A reset AFTER the body starts streaming can't become a 502 — the
+      // status line is already on the wire — so just tear the response down.
+      upstreamRes.on('error', () => res.destroy());
+    },
+  );
+
+  upstream.on('error', (error) => {
+    // Only synthesize a 502 while the response is still unstarted; once
+    // headers are sent, writeHead() would throw ERR_HTTP_HEADERS_SENT and
+    // crash the proxy, so destroy the socket instead.
+    if (res.headersSent) {
+      res.destroy();
+      return;
+    }
+    const target = port === BACKEND_PORT ? 'backend' : 'web dev server';
+    res.writeHead(502, { 'content-type': 'text/plain' });
+    res.end(`[bge dev proxy] ${target} (:${port}) unreachable: ${error.message}\n`);
+  });
+
+  req.pipe(upstream);
+});
+
+// WebSocket upgrades (Flutter's hot-restart / DWDS channel). Node routes
+// upgrade requests here instead of the normal handler, so we open a raw TCP
+// socket to the chosen upstream, replay the handshake, and pipe both ways. The
+// Upgrade/Connection headers are forwarded untouched (req.headers verbatim),
+// which is what makes the switch succeed.
+server.on('upgrade', (req, clientSocket, head) => {
+  const port = upstreamPortFor(req.url);
+  const upstream = net.connect(port, 'localhost', () => {
+    const requestLine = `${req.method} ${req.url} HTTP/1.1\r\n`;
+    const headerLines = Object.entries(req.headers)
+      .map(([key, value]) => `${key}: ${value}`)
+      .join('\r\n');
+    upstream.write(`${requestLine}${headerLines}\r\n\r\n`);
+    if (head && head.length) upstream.write(head);
+    upstream.pipe(clientSocket);
+    clientSocket.pipe(upstream);
+  });
+
+  upstream.on('error', () => clientSocket.destroy());
+  clientSocket.on('error', () => upstream.destroy());
+});
+
+server.listen(PROXY_PORT, 'localhost', () => {
+  process.stdout.write(
+    `[bge dev proxy] http://localhost:${PROXY_PORT}  ->  ` +
+    `web:${WEB_PORT}  api:${BACKEND_PORT}\n` +
+    `[bge dev proxy] backend paths: ${BACKEND_PREFIXES.join(', ')}\n` +
+    `[bge dev proxy] open the browser at http://localhost:${PROXY_PORT} ` +
+    `(NOT :${WEB_PORT})\n`,
+  );
+});


### PR DESCRIPTION
Wire the browser's single-origin auth so the shared shell's auth subtree lights up on web with no platform branching.

- web_network: WebActiveServerScope — a constant single-value ActiveServerScope holding the origin's ActiveServer (active always non-null; watchActive() replays to each subscriber then stays open). bootstrapWebServerScope fetches the origin's ServerIdentity through the WellKnownClient seam, populates a per-server container via registerServerNetworkWeb, and returns the scope; well-known failures propagate for the shell to surface as a retryable bootstrap failure.
- web_platform: WebPlatformBootstrap.initialize now assembles that scope and returns it in BootstrapResult via an injectable serverScopeBuilder seam (const production ctor preserved); depends on web_network.
- serverId/displayName sourced from ServerIdentity (server UUID / name); native still uses the client-local ServerConfig id — both opaque keys.

Tests: WebActiveServerScope holder semantics + bootstrapWebServerScope assembly (fetch, field sourcing, AuthRepository resolution, origin consistency, failure propagation); WebPlatformBootstrap.initialize seam; web_platform shell integration proving the real bootstrap + scope drive BgeApp to the auth/home screens with no kIsWeb.

No app_shell changes — the auth subtree was already scope-driven and branch-free.

chore(dev): reverse proxy for local web testing

Zero-dependency Node proxy (tool/dev_proxy/dev_proxy.mjs) that gives the browser one origin in dev — /api and /.well-known to the backend, everything else to the Flutter dev server — preserving the same-origin cookie model for manual web auth testing. Adds docs/dev/web-proxy.md.