### PR TITLE
fix(household): surface lazy user-id errors on watch streams, not syn…

### DIFF
--- a/packages/storage/drift_storage/lib/src/composition/household_scope_installer.dart
+++ b/packages/storage/drift_storage/lib/src/composition/household_scope_installer.dart
@@ -17,37 +17,27 @@ import '../repositories/sync_queue_repository_impl.dart';
 /// list, where every dependency it resolves from the container is already
 /// present.
 ///
-/// **App wiring is deliberately deferred to #129** (home menu / navigation
-/// shell), which is blocked by **#128**. The platform bootstrap
-/// (`native_platform_bootstrap.dart`) therefore still lists only
-/// `StorageScopeInstaller` and `NetworkScopeInstaller`, and nothing yet
-/// constructs `CreateHouseholdScreen` or registers `HouseholdLocalizations`:
-/// until #129 lands, `HouseholdRepository` is registered nowhere and the
-/// create slice is not reachable from the UI.
+/// ### User id is resolved lazily (#128)
 ///
-/// The deferral is not cosmetic. Adding this installer to the boot-time list
-/// as written crashes bootstrap: per-server scopes activate during
-/// `ServerOrchestrator.initialize()` — **before** sign-in — so the session
-/// read below throws and aborts activation (#128). #128 makes user-scoped
-/// per-server repositories registerable without a session (resolving the user
-/// id lazily at call time); #129 then wires the route, the l10n delegate, and
-/// this installer together behind a real menu.
+/// Per-server scopes activate during `ServerOrchestrator.initialize()` —
+/// **before** sign-in. The current user id is therefore unknown at
+/// activation and must not be read here. Instead the installer hands
+/// [HouseholdRepositoryImpl] a *provider* ([_resolveUserId]) that reads the
+/// live [AuthRepository.currentAuthState] each time a household action runs.
+/// All household actions sit behind the auth gate, so by the time the
+/// provider is invoked a session exists; if it is ever invoked without one
+/// that is a programmer error and it throws a [StateError] (rather than
+/// silently keying off an empty id).
 ///
-/// `currentUserId` is resolved once here, at activation, from the cached
-/// session ([AuthRepository.getCachedSession]); if none is present the install
-/// throws, aborting activation per the [ServerScopeInstaller] contract rather
-/// than registering a user-less repository.
-///
-/// **This eager resolution is the #128 defect** — it assumes scope activation
-/// only happens for a signed-in user, which is false: activation runs at boot,
-/// before authentication. #128 replaces it with a lazily-resolved user id
-/// (reading [AuthRepository.currentAuthState] at call time), so the scope
-/// registers pre-auth and the id is bound when a household action actually
-/// runs. Left as-is here so the fix lands as one reviewable change in #128.
+/// This replaces the previous eager `getCachedSession()` read that assumed
+/// activation only happened for a signed-in user — false, since activation
+/// runs at boot — and aborted bootstrap when it didn't (#128).
 ///
 /// The `HouseholdRemoteDataSource` the create coordinator also needs is
 /// **not** registered here — it shares the per-server Dio and is registered
