### PR TITLE
feat(settings): add settings surface with theme-mode and language seam

### DIFF
--- a/packages/app_shell/lib/app_shell.dart
+++ b/packages/app_shell/lib/app_shell.dart
@@ -6,8 +6,9 @@
 /// pending-link slot (#10), global uncaught-error capture (#34) with the
 /// "ask each time" crash-report flow (#69) and the full review/redaction
 /// surface (#76), app-level i18n — the generated [ShellLocalizations] plus
-/// the active-locale seam (#33) — and the shell screens (splash, bootstrap
-/// failure, placeholders, not-yet-available).
+/// the active-locale seam (#33) — the shell screens (splash, bootstrap
+/// failure, placeholders, not-yet-available), and the settings surface with
+/// its persisted theme-mode and locale controllers (#120).
 ///
 /// Platform composition roots live in `packages/platform/*`; the apps under
 /// `apps/*` are thin `main.dart` wrappers that hand a [PlatformBootstrap]
@@ -35,8 +36,17 @@ export 'src/screens/bootstrap_error_screen.dart';
 export 'src/screens/feedback_flow_screen.dart';
 export 'src/screens/home_placeholder_screen.dart';
 export 'src/screens/not_yet_available_screen.dart';
+export 'src/screens/settings_screen.dart';
 export 'src/screens/shell_placeholder_screen.dart';
 export 'src/screens/splash_screen.dart';
+export 'src/settings/entries/language_settings_entry.dart';
+export 'src/settings/entries/theme_mode_settings_entry.dart';
+export 'src/settings/locale_cubit.dart';
+export 'src/settings/settings_entry.dart';
+export 'src/settings/settings_scope.dart';
+export 'src/settings/settings_section.dart';
+export 'src/settings/settings_sections_builder.dart';
+export 'src/settings/theme_mode_cubit.dart';
 export 'src/widgets/bge_app.dart';
 export 'src/widgets/build_error_view.dart';
 export 'src/widgets/crash_report_prompt.dart';

--- a/packages/app_shell/lib/l10n/intl_en.arb
+++ b/packages/app_shell/lib/l10n/intl_en.arb
@@ -199,5 +199,37 @@
   "feedbackReviewClose": "Close",
   "@feedbackReviewClose": {
     "description": "Label of the button that dismisses the review screen after a terminal outcome"
+  },
+  "settingsTitle": "Settings",
+  "@settingsTitle": {
+    "description": "Title of the settings screen; also the label of the temporary settings launcher on the home placeholder (#120)"
+  },
+  "settingsSectionGeneral": "General",
+  "@settingsSectionGeneral": {
+    "description": "Header for the always-visible, app-level settings section that holds the theme and language controls (#120)"
+  },
+  "settingsThemeModeLabel": "Theme",
+  "@settingsThemeModeLabel": {
+    "description": "Group label for the theme-mode chooser (system / light / dark) (#120)"
+  },
+  "settingsThemeModeSystem": "System default",
+  "@settingsThemeModeSystem": {
+    "description": "Theme-mode option that follows the device's light/dark setting (#120)"
+  },
+  "settingsThemeModeLight": "Light",
+  "@settingsThemeModeLight": {
+    "description": "Light theme-mode option (#120)"
+  },
+  "settingsThemeModeDark": "Dark",
+  "@settingsThemeModeDark": {
+    "description": "Dark theme-mode option (#120)"
+  },
+  "settingsLanguageLabel": "Language",
+  "@settingsLanguageLabel": {
+    "description": "Group label for the app language chooser; shown only when more than one locale is supported (#120)"
+  },
+  "settingsLanguageSystemDefault": "System default",
+  "@settingsLanguageSystemDefault": {
+    "description": "Language option that follows the device language, falling back to English when the device language is unsupported (#120)"
   }
 }

--- a/packages/app_shell/lib/src/bootstrap/run_bge_app.dart
+++ b/packages/app_shell/lib/src/bootstrap/run_bge_app.dart
@@ -99,9 +99,12 @@ import 'platform_bootstrap.dart';
 /// Theming (#32): the four theme slots ([theme], [darkTheme],
 /// [highContrastTheme], [highContrastDarkTheme]) are pure passthrough
 /// override seams — production `main.dart`s leave them null and [BgeApp]
-/// defaults them from `BgeTheme`, keeping the apps thin. [themeMode]
-/// stays [ThemeMode.system]; the user-facing selection + persistence is
-/// #78.
+/// defaults them from `BgeTheme`, keeping the apps thin. [themeMode] and
+/// [locale] seed the persisted user-preference controllers (#120): they
+/// are the fresh-install defaults and apply before hydrated storage is
+/// ready, then a stored user selection overrides them. Leaving them at
+/// their defaults ([ThemeMode.system] / null = follow-system) is the
+/// usual case.
 ///
 /// The splash route renders while bootstrap runs; hydrated-storage
 /// initialization happens inside the cubit so its failures surface on the