-/// in `registerServerNetwork`, beside the resource it depends on.
+/// in `registerServerNetwork`, beside the resource it depends on. Wiring
+/// this installer into the platform boot list, the create route, and the
+/// `HouseholdLocalizations` delegate happens together in #129.
 class HouseholdScopeInstaller implements ServerScopeInstaller {
   const HouseholdScopeInstaller();
 
@@ -58,16 +48,7 @@ class HouseholdScopeInstaller implements ServerScopeInstaller {
   ) async {
     final db = container.get<ServerDatabase>();
     final clock = container.get<ClockService>();
-
-    final session = await container.get<AuthRepository>().getCachedSession();
-    final userId = session?.user.id;
-    if (userId == null) {
-      throw StateError(
-        'HouseholdScopeInstaller requires a signed-in session for server '
-        '"${config.bgeServerId}", but none was cached. Household scope '
-        'activation must follow authentication.',
-      );
-    }
+    final authRepository = container.get<AuthRepository>();
 
     final syncQueue = SyncQueueRepositoryImpl(db, clock);
     container.registerSingleton<SyncQueueRepository>(syncQueue);
@@ -75,10 +56,30 @@ class HouseholdScopeInstaller implements ServerScopeInstaller {
     container.registerSingleton<HouseholdRepository>(
       HouseholdRepositoryImpl(
         db: db,
-        currentUserId: userId,
+        currentUserId: () => _resolveUserId(authRepository, config),
         syncQueue: syncQueue,
         clock: clock,
       ),
+    );
+  }
+
+  /// Reads the authenticated user id from [authRepository] at call time.
+  ///
+  /// Throws a [StateError] if invoked while unauthenticated — unreachable in
+  /// normal use (household actions are gated behind sign-in), so a throw
+  /// here signals a wiring bug, not a user-facing state.
+  static String _resolveUserId(
+    AuthRepository authRepository,
+    ServerConfig config,
+  ) {
+    final state = authRepository.currentAuthState;
+    if (state is AuthStateAuthenticated) {
+      return state.session.user.id;
+    }
+    throw StateError(
+      'A household action ran for server "${config.bgeServerId}" without an '
+      'authenticated session. Household actions are only reachable behind '
+      'the auth gate; the current user id is resolved lazily at call time.',
     );
   }
 }

--- a/packages/storage/drift_storage/lib/src/repositories/household_repository_impl.dart
+++ b/packages/storage/drift_storage/lib/src/repositories/household_repository_impl.dart
@@ -8,7 +8,18 @@ import '../databases/server_database.dart';
 
 /// Read cache + cache-writer implementation of [HouseholdRepository].
 ///
-/// Scoped to a current user via [currentUserId]. Every read path that
+/// Scoped to a current user via [currentUserId] — a provider resolved
+/// **lazily at call time** (#128), never at construction. The scope
+/// installer registers this repository at boot-time server-scope
+/// activation, which runs *before* sign-in; the user id is unknown then
+/// and only becomes needed when a household action actually runs (all of
+/// them sit behind the auth gate). The `Future`-returning reads resolve
+/// the provider on every call. The `Stream`-returning `watch*` methods
+/// resolve it once when the subscription begins — surfacing an
+/// unauthenticated state as a *stream* error, not a synchronous throw —
+/// and do not re-resolve if the authenticated user changes under a live
+/// subscription; tearing per-user state down on sign-out is a separate,
+/// scope-lifecycle concern (#135). Every read path that
 /// returns household data — list, single-by-id, watch, member list,
 /// member watch — gates on the current user being a member of the
 /// household in question AND on the household itself being live
@@ -93,16 +104,21 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
   /// could then diverge on partial failure), and no test would catch it.
   HouseholdRepositoryImpl({
     required ServerDatabase db,
-    required String currentUserId,
+    required String Function() currentUserId,
     required SyncQueueRepository syncQueue,
     required ClockService clock,
   }) : _db = db,
-       _userId = currentUserId,
+       _currentUserId = currentUserId,
        _syncQueue = syncQueue,
        _clock = clock;
 
   final ServerDatabase _db;
-  final String _userId;
+
+  /// Resolves the current authenticated user id at call time (#128). The
+  /// installer wires this to the live auth state; it throws if invoked
+  /// while unauthenticated, which is a programmer error here (household
+  /// actions are only reachable behind the auth gate).
+  final String Function() _currentUserId;
   final SyncQueueRepository _syncQueue;
 
   /// Server-corrected time source (#12). Timestamps this repository
@@ -114,17 +130,7 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
 
   @override
   Future<List<Household>> getHouseholds() async {
-    final query = _db.select(_db.householdsTable).join([
-      innerJoin(
-        _db.householdMembersTable,
-        _db.householdMembersTable.householdId.equalsExp(
-              _db.householdsTable.id,
-            ) &
-            _db.householdMembersTable.userId.equals(_userId),
-      ),
-    ])..where(_db.householdsTable.deletedAt.isNull());
-
-    final rows = await query.get();
+    final rows = await _householdsQuery(_currentUserId()).get();
     return rows
         .map((r) => _mapHousehold(r.readTable(_db.householdsTable)))
         .toList();
@@ -139,7 +145,7 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
             _db.householdMembersTable.householdId.equalsExp(
                   _db.householdsTable.id,
                 ) &
-                _db.householdMembersTable.userId.equals(_userId),
+                _db.householdMembersTable.userId.equals(_currentUserId()),
           ),
         ])..where(
           _db.householdsTable.id.equals(householdId) &
@@ -154,7 +160,7 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
 
   @override
   Future<List<HouseholdMember>> getMembers(String householdId) async {
-    final rows = await _membersQuery(householdId).get();
+    final rows = await _membersQuery(householdId, _currentUserId()).get();
     return rows
         .map((r) => _mapMember(r.readTable(_db.householdMembersTable)))
         .toList();
@@ -162,10 +168,11 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
 
   @override
   Future<HouseholdMember?> getCurrentUserMember(String householdId) async {
+    final userId = _currentUserId();
     final row =
         await (_db.select(_db.householdMembersTable)..where(
               (t) =>
-                  t.householdId.equals(householdId) & t.userId.equals(_userId),
+                  t.householdId.equals(householdId) & t.userId.equals(userId),
             ))
             .getSingleOrNull();
     return row == null ? null : _mapMember(row);
@@ -261,7 +268,7 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
           .insert(
             HouseholdMembersTableCompanion.insert(
               id: cuid(),
-              userId: _userId,
+              userId: _currentUserId(),
               householdId: localId,
               roleName: Value(_encodeRole(HouseholdRole.householdOwner)),
               createdAt: now,
@@ -328,18 +335,12 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
   }
 
   @override
-  Stream<List<Household>> watchHouseholds() {
-    final query = _db.select(_db.householdsTable).join([
-      innerJoin(
-        _db.householdMembersTable,
-        _db.householdMembersTable.householdId.equalsExp(
-              _db.householdsTable.id,
-            ) &
-            _db.householdMembersTable.userId.equals(_userId),
-      ),
-    ])..where(_db.householdsTable.deletedAt.isNull());
-
-    return query.watch().map(
+  Stream<List<Household>> watchHouseholds() async* {
+    // Resolve inside the async* body: an unauthenticated [_currentUserId]
+    // throw surfaces as a stream error the caller can observe (StreamBuilder,
+    // handleError, bloc onError), not a synchronous throw at subscribe time.
+    final userId = _currentUserId();
+    yield* _householdsQuery(userId).watch().map(
       (rows) => rows
           .map((r) => _mapHousehold(r.readTable(_db.householdsTable)))
           .toList(),
@@ -347,8 +348,11 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
   }
 
   @override
-  Stream<List<HouseholdMember>> watchMembers(String householdId) {
-    return _membersQuery(householdId).watch().map(
+  Stream<List<HouseholdMember>> watchMembers(String householdId) async* {
+    // See [watchHouseholds]: resolve inside the body so an unauthenticated
+    // throw is delivered as a stream error, not synchronously at subscribe.
+    final userId = _currentUserId();
+    yield* _membersQuery(householdId, userId).watch().map(
       (rows) => rows
           .map((r) => _mapMember(r.readTable(_db.householdMembersTable)))
           .toList(),
@@ -356,6 +360,23 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
   }
 
   // ── Helpers ──────────────────────────────────────────────────────────────────────
+
+  /// Joined selectable behind [getHouseholds] / [watchHouseholds]: the
+  /// live (non-tombstoned) households that [userId] is a member of. The
+  /// caller resolves [userId] (per-call for the future, once-at-subscribe
+  /// for the stream) so the id is never read inside a synchronous query
+  /// builder on a stream path.
+  JoinedSelectStatement _householdsQuery(String userId) {
+    return _db.select(_db.householdsTable).join([
+      innerJoin(
+        _db.householdMembersTable,
+        _db.householdMembersTable.householdId.equalsExp(
+              _db.householdsTable.id,
+            ) &
+            _db.householdMembersTable.userId.equals(userId),
+      ),
+    ])..where(_db.householdsTable.deletedAt.isNull());
+  }
 
   /// Common selectable for [getMembers] and [watchMembers]: returns
   /// the members of [householdId] iff (a) the household exists and
@@ -382,7 +403,7 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
   /// TODO(visibility): when [Household.visibility] lands, public /
   /// restricted tiers can bypass the `me` self-join so non-members
   /// can browse a friend's household roster. See class doc.
-  JoinedSelectStatement _membersQuery(String householdId) {
+  JoinedSelectStatement _membersQuery(String householdId, String userId) {
     final me = _db.alias(_db.householdMembersTable, 'me');
     return _db.select(_db.householdMembersTable).join([
       innerJoin(
@@ -395,7 +416,7 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
       innerJoin(
         me,
         me.householdId.equalsExp(_db.householdMembersTable.householdId) &
-            me.userId.equals(_userId),
+            me.userId.equals(userId),
       ),
     ])..where(_db.householdMembersTable.householdId.equals(householdId));
   }

--- a/packages/storage/drift_storage/test/composition/household_scope_installer_test.dart
+++ b/packages/storage/drift_storage/test/composition/household_scope_installer_test.dart
@@ -1,0 +1,208 @@
+import 'package:di/di.dart';
+import 'package:drift_storage/drift_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:interfaces/orchestration.dart';
+import 'package:interfaces/repositories.dart';
+import 'package:interfaces/services.dart';
+import 'package:models/domain.dart';
+import 'package:models/dto.dart';
+
+import '../support/fixed_clock.dart';
+
+const _kUserId = 'user-abc';
+const _kServerId = 'server-uuid-1';
+const _kAuthBase = '/api/auth';
+
+/// Minimal [AuthRepository] whose [currentAuthState] is scriptable; only
+/// that getter is exercised by the lazy user-id provider (#128), so every
+/// other member is intentionally unimplemented.
+class _FakeAuthRepository implements AuthRepository {
+  _FakeAuthRepository(this._state);
+
+  AuthState _state;
+
+  /// Flips the scripted auth state so a test can exercise a transition
+  /// (e.g. session expiry) under one repository instance — proving the id
+  /// is resolved per call, not captured at construction.
+  set authState(AuthState next) => _state = next;
+
+  @override
+  AuthState get currentAuthState => _state;
+
+  @override
+  Future<AuthResponse?> getSession() => throw UnimplementedError();
+
+  @override
+  Future<AuthResponse?> getCachedSession() => throw UnimplementedError();
+
+  @override
+  Future<void> signOut() => throw UnimplementedError();
+
+  @override
+  Future<AuthResponse> signIn({
+    required String email,
+    required String password,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<AuthResponse> signUp({
+    required String email,
+    required String password,
+    required String username,
+    String? firstName,
+    String? lastName,
+  }) => throw UnimplementedError();
+
+  @override
+  Stream<AuthState> watchAuthState() => throw UnimplementedError();
+}
+
+AuthResponse _session() => AuthResponse(
+  token: 'tok',
+  user: AuthUser(
+    id: _kUserId,
+    username: 'tester',
+    email: 'tester@example.com',
+    emailVerified: true,
+    createdAt: DateTime.utc(2024),
+    updatedAt: DateTime.utc(2024),
+  ),
+  expiresAt: DateTime.utc(2099),
+);
+
+ServerIdentity _identity() => ServerIdentity(
+  serverId: _kServerId,
+  issuer: 'https://api.example.com',
+  wellKnownSchemaVersion: 1,
+  name: 'Test BGE Server',
+  deviceAuthorizationEndpoint: '$_kAuthBase/device',
+  authBasePath: _kAuthBase,
+  sessionEndpoint: '$_kAuthBase/get-session',
+  signOutEndpoint: '$_kAuthBase/sign-out',
+  passkeySupported: false,
+  twoFactorSupported: false,
+  anonymousAuthSupported: false,
+  strategies: const [
+    EmailAndPasswordStrategy(
+      signUpDisabled: false,
+      signInEndpoint: '$_kAuthBase/sign-in/email',
+      signUpEndpoint: '$_kAuthBase/sign-up/email',
+    ),
+  ],
+);
+
+ServerConfig _config() => ServerConfig(
+  id: 'local-1',
+  displayName: 'My Server',
+  serverUrl: 'https://api.example.com',
+  connectionState: ConnectionState.active,
+  bgeServerId: _kServerId,
+  cachedIdentity: _identity(),
+  lastIdentityFetchedAt: DateTime.utc(2024),
+);
+
+/// Builds a scope container carrying the three resources the installer
+/// resolves — the [ServerDatabase], the [ClockService] and the
+/// [AuthRepository] — mirroring what `StorageScopeInstaller` /
+/// `registerServerNetwork` register ahead of this installer in production.
+DependencyContainer _scopeContainer(AuthRepository auth) {
+  final db = ServerDatabase.memory();
+  return DependencyContainerImpl()
+    ..registerSingleton<ServerDatabase>(db, dispose: (d) => d.close())
+    ..registerSingleton<ClockService>(
+      FixedClockService(DateTime.utc(2024, 1, 15, 10, 30)),
+    )
+    ..registerSingleton<AuthRepository>(auth);
+}
+
+void main() {
+  const installer = HouseholdScopeInstaller();
+
+  test(
+    'installs without a session — activation runs before sign-in (#128)',
+    () async {
+      final container = _scopeContainer(
+        _FakeAuthRepository(const AuthStateUnknown()),
+      );
+      addTearDown(container.dispose);
+
+      // The eager getCachedSession() read this replaces would have thrown
+      // here; the lazy provider defers resolution, so install succeeds.
+      await installer.install(container, _config());
+
+      expect(container.isRegistered<HouseholdRepository>(), isTrue);
+      expect(container.isRegistered<SyncQueueRepository>(), isTrue);
+    },
+  );
+
+  test(
+    'the registered repository resolves the live user id at call time',
+    () async {
+      final container = _scopeContainer(
+        _FakeAuthRepository(AuthStateAuthenticated(session: _session())),
+      );
+      addTearDown(container.dispose);
+      await installer.install(container, _config());
+
+      final repo = container.get<HouseholdRepository>();
+
+      // getHouseholds() reads the provider internally; on the empty DB the
+      // authenticated id yields an empty result rather than throwing.
+      await expectLater(repo.getHouseholds(), completion(isEmpty));
+    },
+  );
+
+  test(
+    'a household action while unauthenticated throws (programmer error)',
+    () async {
+      final container = _scopeContainer(
+        _FakeAuthRepository(const AuthStateUnauthenticated()),
+      );
+      addTearDown(container.dispose);
+      await installer.install(container, _config());
+
+      final repo = container.get<HouseholdRepository>();
+
+      await expectLater(repo.getHouseholds(), throwsA(isA<StateError>()));
+    },
+  );
+
+  test('resolves the user id on each call, not once at construction', () async {
+    final auth = _FakeAuthRepository(
+      AuthStateAuthenticated(session: _session()),
+    );
+    final container = _scopeContainer(auth);
+    addTearDown(container.dispose);
+    await installer.install(container, _config());
+    final repo = container.get<HouseholdRepository>();
+
+    await expectLater(repo.getHouseholds(), completion(isEmpty));
+
+    // Session expires under the same repository instance; the next call
+    // must re-resolve and throw. A regression that captured the id at
+    // construction would still succeed here.
+    auth.authState = const AuthStateUnauthenticated();
+    await expectLater(repo.getHouseholds(), throwsA(isA<StateError>()));
+  });
+
+  test(
+    'watch* deliver an unauthenticated id as a stream error, not a throw',
+    () async {
+      final container = _scopeContainer(
+        _FakeAuthRepository(const AuthStateUnauthenticated()),
+      );
+      addTearDown(container.dispose);
+      await installer.install(container, _config());
+      final repo = container.get<HouseholdRepository>();
+
+      // Invoking the watch methods must not throw synchronously; the
+      // StateError has to arrive on the stream so StreamBuilder / .handleError
+      // / bloc onError can observe it.
+      await expectLater(repo.watchHouseholds(), emitsError(isA<StateError>()));
+      await expectLater(
+        repo.watchMembers('household-1'),
+        emitsError(isA<StateError>()),
+      );
+    },
+  );
+}

--- a/packages/storage/drift_storage/test/repositories/household_repository_impl_create_test.dart
+++ b/packages/storage/drift_storage/test/repositories/household_repository_impl_create_test.dart
@@ -26,7 +26,7 @@ void main() {
     syncQueue = SyncQueueRepositoryImpl(db, clock);
     repo = HouseholdRepositoryImpl(
       db: db,
-      currentUserId: _kUserId,
+      currentUserId: () => _kUserId,
       syncQueue: syncQueue,
       clock: clock,
     );

--- a/packages/storage/drift_storage/test/repositories/household_repository_impl_test.dart
+++ b/packages/storage/drift_storage/test/repositories/household_repository_impl_test.dart
@@ -66,7 +66,7 @@ void main() {
     final clock = FixedClockService(DateTime.utc(2024, 1, 15, 10, 30));
     repo = HouseholdRepositoryImpl(
       db: db,
-      currentUserId: _kUserId,
+      currentUserId: () => _kUserId,
       syncQueue: SyncQueueRepositoryImpl(db, clock),
       clock: clock,
     );

--- a/packages/storage/drift_storage/test/repositories/household_repository_sync_flags_test.dart
+++ b/packages/storage/drift_storage/test/repositories/household_repository_sync_flags_test.dart
@@ -70,7 +70,7 @@ void main() {
     final clock = FixedClockService(DateTime.utc(2024, 1, 15, 10, 30));
     repo = HouseholdRepositoryImpl(
       db: db,
-      currentUserId: _kUserId,
+      currentUserId: () => _kUserId,
       syncQueue: SyncQueueRepositoryImpl(db, clock),
       clock: clock,
     );


### PR DESCRIPTION
…chronously

The lazy currentUserId provider is invoked in the synchronous body of watchHouseholds()/watchMembers(), so an unauthenticated StateError escaped as a synchronous throw at subscribe time — StreamBuilder error snapshots, .handleError, and bloc onError all missed it. Make both watch* methods async* and resolve the provider inside the generator body so the StateError is delivered as a stream error instead. The Future-returning reads are unchanged (their async bodies already capture the throw).

Thread the resolved user id through the query builders: _householdsQuery (extracted) and _membersQuery now take it as a parameter, so the id is never read inside a synchronous stream-query builder.

Correct the repository doc: Future reads resolve the provider per call, but watch* resolve it once when the subscription begins and do not re-resolve if the authenticated user changes under a live subscription. Suspending the per-server scope on sign-out so per-user singletons rebuild is tracked in #135.

Make the installer test's fake auth state mutable and add coverage: the user id is re-resolved on each call (not captured at construction), and watch* report an unauthenticated id as a stream error.

Refs #128

## Summary by Sourcery

Resolve the current user id lazily at call time and ensure unauthenticated errors from household watch streams surface as stream errors instead of synchronous throws.

Enhancements:
- Change HouseholdRepositoryImpl to accept a user-id provider function and thread the resolved id through query helpers for both future and stream-based reads.
- Refine repository and installer documentation to describe lazy user-id resolution semantics and stream error behavior for unauthenticated states.

Tests:
- Add comprehensive tests for HouseholdScopeInstaller and HouseholdRepositoryImpl to cover lazy user-id resolution, behavior across auth state transitions, and delivery of unauthenticated errors via streams.
- Update existing repository tests to use the new user-id provider function rather than a fixed id.