@@ -123,6 +126,7 @@ Future<void> runBgeApp({
   ThemeData? highContrastTheme,
   ThemeData? highContrastDarkTheme,
   ThemeMode themeMode = ThemeMode.system,
+  Locale? locale,
   List<LocalizationsDelegate<dynamic>> additionalLocalizationsDelegates =
       const [],
   UncaughtErrorReporter? uncaughtErrorReporter,
@@ -320,6 +324,7 @@ Future<void> runBgeApp({
       highContrastTheme: highContrastTheme,
       highContrastDarkTheme: highContrastDarkTheme,
       themeMode: themeMode,
+      locale: locale,
       additionalLocalizationsDelegates: additionalLocalizationsDelegates,
     ),
   );

--- a/packages/app_shell/lib/src/router/app_router.dart
+++ b/packages/app_shell/lib/src/router/app_router.dart
@@ -18,9 +18,13 @@ abstract final class AppRoutes {
   static const auth = '/auth';
   static const home = '/home';
   static const feedback = '/feedback';
+  static const settings = '/settings';
   static const error = '/error';
 
   /// The bootstrap-owned locations a ready app is bounced away from.
+  /// `settings` is deliberately absent: it is a normal post-ready
+  /// destination, not a bootstrap leg, so a ready app is not bounced off
+  /// it (#120).
   static const bootstrapLocations = {splash, error, serverAdd, auth};
 }
 
@@ -68,6 +72,20 @@ typedef AuthScreenBuilder = Widget? Function(BuildContext context);
 /// [AppBootstrapReady].
 typedef FeedbackScreenBuilder = Widget? Function(BuildContext context);
 
+/// Builds the settings surface (#120) for the [AppRoutes.settings] route.
+/// Supplied by [BgeApp]; returns null at navigation time when the
+/// app-level settings controllers are not yet available (before the first
+/// storage-ready bootstrap state, or a boot where hydrated storage was
+/// unavailable), in which case the route falls back to
+/// [NotYetAvailableScreen].
+///
+/// Like feedback, the route sits **outside** the auth [ShellRoute]
+/// (settings needs no `AuthBloc`) and is reachable only once
+/// [AppBootstrapReady] admits non-bootstrap locations. `settings` is not
+/// in [AppRoutes.bootstrapLocations], so a ready app is not bounced away
+/// from it.
+typedef SettingsScreenBuilder = Widget? Function(BuildContext context);
+
 /// Builds the application router.
 ///
 /// Redirects are driven entirely by [bootstrapCubit]'s state: while
@@ -85,6 +103,7 @@ GoRouter buildAppRouter({
   HomeScreenBuilder? homeBuilder,
   AuthScopeBuilder? authScopeBuilder,
   FeedbackScreenBuilder? feedbackBuilder,
+  SettingsScreenBuilder? settingsBuilder,
 }) {
   return GoRouter(
     initialLocation: AppRoutes.splash,
@@ -156,6 +175,15 @@ GoRouter buildAppRouter({
         path: AppRoutes.feedback,
         builder: (context, _) =>
             feedbackBuilder?.call(context) ?? const NotYetAvailableScreen(),
+      ),
+      // #120: user settings. Outside the auth ShellRoute (no AuthBloc
+      // needed — see [SettingsScreenBuilder]); reachable only when
+      // [AppBootstrapReady] admits non-bootstrap locations, and not
+      // bounced (settings is not a bootstrap location).
+      GoRoute(
+        path: AppRoutes.settings,
+        builder: (context, _) =>
+            settingsBuilder?.call(context) ?? const NotYetAvailableScreen(),
       ),
       GoRoute(
         path: AppRoutes.error,

--- a/packages/app_shell/lib/src/screens/home_placeholder_screen.dart
+++ b/packages/app_shell/lib/src/screens/home_placeholder_screen.dart
@@ -4,6 +4,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:go_router/go_router.dart';
 
+import '../../l10n/shell_localizations.dart';
 import '../router/app_router.dart';
 
 /// Temporary authenticated landing surface (#37).
@@ -19,7 +20,8 @@ import '../router/app_router.dart';
 /// widget-test host in the meantime and is removed with this screen. It
 /// pushes [AppRoutes.feedback] (rather than `go`) so back returns here.
 /// The label reuses the feedback feature's compose title — one string,
-/// one translation.
+/// one translation. The **temporary** Settings launcher (#120) sits here
+/// for the same reason and likewise pushes [AppRoutes.settings].
 ///
 /// Must be built inside the scope-keyed [AuthBloc] provider (BgeApp's
 /// home builder), so `context.read<AuthBloc>()` resolves the same
@@ -32,10 +34,16 @@ class HomePlaceholderScreen extends StatelessWidget {
     'home_placeholder.send_feedback',
   );
 
+  /// Stable finder key for the temporary #120 settings launcher.
+  static const Key openSettingsButtonKey = Key(
+    'home_placeholder.open_settings',
+  );
+
   @override
   Widget build(BuildContext context) {
     final l10n = AuthLocalizations.of(context);
     final feedbackL10n = FeedbackLocalizations.of(context);
+    final shellL10n = ShellLocalizations.of(context);
     final theme = Theme.of(context);
 
     return Scaffold(
@@ -68,6 +76,16 @@ class HomePlaceholderScreen extends StatelessWidget {
                       onPressed: () => context.push(AppRoutes.feedback),
                       icon: const Icon(Icons.feedback_outlined),
                       label: Text(feedbackL10n.feedbackComposeTitle),
+                    ),
+                  ),
+                  const SizedBox(height: 12),
+                  Semantics(
+                    button: true,
+                    child: OutlinedButton.icon(
+                      key: HomePlaceholderScreen.openSettingsButtonKey,
+                      onPressed: () => context.push(AppRoutes.settings),
+                      icon: const Icon(Icons.settings_outlined),
+                      label: Text(shellL10n.settingsTitle),
                     ),
                   ),
                   const SizedBox(height: 12),

--- a/packages/app_shell/lib/src/screens/settings_screen.dart
+++ b/packages/app_shell/lib/src/screens/settings_screen.dart
@@ -1,0 +1,97 @@
+import 'package:flutter/material.dart';
+
+import '../../l10n/shell_localizations.dart';
+import '../settings/settings_scope.dart';
+import '../settings/settings_section.dart';
+
+/// The settings surface (#120): a scrollable, accessible list of
+/// [SettingsSection]s.
+///
+/// Composition is supplied ([sections]) rather than hard-coded, so feature
+/// entries can be contributed without the screen importing their
+/// internals. Visibility rules:
+/// - a [SettingsScope.perServer] section is omitted when
+///   [activeServerAlias] is null (no active server), and otherwise
+///   rendered under a header naming that alias;
+/// - any section with no entries is omitted entirely.
+///
+/// Accessibility: entries render in a single [ListView] in declaration
+/// order (logical focus order), section headers are marked as semantic
+/// headers, and each entry supplies its own control semantics.
+class SettingsScreen extends StatelessWidget {
+  const SettingsScreen({
+    required this.sections,
+    this.activeServerAlias,
+    super.key,
+  });
+
+  /// The composed sections, in display order.
+  final List<SettingsSection> sections;
+
+  /// Display name of the active server, or null when none is active.
+  /// Gates and labels [SettingsScope.perServer] sections.
+  final String? activeServerAlias;
+
+  /// Key on the scrolling list, for tests.
+  static const Key settingsListKey = Key('settings_list');
+
+  @override
+  Widget build(BuildContext context) {
+    final i18n = ShellLocalizations.of(context);
+    final visibleSections = sections.where(_isVisible).toList(growable: false);
+
+    return Scaffold(
+      appBar: AppBar(title: Text(i18n.settingsTitle)),
+      body: SafeArea(
+        child: ListView(
+          key: settingsListKey,
+          children: [
+            for (final (index, section) in visibleSections.indexed)
+              ..._buildSection(context, section, index),
+          ],
+        ),
+      ),
+    );
+  }
+
+  bool _isVisible(SettingsSection section) {
+    if (section.entries.isEmpty) return false;
+    if (section.scope == SettingsScope.perServer && activeServerAlias == null) {
+      return false;
+    }
+    return true;
+  }
+
+  List<Widget> _buildSection(
+    BuildContext context,
+    SettingsSection section,
+    int index,
+  ) {
+    final header = switch (section.scope) {
+      // Guaranteed non-null here: perServer sections with a null alias are
+      // filtered out by [_isVisible].
+      SettingsScope.perServer => activeServerAlias,
+      SettingsScope.appLevel => section.titleBuilder?.call(context),
+    };
+
+    return [
+      if (header != null)
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 16, 16, 4),
+          child: Semantics(
+            header: true,
+            child: Text(header, style: Theme.of(context).textTheme.titleSmall),
+          ),
+        ),
+      // Namespaced by the section's position in the visible list: entries
+      // flatten into one ListView, so an id only unique *within* a section
+      // (SettingsEntry's contract) would otherwise collide across sections
+      // (e.g. an app-level and a per-server 'notifications' entry).
+      for (final entry in section.entries)
+        KeyedSubtree(
+          key: ValueKey('settings_entry_${index}_${entry.id}'),
+          child: entry.build(context),
+        ),
+    ];
+  }
+}

--- a/packages/app_shell/lib/src/settings/entries/language_settings_entry.dart
+++ b/packages/app_shell/lib/src/settings/entries/language_settings_entry.dart
@@ -1,0 +1,77 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../l10n/shell_localizations.dart';
+import '../locale_cubit.dart';
+import '../settings_entry.dart';
+
+/// The language settings entry (#120 Q5): a labelled radio group of
+/// "System default" plus one option per supported locale, backed by
+/// [LocaleCubit] (`null` state = follow system).
+///
+/// The shell only composes this entry when more than one locale is
+/// supported (see `buildSettingsSections`); at launch the app is
+/// English-only, so it is dormant. When a second locale lands (#127) it
+/// appears with no further wiring.
+///
+/// [localeLabelBuilder] supplies the display label for a locale; when
+/// absent the BCP 47 tag is shown. Proper endonym labelling is #127.
+class LanguageSettingsEntry implements SettingsEntry {
+  const LanguageSettingsEntry({
+    required this.cubit,
+    required this.supportedLocales,
+    this.localeLabelBuilder,
+  });
+
+  final LocaleCubit cubit;
+  final List<Locale> supportedLocales;
+  final String Function(BuildContext context, Locale locale)?
+  localeLabelBuilder;
+
+  @override
+  String get id => 'language';
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<LocaleCubit, Locale?>(
+      bloc: cubit,
+      builder: (context, selected) {
+        final i18n = ShellLocalizations.of(context);
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+              child: Text(
+                i18n.settingsLanguageLabel,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ),
+            RadioGroup<Locale?>(
+              groupValue: selected,
+              onChanged: cubit.select,
+              child: Column(
+                children: [
+                  RadioListTile<Locale?>(
+                    key: const Key('settings_language_system'),
+                    value: null,
+                    title: Text(i18n.settingsLanguageSystemDefault),
+                  ),
+                  for (final locale in supportedLocales)
+                    RadioListTile<Locale?>(
+                      key: Key('settings_language_${locale.toLanguageTag()}'),
+                      value: locale,
+                      title: Text(
+                        localeLabelBuilder?.call(context, locale) ??
+                            locale.toLanguageTag(),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/packages/app_shell/lib/src/settings/entries/theme_mode_settings_entry.dart
+++ b/packages/app_shell/lib/src/settings/entries/theme_mode_settings_entry.dart
@@ -1,0 +1,68 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+import '../../../l10n/shell_localizations.dart';
+import '../settings_entry.dart';
+import '../theme_mode_cubit.dart';
+
+/// The theme-mode settings entry (#120): a labelled radio group of
+/// system / light / dark, backed by [ThemeModeCubit].
+///
+/// Uses [RadioGroup] + [RadioListTile] (Flutter 3.32+) so each option
+/// carries proper radio semantics and value announcement — not a bare
+/// gesture — and inherits the theme's 48dp minimum tap target.
+class ThemeModeSettingsEntry implements SettingsEntry {
+  const ThemeModeSettingsEntry({required this.cubit});
+
+  final ThemeModeCubit cubit;
+
+  @override
+  String get id => 'theme_mode';
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<ThemeModeCubit, ThemeMode>(
+      bloc: cubit,
+      builder: (context, mode) {
+        final i18n = ShellLocalizations.of(context);
+        return Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Padding(
+              padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+              child: Text(
+                i18n.settingsThemeModeLabel,
+                style: Theme.of(context).textTheme.titleMedium,
+              ),
+            ),
+            RadioGroup<ThemeMode>(
+              groupValue: mode,
+              onChanged: (value) {
+                if (value != null) cubit.select(value);
+              },
+              child: Column(
+                children: [
+                  RadioListTile<ThemeMode>(
+                    key: const Key('settings_theme_system'),
+                    value: ThemeMode.system,
+                    title: Text(i18n.settingsThemeModeSystem),
+                  ),
+                  RadioListTile<ThemeMode>(
+                    key: const Key('settings_theme_light'),
+                    value: ThemeMode.light,
+                    title: Text(i18n.settingsThemeModeLight),
+                  ),
+                  RadioListTile<ThemeMode>(
+                    key: const Key('settings_theme_dark'),
+                    value: ThemeMode.dark,
+                    title: Text(i18n.settingsThemeModeDark),
+                  ),
+                ],
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}

--- a/packages/app_shell/lib/src/settings/locale_cubit.dart
+++ b/packages/app_shell/lib/src/settings/locale_cubit.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/widgets.dart' show Locale;
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+
+/// App-level, persisted locale *override* (#120 Q5) feeding
+/// `MaterialApp.locale`.
+///
+/// `null` means "follow the system locale": with a null `MaterialApp.locale`
+/// Flutter's resolution picks the best supported match for the device
+/// locale, falling back to the first supported locale (English) when there
+/// is no match. A non-null value is an explicit user override.
+///
+/// This is distinct from `ActiveLocaleController` (#33), which is a
+/// read-only *mirror* of the negotiated locale and cannot drive selection;
+/// the override set here flows into negotiation and the mirror reflects it.
+///
+/// [HydratedCubit] construction-timing caveat applies — see [ThemeModeCubit].
+class LocaleCubit extends HydratedCubit<Locale?> {
+  /// Seeds [initialLocale] (default `null` = follow system) — the value
+  /// used until a stored selection is hydrated, and the fresh-install
+  /// default. The embedder/`runBgeApp` value flows in here; a persisted
+  /// user selection still overrides it.
+  LocaleCubit({Locale? initialLocale}) : super(initialLocale);
+
+  /// Records an explicit locale, or `null` to follow the system locale.
+  void select(Locale? locale) => emit(locale);
+
+  @override
+  Locale? fromJson(Map<String, dynamic> json) {
+    final tag = json['languageTag'];
+    if (tag is! String || tag.isEmpty) return null;
+    return _parseLanguageTag(tag);
+  }
+
+  @override
+  Map<String, dynamic>? toJson(Locale? state) => {
+    'languageTag': state?.toLanguageTag(),
+  };
+
+  /// Pragmatic BCP 47 parse covering the tags the app emits via
+  /// [Locale.toLanguageTag]: `language`, optional 4-letter `script`, and
+  /// optional 2-letter / 3-digit `region`, in either `-` or `_` form.
+  ///
+  /// Defensive against corrupt storage: returns null (follow system) for
+  /// anything whose primary subtag is not a well-formed language code,
+  /// rather than letting [Locale.fromSubtags] assert on an empty subtag or
+  /// mint an invalid locale — matching [ThemeModeCubit]'s unknown-value
+  /// fallback. (We only ever emit 2–3 letter language codes, so the rarer
+  /// reserved/registered forms are treated as corrupt here.)
+  static Locale? _parseLanguageTag(String tag) {
+    final parts = tag.split(RegExp('[-_]'));
+    final language = parts.first.toLowerCase();
+    if (!RegExp(r'^[a-z]{2,3}$').hasMatch(language)) return null;
+    String? script;
+    String? region;
+    for (final part in parts.skip(1)) {
+      if (RegExp(r'^[A-Za-z]{4}$').hasMatch(part)) {
+        script = part[0].toUpperCase() + part.substring(1).toLowerCase();
+      } else if (RegExp(r'^[A-Za-z]{2}$').hasMatch(part) ||
+          RegExp(r'^[0-9]{3}$').hasMatch(part)) {
+        region = part.toUpperCase();
+      }
+    }
+    return Locale.fromSubtags(
+      languageCode: language,
+      scriptCode: script,
+      countryCode: region,
+    );
+  }
+}

--- a/packages/app_shell/lib/src/settings/settings_entry.dart
+++ b/packages/app_shell/lib/src/settings/settings_entry.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/widgets.dart';
+
+/// A single user-facing settings control (#120).
+///
+/// Kept app_shell-local and deliberately minimal: the shell composes
+/// entries explicitly for now (only theme + language exist), but the
+/// contract is shaped so it can be lifted to a `core/interfaces`
+/// `SettingsRegistry` later — feature packages contributing entries —
+/// without changing this surface, mirroring `UserDataExportRegistry`.
+///
+/// Implementations own their own reactivity (e.g. a `BlocBuilder` over the
+/// backing cubit); [build] is called from within the settings list.
+abstract interface class SettingsEntry {
+  /// Stable identifier, used for the entry's [Key] and focus order.
+  /// Must be unique within a section.
+  String get id;
+
+  /// Builds the entry's control. Called with a context beneath the
+  /// settings [Scaffold] and the shell [Localizations].
+  Widget build(BuildContext context);
+}

--- a/packages/app_shell/lib/src/settings/settings_scope.dart
+++ b/packages/app_shell/lib/src/settings/settings_scope.dart
@@ -1,0 +1,14 @@
+/// The two composition scopes a [SettingsSection] can belong to (#120),
+/// mirroring the app's DI topology (app-level vs. per-server).
+///
+/// The distinction is behavioural, not cosmetic: [appLevel] sections are
+/// always visible; [perServer] sections are shown only while a server is
+/// active and are rendered under a header naming that server's alias.
+enum SettingsScope {
+  /// Always visible — backed by app-level state (theme, language).
+  appLevel,
+
+  /// Visible only with an active server scope — backed by per-server
+  /// state (e.g. analytics opt-in #17, per-server notification prefs).
+  perServer,
+}

--- a/packages/app_shell/lib/src/settings/settings_section.dart
+++ b/packages/app_shell/lib/src/settings/settings_section.dart
@@ -1,0 +1,31 @@
+import 'package:flutter/widgets.dart';
+
+import 'settings_entry.dart';
+import 'settings_scope.dart';
+
+/// A titled group of [SettingsEntry]s in a given [SettingsScope] (#120).
+///
+/// The screen decides visibility from [scope]: a [SettingsScope.perServer]
+/// section is omitted when no server is active, and any section with no
+/// [entries] is omitted entirely (no empty chrome).
+class SettingsSection {
+  const SettingsSection({
+    required this.scope,
+    required this.entries,
+    this.titleBuilder,
+  });
+
+  /// Governs visibility and header treatment (see [SettingsScope]).
+  final SettingsScope scope;
+
+  /// The controls in this section, in display + focus order.
+  final List<SettingsEntry> entries;
+
+  /// Builds the section header, or null for no header.
+  ///
+  /// A builder (rather than a resolved string) so the title can come from
+  /// [Localizations] read from the build context. For
+  /// [SettingsScope.perServer] sections this is typically null — the
+  /// screen supplies the active server's alias as the header instead.
+  final String Function(BuildContext context)? titleBuilder;
+}

--- a/packages/app_shell/lib/src/settings/settings_sections_builder.dart
+++ b/packages/app_shell/lib/src/settings/settings_sections_builder.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/widgets.dart';
+
+import '../../l10n/shell_localizations.dart';
+import 'entries/language_settings_entry.dart';
+import 'entries/theme_mode_settings_entry.dart';
+import 'locale_cubit.dart';
+import 'settings_entry.dart';
+import 'settings_section.dart';
+import 'settings_scope.dart';
+import 'theme_mode_cubit.dart';
+
+/// Composes the settings sections the shell renders (#120).
+///
+/// Explicit, app_shell-local composition (Q1): the app-level section
+/// always carries the theme-mode entry, plus the language entry **only
+/// when more than one locale is supported** (Q5 visibility gate). A
+/// per-server section is always returned for structural completeness but
+/// is empty until a feature contributes a per-server entry
+/// ([perServerEntries]); `SettingsScreen` omits it when empty or when no
+/// server is active.
+List<SettingsSection> buildSettingsSections({
+  required ThemeModeCubit themeModeCubit,
+  required LocaleCubit localeCubit,
+  required List<Locale> supportedLocales,
+  String Function(BuildContext context, Locale locale)? localeLabelBuilder,
+  List<SettingsEntry> perServerEntries = const [],
+}) {
+  final appLevelEntries = <SettingsEntry>[
+    ThemeModeSettingsEntry(cubit: themeModeCubit),
+    if (supportedLocales.length > 1)
+      LanguageSettingsEntry(
+        cubit: localeCubit,
+        supportedLocales: supportedLocales,
+        localeLabelBuilder: localeLabelBuilder,
+      ),
+  ];
+
+  return [
+    SettingsSection(
+      scope: SettingsScope.appLevel,
+      titleBuilder: (context) =>
+          ShellLocalizations.of(context).settingsSectionGeneral,
+      entries: appLevelEntries,
+    ),
+    SettingsSection(scope: SettingsScope.perServer, entries: perServerEntries),
+  ];
+}

--- a/packages/app_shell/lib/src/settings/theme_mode_cubit.dart
+++ b/packages/app_shell/lib/src/settings/theme_mode_cubit.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart' show ThemeMode;
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+
+/// App-level, persisted theme-mode selection (#120; the persistence half
+/// of #78) feeding `MaterialApp.themeMode`.
+///
+/// Deliberately only system / light / dark — the high-contrast variants
+/// are an orthogonal accessibility axis selected automatically by the OS
+/// via `MaterialApp.highContrastTheme` (#32/#120 Q4), not an in-app mode.
+///
+/// This is a [HydratedCubit], so it must be constructed only after
+/// `HydratedBloc.storage` is initialized. `AppBootstrapCubit` initializes
+/// storage during bootstrap before emitting any post-init state, and the
+/// shell constructs this lazily on the first such state — never eagerly,
+/// which would call [hydrate] before storage exists and throw.
+class ThemeModeCubit extends HydratedCubit<ThemeMode> {
+  /// Seeds [initialThemeMode] (default [ThemeMode.system]) — the value
+  /// used until a stored selection is hydrated, and the fresh-install
+  /// default. The embedder/`runBgeApp` value flows in here, so an app can
+  /// set the default theme without it being discarded once storage is
+  /// ready; a persisted user selection still overrides it.
+  ThemeModeCubit({ThemeMode initialThemeMode = ThemeMode.system})
+    : super(initialThemeMode);
+
+  /// Records an explicit theme-mode choice; persisted via [toJson].
+  void select(ThemeMode mode) => emit(mode);
+
+  @override
+  ThemeMode fromJson(Map<String, dynamic> json) {
+    final name = json['themeMode'];
+    if (name is! String) return ThemeMode.system;
+    // Tolerate an unknown/removed value (e.g. a dropped high-contrast
+    // mode from an older build) by falling back rather than throwing.
+    return ThemeMode.values.asNameMap()[name] ?? ThemeMode.system;
+  }
+
+  @override
+  Map<String, dynamic>? toJson(ThemeMode state) => {'themeMode': state.name};
+}

--- a/packages/app_shell/lib/src/widgets/bge_app.dart
+++ b/packages/app_shell/lib/src/widgets/bge_app.dart
@@ -16,6 +16,7 @@ import 'package:ui_tokens/ui_tokens.dart';
 
 import '../../l10n/shell_localizations.dart';
 import '../bootstrap/app_bootstrap_cubit.dart';
+import '../bootstrap/app_bootstrap_state.dart';
 import '../deep_links/deep_link_handler.dart';
 import '../deep_links/pending_deep_link_holder.dart';
 import '../i18n/active_locale.dart';
@@ -24,7 +25,11 @@ import '../observability/shell_observability.dart';
 import '../router/app_router.dart';
 import '../screens/feedback_flow_screen.dart';
 import '../screens/home_placeholder_screen.dart';
+import '../screens/settings_screen.dart';
 import '../screens/splash_screen.dart';
+import '../settings/locale_cubit.dart';
+import '../settings/settings_sections_builder.dart';
+import '../settings/theme_mode_cubit.dart';
 import 'crash_report_prompt.dart';
 import 'feedback_review_screen.dart';
 import 'router_back_interceptor.dart';
@@ -37,8 +42,11 @@ import 'router_back_interceptor.dart';
 /// the OS "increase contrast" accessibility setting selects the
 /// high-contrast variants automatically via `MaterialApp`. OS text
 /// scaling is honored up to [BgeTextScale.maxScaleFactor] (WCAG 1.4.4:
-/// 200%) via a `MediaQuery` clamp in the app builder. [themeMode] stays
-/// [ThemeMode.system]; the user-facing selection + persistence is #78.
+/// 200%) via a `MediaQuery` clamp in the app builder. The persisted user
+/// selection drives `MaterialApp`'s `themeMode`/`locale` via app-level
+/// [HydratedCubit]s created once hydrated storage is ready (#120);
+/// [BgeApp.themeMode]/[BgeApp.locale] are the pre-storage-ready fallback
+/// and a test/embedder seam.
 ///
 /// i18n (#33): the shell owns the localization composition. Its own
 /// delegates ([ShellLocalizations.localizationsDelegates], which bundle
@@ -125,6 +133,7 @@ class BgeApp extends StatefulWidget {
     this.highContrastTheme,
     this.highContrastDarkTheme,
     this.themeMode = ThemeMode.system,
+    this.locale,
     this.additionalLocalizationsDelegates = const [],
     super.key,
   });
@@ -191,6 +200,12 @@ class BgeApp extends StatefulWidget {
   final ThemeData? highContrastDarkTheme;
 
   final ThemeMode themeMode;
+
+  /// Explicit `MaterialApp.locale` override (test/embedder seam). Null
+  /// follows system resolution. In production the persisted [LocaleCubit]
+  /// override wins once available (#120); this is the pre-storage-ready
+  /// fallback.
+  final Locale? locale;
   final List<LocalizationsDelegate<dynamic>> additionalLocalizationsDelegates;
 
   @override
@@ -226,6 +241,36 @@ class _BgeAppState extends State<BgeApp> {
   final ValueNotifier<bool> _promptDismissArmed = ValueNotifier<bool>(false);
   Timer? _promptDismissDisarmTimer;
 
+  /// App-level, persisted theme-mode + locale controllers (#120).
+  ///
+  /// Created lazily on the first storage-ready bootstrap state — never
+  /// eagerly. They are [HydratedCubit]s, and `HydratedBloc.storage` is
+  /// initialized inside `AppBootstrapCubit`'s bootstrap *before* it emits
+  /// any post-init state (see [_isStorageReady]); constructing them before
+  /// then would call `hydrate()` with no storage and throw
+  /// `StorageNotFound`, crashing before the first frame — the exact
+  /// failure the deferred storage init exists to route to the retryable
+  /// error screen. App-level (not per-server): a sign-out must not tear
+  /// them down, so they live for the app's lifetime and are closed in
+  /// [dispose]. Null until created, or if storage was unavailable, in
+  /// which case theme/locale fall back to
+  /// [BgeApp.themeMode]/[BgeApp.locale].
+  ThemeModeCubit? _themeModeCubit;
+  LocaleCubit? _localeCubit;
+  bool _settingsControllersCreated = false;
+  StreamSubscription<AppBootstrapState>? _settingsControllerSub;
+
+  /// Rebuild [MaterialApp.router] when a settings controller emits. Kept
+  /// as plain stream subscriptions (rather than wrapping the app in a
+  /// `BlocBuilder`) so the widget *structure* under [build] never changes
+  /// shape when the controllers appear: a `BlocBuilder` wrapper would only
+  /// exist once the cubits do, and swapping it in would remount the whole
+  /// `MaterialApp.router` subtree — discarding in-flight Navigator/overlay
+  /// state (e.g. a half-typed crash-prompt comment). `setState` on the
+  /// same-shaped tree updates `themeMode`/`locale` in place instead.
+  StreamSubscription<ThemeMode>? _themeModeSub;
+  StreamSubscription<Locale?>? _localeSub;
+
   @override
   void initState() {
     super.initState();
@@ -247,12 +292,28 @@ class _BgeAppState extends State<BgeApp> {
       homeBuilder: _buildHomeRoute,
       authScopeBuilder: _buildAuthScope,
       feedbackBuilder: _buildFeedbackRoute,
+      settingsBuilder: _buildSettingsRoute,
     );
     // #76/#105: keep the review slot honest whenever the crash draft
     // empties or changes identity.
     final reporter = widget.feedbackReporter;
     if (reporter != null) {
       reporter.pendingCrashReport.addListener(_handlePendingCrashChanged);
+    }
+    // #120: create the persisted theme-mode + locale controllers as soon
+    // as hydrated storage is ready (the first storage-ready bootstrap
+    // state), then keep them for the app's lifetime. See the field docs
+    // for why they cannot be constructed eagerly here. If we are already at
+    // a storage-ready state we try synchronously; otherwise (or if that
+    // attempt fails) we listen and retry on later storage-ready states,
+    // cancelling only once creation succeeds.
+    if (_isStorageReady(widget.bootstrapCubit.state)) {
+      _createSettingsControllers();
+    }
+    if (!_settingsControllersCreated) {
+      _settingsControllerSub = widget.bootstrapCubit.stream.listen(
+        _onBootstrapStateForSettings,
+      );
     }
   }
 
@@ -408,6 +469,92 @@ class _BgeAppState extends State<BgeApp> {
     );
   }
 
+  /// True once bootstrap has left the initializing/failed legs for a state
+  /// that only follows successful hydrated-storage init inside
+  /// `AppBootstrapCubit` — i.e. `HydratedBloc.storage` is guaranteed
+  /// available. `Failed` is excluded: storage init is the first bootstrap
+  /// step, so a storage failure surfaces as `Failed` with storage NOT
+  /// ready, and this must stay false there.
+  static bool _isStorageReady(AppBootstrapState state) =>
+      state is AppBootstrapNeedsServer ||
+      state is AppBootstrapNeedsAuth ||
+      state is AppBootstrapReady;
+
+  /// Constructs the app-level settings controllers exactly once, seeding
+  /// their defaults from [BgeApp.themeMode]/[BgeApp.locale] (so an embedder
+  /// default is honored on a fresh install, then overridden by any
+  /// persisted user selection). In production a storage-ready state
+  /// guarantees `HydratedBloc.storage` exists so construction succeeds;
+  /// the guard is a defensive net for tests (or an unforeseen state) that
+  /// reach a storage-ready state without initializing storage. On failure
+  /// it closes any partially constructed pair (no leaked cubit) and leaves
+  /// [_settingsControllersCreated] false so [_onBootstrapStateForSettings]
+  /// can retry on a later storage-ready state; until then theme/locale fall
+  /// back to the widget defaults rather than crashing.
+  void _createSettingsControllers() {
+    if (_settingsControllersCreated) return;
+    ThemeModeCubit? themeModeCubit;
+    LocaleCubit? localeCubit;
+    try {
+      themeModeCubit = ThemeModeCubit(initialThemeMode: widget.themeMode);
+      localeCubit = LocaleCubit(initialLocale: widget.locale);
+    } on Object {
+      // Close whatever was built (e.g. theme succeeded, locale threw) so a
+      // failed attempt never leaks a live cubit; the flag stays false to
+      // allow a retry.
+      unawaited(themeModeCubit?.close());
+      unawaited(localeCubit?.close());
+      return;
+    }
+    _settingsControllersCreated = true;
+    _themeModeCubit = themeModeCubit;
+    _localeCubit = localeCubit;
+    // Rebuild MaterialApp in place when either preference changes.
+    _themeModeSub = themeModeCubit.stream.listen((_) {
+      if (mounted) setState(() {});
+    });
+    _localeSub = localeCubit.stream.listen((_) {
+      if (mounted) setState(() {});
+    });
+  }
+
+  /// Retry-capable bootstrap-state handler for lazy settings-controller
+  /// creation. Runs on each emission until creation succeeds: ignores
+  /// non-storage-ready states, attempts creation on storage-ready ones, and
+  /// tears down the subscription (and rebuilds to bind the new values) only
+  /// once the controllers exist. A failed attempt keeps the subscription
+  /// alive so a later storage-ready state can retry.
+  void _onBootstrapStateForSettings(AppBootstrapState state) {
+    if (_settingsControllersCreated || !_isStorageReady(state)) return;
+    _createSettingsControllers();
+    if (!_settingsControllersCreated) return;
+    unawaited(_settingsControllerSub?.cancel());
+    _settingsControllerSub = null;
+    if (mounted) setState(() {});
+  }
+
+  /// Renders the #120 settings surface at navigation time. Null (→
+  /// [NotYetAvailableScreen], matching the feedback guard) until the
+  /// controllers exist. Composes the app-level section (theme; language
+  /// only when >1 supported locale) and passes the active server's alias
+  /// so the per-server section is shown/omitted correctly — at launch
+  /// there are no per-server entries, so that section is empty and omitted
+  /// by [SettingsScreen].
+  Widget? _buildSettingsRoute(BuildContext context) {
+    final themeModeCubit = _themeModeCubit;
+    final localeCubit = _localeCubit;
+    if (themeModeCubit == null || localeCubit == null) return null;
+    return SettingsScreen(
+      sections: buildSettingsSections(
+        themeModeCubit: themeModeCubit,
+        localeCubit: localeCubit,
+        supportedLocales: ShellLocalizations.supportedLocales,
+      ),
+      activeServerAlias:
+          widget.bootstrapCubit.activeServerScope?.active?.displayName,
+    );
+  }
+
   @override
   void dispose() {
     _router.dispose();
@@ -419,6 +566,11 @@ class _BgeAppState extends State<BgeApp> {
     _promptDismissDisarmTimer?.cancel();
     _promptDismissArmed.dispose();
     _reviewPreview.dispose();
+    unawaited(_settingsControllerSub?.cancel());
+    unawaited(_themeModeSub?.cancel());
+    unawaited(_localeSub?.cancel());
+    unawaited(_themeModeCubit?.close());
+    unawaited(_localeCubit?.close());
     if (widget.closeBootstrapCubitOnDispose) {
       unawaited(widget.bootstrapCubit.close());
     }
@@ -440,13 +592,27 @@ class _BgeAppState extends State<BgeApp> {
 
   @override
   Widget build(BuildContext context) {
+    // The tree shape is INVARIANT across the settings-controller lifecycle:
+    // `MaterialApp.router` is always the direct child of the bootstrap
+    // provider, whether or not the controllers exist yet. Reactivity comes
+    // from `setState` (the controllers' stream subscriptions), not from a
+    // conditionally-inserted `BlocBuilder` — inserting a wrapper when the
+    // cubits appear would remount the whole `MaterialApp.router` subtree
+    // and discard in-flight Navigator/overlay state. Once a controller
+    // exists it owns the value (seed = embedder default, then any persisted
+    // selection); before then the widget fallback applies. `locale` uses an
+    // explicit null check, not `??`, because a null controller *value*
+    // means "follow system" and must not fall back to [BgeApp.locale].
     return BlocProvider.value(
       value: widget.bootstrapCubit,
-      child: _buildMaterialApp(),
+      child: _buildMaterialApp(
+        themeMode: _themeModeCubit?.state ?? widget.themeMode,
+        locale: _localeCubit != null ? _localeCubit!.state : widget.locale,
+      ),
     );
   }
 
-  Widget _buildMaterialApp() {
+  Widget _buildMaterialApp({required ThemeMode themeMode, Locale? locale}) {
     return MaterialApp.router(
       onGenerateTitle: (context) =>
           ShellLocalizations.of(context).shellAppTitle,
@@ -456,7 +622,8 @@ class _BgeAppState extends State<BgeApp> {
           widget.highContrastTheme ?? BgeTheme.highContrastLight(),
       highContrastDarkTheme:
           widget.highContrastDarkTheme ?? BgeTheme.highContrastDark(),
-      themeMode: widget.themeMode,
+      themeMode: themeMode,
+      locale: locale,
       routerConfig: _router,
       builder: (context, child) {
         final content = child ?? const SizedBox.shrink();

--- a/packages/app_shell/test/router/settings_route_test.dart
+++ b/packages/app_shell/test/router/settings_route_test.dart
@@ -1,0 +1,113 @@
+import 'package:app_shell/app_shell.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+
+class _MockAppBootstrapCubit extends MockCubit<AppBootstrapState>
+    implements AppBootstrapCubit {}
+
+/// A marker the settings builder returns so the test can assert the route
+/// resolved to the builder rather than the [NotYetAvailableScreen]
+/// fallback.
+const _settingsMarkerKey = Key('settings_route_marker');
+
+void main() {
+  late _MockAppBootstrapCubit cubit;
+
+  setUp(() {
+    cubit = _MockAppBootstrapCubit();
+  });
+
+  Future<GoRouter> pumpRouter(
+    WidgetTester tester, {
+    required AppBootstrapState initialState,
+    SettingsScreenBuilder? settingsBuilder,
+  }) async {
+    whenListen(
+      cubit,
+      const Stream<AppBootstrapState>.empty(),
+      initialState: initialState,
+    );
+    final listenable = BootstrapStreamListenable(cubit.stream);
+    final router = buildAppRouter(
+      bootstrapCubit: cubit,
+      refreshListenable: listenable,
+      settingsBuilder: settingsBuilder,
+    );
+    addTearDown(() {
+      router.dispose();
+      listenable.dispose();
+    });
+    await tester.pumpWidget(
+      MaterialApp.router(
+        routerConfig: router,
+        localizationsDelegates: ShellLocalizations.localizationsDelegates,
+        supportedLocales: ShellLocalizations.supportedLocales,
+      ),
+    );
+    await tester.pump();
+    return router;
+  }
+
+  group('buildAppRouter — settings route (#120)', () {
+    testWidgets('resolves the settings builder when ready', (tester) async {
+      final router = await pumpRouter(
+        tester,
+        initialState: const AppBootstrapReady(),
+        settingsBuilder: (_) =>
+            const Scaffold(body: SizedBox(key: _settingsMarkerKey)),
+      );
+
+      router.go(AppRoutes.settings);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(_settingsMarkerKey), findsOneWidget);
+    });
+
+    testWidgets('falls back to NotYetAvailable when no settings builder is '
+        'supplied', (tester) async {
+      final router = await pumpRouter(
+        tester,
+        initialState: const AppBootstrapReady(),
+      );
+
+      router.go(AppRoutes.settings);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(NotYetAvailableScreen), findsOneWidget);
+    });
+
+    testWidgets('is not a bootstrap location — a ready app is not bounced off '
+        'it', (tester) async {
+      final router = await pumpRouter(
+        tester,
+        initialState: const AppBootstrapReady(),
+        settingsBuilder: (_) =>
+            const Scaffold(body: SizedBox(key: _settingsMarkerKey)),
+      );
+
+      router.go(AppRoutes.settings);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(_settingsMarkerKey), findsOneWidget);
+      expect(find.text('Home'), findsNothing);
+    });
+
+    testWidgets('is gated behind bootstrap: visiting it while unauthenticated '
+        'redirects to auth', (tester) async {
+      final router = await pumpRouter(
+        tester,
+        initialState: const AppBootstrapNeedsAuth(),
+        settingsBuilder: (_) =>
+            const Scaffold(body: SizedBox(key: _settingsMarkerKey)),
+      );
+
+      router.go(AppRoutes.settings);
+      await tester.pumpAndSettle();
+
+      expect(find.byKey(_settingsMarkerKey), findsNothing);
+      expect(find.text('Sign in'), findsOneWidget);
+    });
+  });
+}

--- a/packages/app_shell/test/screens/settings_screen_test.dart
+++ b/packages/app_shell/test/screens/settings_screen_test.dart
@@ -1,0 +1,232 @@
+import 'package:app_shell/app_shell.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:ui_tokens/ui_tokens.dart';
+
+class _MockStorage extends Mock implements Storage {}
+
+/// A minimal per-server entry for exercising per-server section
+/// visibility without any backing state.
+class _FakeEntry implements SettingsEntry {
+  const _FakeEntry();
+  @override
+  String get id => 'fake';
+  @override
+  Widget build(BuildContext context) =>
+      const Text('FAKE ENTRY', key: Key('fake_entry'));
+}
+
+void main() {
+  late ThemeModeCubit themeModeCubit;
+  late LocaleCubit localeCubit;
+
+  setUp(() {
+    final storage = _MockStorage();
+    when(() => storage.read(any())).thenReturn(null);
+    when(() => storage.write(any(), any<dynamic>())).thenAnswer((_) async {});
+    when(() => storage.delete(any())).thenAnswer((_) async {});
+    HydratedBloc.storage = storage;
+    themeModeCubit = ThemeModeCubit();
+    localeCubit = LocaleCubit();
+  });
+
+  tearDown(() {
+    themeModeCubit.close();
+    localeCubit.close();
+  });
+
+  Future<void> pumpSettings(
+    WidgetTester tester, {
+    required List<SettingsSection> sections,
+    String? activeServerAlias,
+  }) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        localizationsDelegates: ShellLocalizations.localizationsDelegates,
+        supportedLocales: ShellLocalizations.supportedLocales,
+        home: SettingsScreen(
+          sections: sections,
+          activeServerAlias: activeServerAlias,
+        ),
+      ),
+    );
+    await tester.pumpAndSettle();
+  }
+
+  List<SettingsSection> appSections({required List<Locale> supportedLocales}) =>
+      buildSettingsSections(
+        themeModeCubit: themeModeCubit,
+        localeCubit: localeCubit,
+        supportedLocales: supportedLocales,
+      );
+
+  group('SettingsScreen — composition', () {
+    testWidgets('renders the title and the app-level theme entry', (
+      tester,
+    ) async {
+      await pumpSettings(
+        tester,
+        sections: appSections(supportedLocales: const [Locale('en')]),
+      );
+
+      expect(find.text('Settings'), findsOneWidget);
+      expect(find.text('General'), findsOneWidget);
+      expect(find.text('Theme'), findsOneWidget);
+      // The three theme options render as radios.
+      expect(find.byType(RadioListTile<ThemeMode>), findsNWidgets(3));
+    });
+
+    testWidgets('omits the language entry with a single supported locale', (
+      tester,
+    ) async {
+      await pumpSettings(
+        tester,
+        sections: appSections(supportedLocales: const [Locale('en')]),
+      );
+
+      expect(find.text('Language'), findsNothing);
+    });
+
+    testWidgets('shows the language entry with more than one supported '
+        'locale', (tester) async {
+      await pumpSettings(
+        tester,
+        sections: appSections(
+          supportedLocales: const [Locale('en'), Locale('es')],
+        ),
+      );
+
+      expect(find.text('Language'), findsOneWidget);
+    });
+  });
+
+  group('SettingsScreen — per-server section visibility', () {
+    List<SettingsSection> withPerServer(List<SettingsEntry> entries) => [
+      SettingsSection(scope: SettingsScope.perServer, entries: entries),
+    ];
+
+    testWidgets('renders the per-server section under the server alias when a '
+        'server is active and it has entries', (tester) async {
+      await pumpSettings(
+        tester,
+        sections: withPerServer(const [_FakeEntry()]),
+        activeServerAlias: 'Living Room Pi',
+      );
+
+      expect(find.text('Living Room Pi'), findsOneWidget);
+      expect(find.byKey(const Key('fake_entry')), findsOneWidget);
+    });
+
+    testWidgets('omits the per-server section when no server is active', (
+      tester,
+    ) async {
+      await pumpSettings(
+        tester,
+        sections: withPerServer(const [_FakeEntry()]),
+        activeServerAlias: null,
+      );
+
+      expect(find.text('Living Room Pi'), findsNothing);
+      expect(find.byKey(const Key('fake_entry')), findsNothing);
+    });
+
+    testWidgets('omits an empty per-server section even with an active '
+        'server', (tester) async {
+      await pumpSettings(
+        tester,
+        sections: withPerServer(const []),
+        activeServerAlias: 'Living Room Pi',
+      );
+
+      expect(find.text('Living Room Pi'), findsNothing);
+    });
+  });
+
+  group('SettingsScreen — accessibility', () {
+    testWidgets('theme options expose radio semantics with their labels', (
+      tester,
+    ) async {
+      final handle = tester.ensureSemantics();
+      await pumpSettings(
+        tester,
+        sections: appSections(supportedLocales: const [Locale('en')]),
+      );
+
+      expect(find.bySemanticsLabel(RegExp('System default')), findsWidgets);
+      expect(find.bySemanticsLabel(RegExp('Light')), findsOneWidget);
+      expect(find.bySemanticsLabel(RegExp('Dark')), findsOneWidget);
+      handle.dispose();
+    });
+
+    testWidgets('entries render in declaration order (logical focus order): '
+        'theme precedes language', (tester) async {
+      await pumpSettings(
+        tester,
+        sections: appSections(
+          supportedLocales: const [Locale('en'), Locale('es')],
+        ),
+      );
+
+      final themeY = tester.getTopLeft(find.text('Theme')).dy;
+      final languageY = tester.getTopLeft(find.text('Language')).dy;
+      expect(themeY, lessThan(languageY));
+    });
+  });
+
+  group('SettingsScreen — interaction', () {
+    testWidgets('tapping a theme option updates the backing cubit', (
+      tester,
+    ) async {
+      await pumpSettings(
+        tester,
+        sections: appSections(supportedLocales: const [Locale('en')]),
+      );
+
+      await tester.tap(find.byKey(const Key('settings_theme_dark')));
+      await tester.pump();
+
+      expect(themeModeCubit.state, ThemeMode.dark);
+    });
+  });
+
+  group('theme-mode application', () {
+    testWidgets('a theme-mode selection changes the applied brightness', (
+      tester,
+    ) async {
+      await tester.pumpWidget(
+        BlocBuilder<ThemeModeCubit, ThemeMode>(
+          bloc: themeModeCubit,
+          builder: (context, mode) => MediaQuery(
+            data: const MediaQueryData(platformBrightness: Brightness.light),
+            child: MaterialApp(
+              theme: BgeTheme.light(),
+              darkTheme: BgeTheme.dark(),
+              themeMode: mode,
+              home: Builder(
+                builder: (context) => Text(
+                  Theme.of(context).brightness == Brightness.dark
+                      ? 'DARK'
+                      : 'LIGHT',
+                  textDirection: TextDirection.ltr,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('LIGHT'), findsOneWidget);
+
+      themeModeCubit.select(ThemeMode.dark);
+      // MaterialApp animates theme changes via AnimatedTheme (~200ms);
+      // ThemeData.lerp holds brightness on the old value until t >= 0.5, so
+      // a single pump() (0ms elapsed) would still read light. Settle it.
+      await tester.pumpAndSettle();
+
+      expect(find.text('DARK'), findsOneWidget);
+    });
+  });
+}

--- a/packages/app_shell/test/settings/locale_cubit_test.dart
+++ b/packages/app_shell/test/settings/locale_cubit_test.dart
@@ -1,0 +1,103 @@
+import 'dart:ui';
+
+import 'package:app_shell/app_shell.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockStorage extends Mock implements Storage {}
+
+void main() {
+  group('LocaleCubit', () {
+    late Storage storage;
+
+    setUp(() {
+      storage = _MockStorage();
+      when(() => storage.read(any())).thenReturn(null);
+      when(() => storage.write(any(), any<dynamic>())).thenAnswer((_) async {});
+      when(() => storage.delete(any())).thenAnswer((_) async {});
+      HydratedBloc.storage = storage;
+    });
+
+    test('defaults to null (follow system) when nothing is stored', () {
+      final cubit = LocaleCubit();
+      addTearDown(cubit.close);
+      expect(cubit.state, isNull);
+    });
+
+    blocTest<LocaleCubit, Locale?>(
+      'select(locale) emits it and persists its language tag',
+      build: LocaleCubit.new,
+      act: (cubit) => cubit.select(const Locale('es')),
+      expect: () => const [Locale('es')],
+      verify: (_) {
+        final captured = verify(
+          () => storage.write('LocaleCubit', captureAny()),
+        ).captured;
+        expect(captured.last, {'languageTag': 'es'});
+      },
+    );
+
+    blocTest<LocaleCubit, Locale?>(
+      'select(null) after a value returns to follow-system and persists null',
+      build: LocaleCubit.new,
+      act: (cubit) => cubit
+        ..select(const Locale('es'))
+        ..select(null),
+      expect: () => const [Locale('es'), null],
+      verify: (_) {
+        final captured = verify(
+          () => storage.write('LocaleCubit', captureAny()),
+        ).captured;
+        expect(captured.last, {'languageTag': null});
+      },
+    );
+
+    test('hydrates a plain language tag', () {
+      when(() => storage.read('LocaleCubit')).thenReturn({'languageTag': 'en'});
+      final cubit = LocaleCubit();
+      addTearDown(cubit.close);
+      expect(cubit.state, const Locale('en'));
+    });
+
+    test('hydrates a language+region tag', () {
+      when(
+        () => storage.read('LocaleCubit'),
+      ).thenReturn({'languageTag': 'de-DE'});
+      final cubit = LocaleCubit();
+      addTearDown(cubit.close);
+      expect(cubit.state, const Locale('de', 'DE'));
+    });
+
+    test('hydrates a language+script tag', () {
+      when(
+        () => storage.read('LocaleCubit'),
+      ).thenReturn({'languageTag': 'zh-Hant'});
+      final cubit = LocaleCubit();
+      addTearDown(cubit.close);
+      expect(cubit.state?.languageCode, 'zh');
+      expect(cubit.state?.scriptCode, 'Hant');
+      expect(cubit.state?.countryCode, isNull);
+    });
+
+    test('treats a null/empty stored tag as follow-system', () {
+      when(() => storage.read('LocaleCubit')).thenReturn({'languageTag': null});
+      final cubit = LocaleCubit();
+      addTearDown(cubit.close);
+      expect(cubit.state, isNull);
+    });
+
+    test('treats a corrupt stored tag as follow-system instead of throwing '
+        'or minting an invalid locale', () {
+      for (final corrupt in ['-US', '123', '@@', 'e', 'toolonglang']) {
+        when(
+          () => storage.read('LocaleCubit'),
+        ).thenReturn({'languageTag': corrupt});
+        final cubit = LocaleCubit();
+        addTearDown(cubit.close);
+        expect(cubit.state, isNull, reason: 'tag "$corrupt" should follow system');
+      }
+    });
+  });
+}

--- a/packages/app_shell/test/settings/settings_sections_builder_test.dart
+++ b/packages/app_shell/test/settings/settings_sections_builder_test.dart
@@ -1,0 +1,98 @@
+import 'package:app_shell/app_shell.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockStorage extends Mock implements Storage {}
+
+class _FakePerServerEntry implements SettingsEntry {
+  const _FakePerServerEntry();
+  @override
+  String get id => 'fake_per_server';
+  @override
+  Widget build(BuildContext context) => const SizedBox.shrink();
+}
+
+void main() {
+  group('buildSettingsSections', () {
+    late ThemeModeCubit themeModeCubit;
+    late LocaleCubit localeCubit;
+
+    setUp(() {
+      final storage = _MockStorage();
+      when(() => storage.read(any())).thenReturn(null);
+      when(() => storage.write(any(), any<dynamic>())).thenAnswer((_) async {});
+      when(() => storage.delete(any())).thenAnswer((_) async {});
+      HydratedBloc.storage = storage;
+      themeModeCubit = ThemeModeCubit();
+      localeCubit = LocaleCubit();
+    });
+
+    tearDown(() {
+      themeModeCubit.close();
+      localeCubit.close();
+    });
+
+    List<SettingsSection> build({required List<Locale> supportedLocales}) =>
+        buildSettingsSections(
+          themeModeCubit: themeModeCubit,
+          localeCubit: localeCubit,
+          supportedLocales: supportedLocales,
+        );
+
+    SettingsSection appLevelOf(List<SettingsSection> sections) =>
+        sections.firstWhere((s) => s.scope == SettingsScope.appLevel);
+
+    test('the app-level section always carries the theme-mode entry', () {
+      final sections = build(supportedLocales: const [Locale('en')]);
+      expect(
+        appLevelOf(sections).entries.map((e) => e.id),
+        contains('theme_mode'),
+      );
+    });
+
+    test('the language entry is omitted with a single supported locale', () {
+      final sections = build(supportedLocales: const [Locale('en')]);
+      expect(
+        appLevelOf(sections).entries.map((e) => e.id),
+        isNot(contains('language')),
+      );
+    });
+
+    test('the language entry appears with more than one supported locale', () {
+      final sections = build(
+        supportedLocales: const [Locale('en'), Locale('es')],
+      );
+      expect(
+        appLevelOf(sections).entries.map((e) => e.id),
+        contains('language'),
+      );
+    });
+
+    test('a per-server section is always present and empty at launch (for '
+        'the screen to omit)', () {
+      final sections = build(supportedLocales: const [Locale('en')]);
+      final perServer = sections.firstWhere(
+        (s) => s.scope == SettingsScope.perServer,
+      );
+      expect(perServer.entries, isEmpty);
+    });
+
+    test(
+      'per-server entries, when supplied, populate the per-server section',
+      () {
+        final sections = buildSettingsSections(
+          themeModeCubit: themeModeCubit,
+          localeCubit: localeCubit,
+          supportedLocales: const [Locale('en')],
+          perServerEntries: const [_FakePerServerEntry()],
+        );
+        final perServer = sections.firstWhere(
+          (s) => s.scope == SettingsScope.perServer,
+        );
+        expect(perServer.entries.map((e) => e.id), contains('fake_per_server'));
+      },
+    );
+  });
+}

--- a/packages/app_shell/test/settings/theme_mode_cubit_test.dart
+++ b/packages/app_shell/test/settings/theme_mode_cubit_test.dart
@@ -1,0 +1,67 @@
+import 'package:app_shell/app_shell.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart' show ThemeMode;
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockStorage extends Mock implements Storage {}
+
+void main() {
+  group('ThemeModeCubit', () {
+    late Storage storage;
+
+    setUp(() {
+      storage = _MockStorage();
+      when(() => storage.read(any())).thenReturn(null);
+      when(() => storage.write(any(), any<dynamic>())).thenAnswer((_) async {});
+      when(() => storage.delete(any())).thenAnswer((_) async {});
+      HydratedBloc.storage = storage;
+    });
+
+    test('defaults to ThemeMode.system when nothing is stored', () {
+      final cubit = ThemeModeCubit();
+      addTearDown(cubit.close);
+      expect(cubit.state, ThemeMode.system);
+    });
+
+    blocTest<ThemeModeCubit, ThemeMode>(
+      'select(dark) emits dark and persists {themeMode: dark}',
+      build: ThemeModeCubit.new,
+      act: (cubit) => cubit.select(ThemeMode.dark),
+      expect: () => const [ThemeMode.dark],
+      verify: (_) {
+        final captured = verify(
+          () => storage.write('ThemeModeCubit', captureAny()),
+        ).captured;
+        expect(captured.last, {'themeMode': 'dark'});
+      },
+    );
+
+    test('hydrates a stored value', () {
+      when(
+        () => storage.read('ThemeModeCubit'),
+      ).thenReturn({'themeMode': 'light'});
+      final cubit = ThemeModeCubit();
+      addTearDown(cubit.close);
+      expect(cubit.state, ThemeMode.light);
+    });
+
+    test('falls back to system on an unknown stored value (e.g. a removed '
+        'mode from an older build)', () {
+      when(
+        () => storage.read('ThemeModeCubit'),
+      ).thenReturn({'themeMode': 'highContrast'});
+      final cubit = ThemeModeCubit();
+      addTearDown(cubit.close);
+      expect(cubit.state, ThemeMode.system);
+    });
+
+    test('falls back to system on a malformed payload', () {
+      when(() => storage.read('ThemeModeCubit')).thenReturn({'themeMode': 42});
+      final cubit = ThemeModeCubit();
+      addTearDown(cubit.close);
+      expect(cubit.state, ThemeMode.system);
+    });
+  });
+}

--- a/packages/app_shell/test/widgets/bge_app_settings_test.dart
+++ b/packages/app_shell/test/widgets/bge_app_settings_test.dart
@@ -1,0 +1,118 @@
+import 'dart:async';
+
+import 'package:app_shell/app_shell.dart';
+import 'package:bloc_test/bloc_test.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hydrated_bloc/hydrated_bloc.dart';
+import 'package:mocktail/mocktail.dart';
+
+class _MockAppBootstrapCubit extends MockCubit<AppBootstrapState>
+    implements AppBootstrapCubit {}
+
+class _MockStorage extends Mock implements Storage {}
+
+/// Exercises the #120 settings wiring that lives inside [BgeApp] —
+/// `_createSettingsControllers`, `_buildSettingsRoute`, and the reactive
+/// theme/locale binding — which the whole-`runBgeApp` bootstrap test can't
+/// reach (it stubs hydrated storage to a no-op, so the controllers never
+/// get created). These drive a mock cubit to a storage-ready state with a
+/// real (mocked) `HydratedBloc.storage`, which is what makes the
+/// controllers materialize.
+void main() {
+  late _MockAppBootstrapCubit cubit;
+  late StreamController<AppBootstrapState> states;
+  late Storage storage;
+
+  setUp(() {
+    cubit = _MockAppBootstrapCubit();
+    states = StreamController<AppBootstrapState>();
+    storage = _MockStorage();
+    when(() => storage.read(any())).thenReturn(null);
+    when(() => storage.write(any(), any<dynamic>())).thenAnswer((_) async {});
+    when(() => storage.delete(any())).thenAnswer((_) async {});
+    HydratedBloc.storage = storage;
+  });
+
+  tearDown(() => states.close());
+
+  /// Pumps [BgeApp] starting at [AppBootstrapInitializing] (production's
+  /// first frame — `initialize()` suspends before `runApp`).
+  Future<void> pumpBooting(
+    WidgetTester tester, {
+    ThemeMode themeMode = ThemeMode.system,
+    Locale? locale,
+  }) async {
+    whenListen(
+      cubit,
+      states.stream,
+      initialState: const AppBootstrapInitializing(),
+    );
+    await tester.pumpWidget(
+      BgeApp(bootstrapCubit: cubit, themeMode: themeMode, locale: locale),
+    );
+    // Splash animates at Initializing, so a single frame (not settle).
+    await tester.pump();
+  }
+
+  MaterialApp materialApp(WidgetTester tester) =>
+      tester.widget<MaterialApp>(find.byType(MaterialApp));
+
+  group('BgeApp settings wiring (#120)', () {
+    testWidgets('resolves the settings route through _buildSettingsRoute once '
+        'the controllers exist', (tester) async {
+      await pumpBooting(tester);
+
+      states.add(const AppBootstrapReady());
+      await tester.pumpAndSettle();
+
+      final router = materialApp(tester).routerConfig! as GoRouter;
+      router.go(AppRoutes.settings);
+      await tester.pumpAndSettle();
+
+      expect(find.byType(SettingsScreen), findsOneWidget);
+      expect(find.byType(NotYetAvailableScreen), findsNothing);
+    });
+
+    testWidgets('honors the themeMode seed and does not discard it once '
+        'storage is ready (regression)', (tester) async {
+      await pumpBooting(tester, themeMode: ThemeMode.dark);
+      expect(materialApp(tester).themeMode, ThemeMode.dark);
+
+      states.add(const AppBootstrapReady());
+      await tester.pumpAndSettle();
+
+      // Nothing persisted (read → null), so the seed stands — it must NOT
+      // flip to ThemeMode.system when the controller is created.
+      expect(materialApp(tester).themeMode, ThemeMode.dark);
+    });
+
+    testWidgets('a persisted theme-mode overrides the seed', (tester) async {
+      when(
+        () => storage.read('ThemeModeCubit'),
+      ).thenReturn({'themeMode': 'light'});
+
+      await pumpBooting(tester, themeMode: ThemeMode.dark);
+
+      states.add(const AppBootstrapReady());
+      await tester.pumpAndSettle();
+
+      expect(materialApp(tester).themeMode, ThemeMode.light);
+    });
+
+    testWidgets('creating the controllers does not remount MaterialApp — the '
+        'element is preserved across Initializing → Ready (regression)', (
+      tester,
+    ) async {
+      await pumpBooting(tester);
+      final before = tester.element(find.byType(MaterialApp));
+
+      states.add(const AppBootstrapReady());
+      await tester.pumpAndSettle();
+
+      final after = tester.element(find.byType(MaterialApp));
+      expect(identical(before, after), isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Introduce the #120 settings scaffold and its two baseline entries.

- Section-contribution architecture (SettingsEntry / SettingsSection / SettingsScope), composed explicitly in app_shell and shaped to lift to a core/interfaces SettingsRegistry later. App-level sections are always visible; per-server sections render under the active server's alias and are omitted when no server is active or when empty. Entry keys are namespaced by section position, so ids need only be unique within a section.
- Persisted theme-mode (ThemeModeCubit, HydratedCubit) driving MaterialApp.themeMode — system/light/dark only; high contrast stays an orthogonal OS-selected axis.
- Persisted locale override (LocaleCubit, null = follow system) driving MaterialApp.locale. The language entry is fully wired but dormant, shown only when more than one locale is supported.
- Settings route registered outside the auth ShellRoute (no AuthBloc needed) and kept out of bootstrapLocations so a ready app is not bounced off it; temporary launcher on the home placeholder.
- Accessibility: RadioGroup/RadioListTile semantics, semantic section headers, and declaration-order (logical focus) layout. ARB strings added with translator descriptions.

The theme-mode and locale HydratedCubits are constructed lazily on the first storage-ready bootstrap state, not eagerly: HydratedBloc.storage is initialized inside AppBootstrapCubit before it emits any post-init state, so eager construction would call hydrate() with no storage and throw StorageNotFound pre-first-frame. BgeApp keeps an invariant widget-tree shape (MaterialApp.router is always the direct child of the bootstrap provider) and rebinds themeMode/locale via setState, so creating the controllers never remounts the MaterialApp subtree. themeMode/locale (BgeApp and runBgeApp) seed the controllers' fresh-install defaults and are overridden by any persisted selection.

Resolves #120
Refs #126, #127

## Summary by Sourcery

Introduce an app-level settings surface with persisted theme mode and locale, wired into BgeApp and the router, and backed by new settings architecture and tests.

New Features:
- Add a configurable settings screen composed from app-level and per-server sections, with temporary launcher from the home placeholder.
- Introduce persisted theme-mode and locale controllers that drive MaterialApp.themeMode and MaterialApp.locale via HydratedCubits.
- Add theme mode and language settings entries, with language selection shown only when multiple locales are supported.

Enhancements:
- Wire a new /settings route into the router outside the auth shell and expose settings-related types through the app_shell public API.
- Ensure BgeApp lazily constructs settings controllers once hydrated storage is ready without remounting MaterialApp, honoring embedder defaults.

Tests:
- Add widget and routing tests covering the settings screen composition, accessibility, interaction, and /settings route behavior.
- Add tests for ThemeModeCubit, LocaleCubit, and settings section composition, including persistence and hydration behavior.