### PR TITLE
feat(di): add per-user session scope nested in per-server scope

### DIFF
--- a/packages/app_shell/lib/src/widgets/bge_app.dart
+++ b/packages/app_shell/lib/src/widgets/bge_app.dart
@@ -758,6 +758,32 @@ class _BgeAppState extends State<BgeApp> {
 /// orchestration — web until #96) or has no active server, the child
 /// renders without an auth bloc; the router's placeholder builders then
 /// apply, and `onAuthenticated`/`onSignedOut` are simply never invoked.
+///
+/// ## User-session scope (#135)
+///
+/// This listener is also the single authority for the per-(server, user)
+/// dependency scope. On any transition into [AuthAuthenticated] it
+/// activates the [UserSessionScope] resolved from the active server's
+/// container for the session's user id; on any transition into
+/// [AuthUnauthenticated] — explicit sign-out *or* a mid-session
+/// authentication loss surfaced by the repository — it deactivates it, so
+/// per-user singletons and their live queries never outlive a user change.
+///
+/// Ordering differs by direction. **Sign-in**: activation completes
+/// *before* `onAuthenticated()`, so by the time the router advances to
+/// home the user's services are installed; if activation fails, the gate
+/// does **not** advance — the shell logs the failure and dispatches
+/// [AuthSignOutRequested], converging the system to a coherent
+/// unauthenticated state (an "authenticated" session whose per-user
+/// services can never resolve must not persist silently; signing back in
+/// retries from clean state). **Sign-out**: `onSignedOut()` runs first —
+/// synchronously, in the listener — and the scope pop follows, so the
+/// home subtree is already unmounting when its repositories are disposed
+/// and no live widget can dispatch into a disposed service; the pop still
+/// closes vended streams regardless of UI disposal, which is what the
+/// #135 acceptance relies on. A container with no registered
+/// [UserSessionScope] (web until #137; shell tests that don't provide
+/// one) skips the scope step entirely, keeping the prior behavior.
 class _AuthScope extends StatelessWidget {
   const _AuthScope({
     required this.scope,
@@ -770,6 +796,8 @@ class _AuthScope extends StatelessWidget {
   final VoidCallback onAuthenticated;
   final VoidCallback onSignedOut;
   final Widget child;
+
+  static final BgeLogger _log = BgeLogger('bge.shell.auth_scope');
 
   @override
   Widget build(BuildContext context) {
@@ -797,9 +825,26 @@ class _AuthScope extends StatelessWidget {
                 current is AuthAuthenticated || current is AuthUnauthenticated,
             listener: (context, state) {
               if (state is AuthAuthenticated) {
-                onAuthenticated();
+                // Captured synchronously — the async handler outlives this
+                // listener frame and needs the bloc for the sign-out
+                // fallback on activation failure.
+                final authBloc = context.read<AuthBloc>();
+                // Fire-and-forget from the framework's perspective; the
+                // ordering that matters (activation before the gate
+                // callback) is owned inside the handler, and the context
+                // serializes scope operations, so overlapping handlers
+                // cannot interleave scope mutations (#135).
+                unawaited(
+                  _handleAuthenticated(active, authBloc, state.session.user.id),
+                );
               } else if (state is AuthUnauthenticated) {
+                // Route first: the gate callback is synchronous here (its
+                // original pre-#135 semantics — a throw surfaces through
+                // the listener, not as an unhandled zone error), and the
+                // home subtree starts unmounting before the scope pop
+                // disposes its repositories.
                 onSignedOut();
+                unawaited(_deactivateSessionScope(active));
               }
             },
             child: child,
@@ -807,5 +852,77 @@ class _AuthScope extends StatelessWidget {
         );
       },
     );
+  }
+
+  /// Resolves the per-server [UserSessionScope], or null where the
+  /// platform composition hasn't registered one (web until #137).
+  UserSessionScope? _userSessionScopeOf(ActiveServer active) =>
+      active.container.isRegistered<UserSessionScope>()
+      ? active.container.get<UserSessionScope>()
+      : null;
+
+  /// Activates the user-session scope for [userId], then advances the
+  /// bootstrap gate. On activation failure the gate does **not** advance:
+  /// the failure is logged and a sign-out is dispatched so the system
+  /// converges to unauthenticated instead of stranding an authenticated
+  /// session whose per-user services can never resolve (#135) — signing
+  /// back in retries activation from a clean scope.
+  Future<void> _handleAuthenticated(
+    ActiveServer active,
+    AuthBloc authBloc,
+    String userId,
+  ) async {
+    final sessionScope = _userSessionScopeOf(active);
+    if (sessionScope != null) {
+      try {
+        await sessionScope.activate(userId);
+      } on Object catch (error, stackTrace) {
+        _log.error(
+          'User-session scope activation failed; signing out to recover',
+          error: error,
+          stackTrace: stackTrace,
+          context: {'serverId': active.serverId},
+        );
+        // The bloc may have been disposed by a server switch while the
+        // activation was in flight; there is nothing to converge then.
+        if (!authBloc.isClosed) {
+          authBloc.add(const AuthSignOutRequested());
+        }
+        return;
+      }
+    }
+    try {
+      onAuthenticated();
+    } on Object catch (error, stackTrace) {
+      // The callback runs in an unawaited async continuation; without
+      // this guard a throw (e.g. the bootstrap cubit closed during the
+      // await above) becomes an unhandled zone error.
+      _log.error(
+        'Bootstrap gate callback threw after sign-in',
+        error: error,
+        stackTrace: stackTrace,
+        context: {'serverId': active.serverId},
+      );
+    }
+  }
+
+  /// Pops the user-session scope after the gate has routed away (#135):
+  /// the departing user's services are disposed and their live streams
+  /// closed while the home subtree unmounts. Failures are logged — the
+  /// user is already signed out; a scope bug must not resurface as an
+  /// unhandled zone error.
+  Future<void> _deactivateSessionScope(ActiveServer active) async {
+    final sessionScope = _userSessionScopeOf(active);
+    if (sessionScope == null) return;
+    try {
+      await sessionScope.deactivate();
+    } on Object catch (error, stackTrace) {
+      _log.error(
+        'User-session scope deactivation failed',
+        error: error,
+        stackTrace: stackTrace,
+        context: {'serverId': active.serverId},
+      );
+    }
   }
 }

--- a/packages/app_shell/test/widgets/bge_app_user_session_wiring_test.dart
+++ b/packages/app_shell/test/widgets/bge_app_user_session_wiring_test.dart
@@ -1,0 +1,336 @@
+import 'dart:async';
+
+import 'package:app_shell/app_shell.dart';
+import 'package:auth/auth.dart';
+import 'package:di/di.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:interfaces/orchestration.dart';
+import 'package:interfaces/repositories.dart';
+import 'package:models/domain.dart';
+import 'package:models/dto.dart';
+
+import '../support/fake_platform_bootstrap.dart';
+
+/// #135 shell wiring: the auth gate listener drives the [UserSessionScope]
+/// resolved from the active server's container — activate on any transition
+/// into authenticated, deactivate on any transition out — and tolerates a
+/// container without the seam (web until #137).
+
+/// A fake per-server [AuthRepository] with scriptable session state,
+/// mirroring the fake in `bge_app_auth_wiring_test.dart`.
+class _FakeAuthRepository implements AuthRepository {
+  _FakeAuthRepository({AuthResponse? initialSession})
+    : _session = initialSession;
+
+  AuthResponse? _session;
+  AuthState _currentState = const AuthStateUnknown();
+  final _controller = StreamController<AuthState>.broadcast();
+
+  @override
+  AuthState get currentAuthState => _currentState;
+
+  @override
+  Future<AuthResponse?> getSession() async => _session;
+
+  @override
+  Future<void> signOut() async {
+    _session = null;
+    _setState(const AuthStateUnauthenticated());
+  }
+
+  @override
+  Future<AuthResponse> signIn({
+    required String email,
+    required String password,
+  }) async {
+    _session = _sampleSession();
+    _setState(AuthStateAuthenticated(session: _session!));
+    return _session!;
+  }
+
+  @override
+  Future<AuthResponse> signUp({
+    required String email,
+    required String password,
+    required String username,
+    String? firstName,
+    String? lastName,
+  }) async {
+    _session = _sampleSession();
+    _setState(AuthStateAuthenticated(session: _session!));
+    return _session!;
+  }
+
+  @override
+  Future<AuthResponse?> getCachedSession() async => _session;
+
+  @override
+  Stream<AuthState> watchAuthState() {
+    return Stream.multi((controller) {
+      controller.add(_currentState);
+      final sub = _controller.stream.listen(
+        controller.add,
+        onError: controller.addError,
+        onDone: controller.close,
+      );
+      controller.onCancel = sub.cancel;
+    });
+  }
+
+  void _setState(AuthState next) {
+    _currentState = next;
+    if (!_controller.isClosed) _controller.add(next);
+  }
+}
+
+/// Records every [UserSessionScope] call in order so the tests can assert
+/// the shell drives the seam symmetrically with the auth transitions.
+class _RecordingUserSessionScope implements UserSessionScope {
+  final calls = <String>[];
+  String? _activeUserId;
+
+  @override
+  String? get activeUserId => _activeUserId;
+
+  @override
+  Future<void> activate(String userId) async {
+    calls.add('activate:$userId');
+    _activeUserId = userId;
+  }
+
+  @override
+  Future<void> deactivate() async {
+    calls.add('deactivate');
+    _activeUserId = null;
+  }
+}
+
+/// A seam that always fails: activation failure must sign the user out
+/// (never strand an authenticated session without services), and
+/// deactivation failure must be logged without breaking the sign-out
+/// flow (#135 review).
+class _ThrowingUserSessionScope implements UserSessionScope {
+  @override
+  String? get activeUserId => null;
+
+  @override
+  Future<void> activate(String userId) async =>
+      throw StateError('activation boom');
+
+  @override
+  Future<void> deactivate() async => throw StateError('deactivation boom');
+}
+
+/// A seam whose [deactivate] completes only when the test releases it,
+/// proving the gate routes away *before* the scope pop finishes — no live
+/// home widget over disposed repositories (#135 review).
+class _GatedUserSessionScope implements UserSessionScope {
+  final deactivateGate = Completer<void>();
+  var deactivateStarted = false;
+
+  @override
+  String? get activeUserId => null;
+
+  @override
+  Future<void> activate(String userId) async {}
+
+  @override
+  Future<void> deactivate() {
+    deactivateStarted = true;
+    return deactivateGate.future;
+  }
+}
+
+/// Minimal [ActiveServerScope] emitting one fixed active server.
+class _FakeActiveServerScope implements ActiveServerScope {
+  _FakeActiveServerScope(this._active);
+  final ActiveServer _active;
+
+  @override
+  ActiveServer? get active => _active;
+
+  @override
+  Stream<ActiveServer?> watchActive() => Stream.value(_active);
+}
+
+const _kAuthBase = '/api/auth';
+
+ServerIdentity _identity() => ServerIdentity(
+  serverId: 'server-uuid-1',
+  issuer: 'https://api.example.com',
+  wellKnownSchemaVersion: 1,
+  name: 'Test BGE Server',
+  deviceAuthorizationEndpoint: '$_kAuthBase/device',
+  authBasePath: _kAuthBase,
+  sessionEndpoint: '$_kAuthBase/get-session',
+  signOutEndpoint: '$_kAuthBase/sign-out',
+  passkeySupported: false,
+  twoFactorSupported: false,
+  anonymousAuthSupported: false,
+  strategies: [
+    const EmailAndPasswordStrategy(
+      signUpDisabled: false,
+      signInEndpoint: '$_kAuthBase/sign-in/email',
+      signUpEndpoint: '$_kAuthBase/sign-up/email',
+    ),
+  ],
+);
+
+AuthResponse _sampleSession() => AuthResponse(
+  token: 'tok-abc',
+  user: AuthUser(
+    id: 'u1',
+    username: 'tester',
+    email: 'u1@example.com',
+    emailVerified: true,
+    createdAt: DateTime(2099),
+    updatedAt: DateTime(2099),
+  ),
+  expiresAt: DateTime(2099).toUtc(),
+);
+
+ActiveServer _activeServer(
+  AuthRepository repo, {
+  UserSessionScope? sessionScope,
+}) {
+  final container = DependencyContainerImpl()
+    ..registerSingleton<AuthRepository>(repo);
+  if (sessionScope != null) {
+    container.registerSingleton<UserSessionScope>(sessionScope);
+  }
+  return ActiveServer(
+    serverId: 'server-uuid-1',
+    displayName: 'My Server',
+    identity: _identity(),
+    container: container,
+  );
+}
+
+void main() {
+  Future<void> noopHydrated(PlatformBootstrap _) async {}
+
+  AppBootstrapCubit buildCubit(
+    _FakeAuthRepository repo, {
+    UserSessionScope? sessionScope,
+  }) => AppBootstrapCubit(
+    platformBootstrap: FakePlatformBootstrap(
+      activeServerScope: _FakeActiveServerScope(
+        _activeServer(repo, sessionScope: sessionScope),
+      ),
+    ),
+    hydratedStorageInitializer: noopHydrated,
+  );
+
+  testWidgets('a restored session activates the user-session scope for the '
+      'session user before home renders', (tester) async {
+    final repo = _FakeAuthRepository(initialSession: _sampleSession());
+    final sessionScope = _RecordingUserSessionScope();
+    final cubit = buildCubit(repo, sessionScope: sessionScope);
+    addTearDown(cubit.close);
+
+    await tester.pumpWidget(BgeApp(bootstrapCubit: cubit));
+    await cubit.initialize();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(HomePlaceholderScreen), findsOneWidget);
+    expect(sessionScope.calls, ['activate:u1']);
+    expect(sessionScope.activeUserId, 'u1');
+  });
+
+  testWidgets('sign-out deactivates the user-session scope', (tester) async {
+    final repo = _FakeAuthRepository(initialSession: _sampleSession());
+    final sessionScope = _RecordingUserSessionScope();
+    final cubit = buildCubit(repo, sessionScope: sessionScope);
+    addTearDown(cubit.close);
+
+    await tester.pumpWidget(BgeApp(bootstrapCubit: cubit));
+    await cubit.initialize();
+    await tester.pumpAndSettle();
+    expect(sessionScope.calls, ['activate:u1']);
+
+    await tester.tap(find.byIcon(Icons.logout));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AuthScreen), findsOneWidget);
+    expect(sessionScope.calls, ['activate:u1', 'deactivate']);
+    expect(sessionScope.activeUserId, isNull);
+  });
+
+  testWidgets('the no-session startup path only issues an idempotent '
+      'deactivate', (tester) async {
+    final repo = _FakeAuthRepository(); // no session
+    final sessionScope = _RecordingUserSessionScope();
+    final cubit = buildCubit(repo, sessionScope: sessionScope);
+    addTearDown(cubit.close);
+
+    await tester.pumpWidget(BgeApp(bootstrapCubit: cubit));
+    await cubit.initialize();
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AuthScreen), findsOneWidget);
+    // The unauthenticated startup transition drives a deactivate; the seam
+    // contract makes it a harmless no-op. No activation may occur.
+    expect(sessionScope.calls, isNot(contains(startsWith('activate:'))));
+  });
+
+  testWidgets('a container without a UserSessionScope keeps the auth flow '
+      'working (web until #137)', (tester) async {
+    final repo = _FakeAuthRepository(initialSession: _sampleSession());
+    final cubit = buildCubit(repo); // seam not registered
+    addTearDown(cubit.close);
+
+    await tester.pumpWidget(BgeApp(bootstrapCubit: cubit));
+    await cubit.initialize();
+    await tester.pumpAndSettle();
+    expect(find.byType(HomePlaceholderScreen), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.logout));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AuthScreen), findsOneWidget);
+  });
+
+  testWidgets('a failed activation signs the user out instead of stranding '
+      'an authenticated session without services', (tester) async {
+    final repo = _FakeAuthRepository(initialSession: _sampleSession());
+    final cubit = buildCubit(repo, sessionScope: _ThrowingUserSessionScope());
+    addTearDown(cubit.close);
+
+    await tester.pumpWidget(BgeApp(bootstrapCubit: cubit));
+    await cubit.initialize();
+    await tester.pumpAndSettle();
+
+    // Activation threw → the gate never advanced; the dispatched sign-out
+    // converged the session to unauthenticated. The deactivation on that
+    // sign-out transition also threw and was logged — the flow survives
+    // both.
+    expect(find.byType(HomePlaceholderScreen), findsNothing);
+    expect(find.byType(AuthScreen), findsOneWidget);
+  });
+
+  testWidgets('sign-out routes away before the scope pop completes — no '
+      'live home widget over disposed repositories', (tester) async {
+    final repo = _FakeAuthRepository(initialSession: _sampleSession());
+    final sessionScope = _GatedUserSessionScope();
+    final cubit = buildCubit(repo, sessionScope: sessionScope);
+    addTearDown(cubit.close);
+
+    await tester.pumpWidget(BgeApp(bootstrapCubit: cubit));
+    await cubit.initialize();
+    await tester.pumpAndSettle();
+    expect(find.byType(HomePlaceholderScreen), findsOneWidget);
+
+    await tester.tap(find.byIcon(Icons.logout));
+    await tester.pumpAndSettle();
+
+    // The pop is still held open by the gate, yet home is already gone.
+    expect(sessionScope.deactivateStarted, isTrue);
+    expect(find.byType(HomePlaceholderScreen), findsNothing);
+    expect(find.byType(AuthScreen), findsOneWidget);
+
+    sessionScope.deactivateGate.complete();
+    await tester.pumpAndSettle();
+    expect(find.byType(AuthScreen), findsOneWidget);
+  });
+}

--- a/packages/core/di/lib/src/server_context_impl.dart
+++ b/packages/core/di/lib/src/server_context_impl.dart
@@ -71,10 +71,12 @@ class ServerContextImpl implements ServerContext {
   ServerContextImpl({
     required ServerConfig config,
     List<ServerScopeInstaller> installers = const [],
+    List<UserScopeInstaller> userInstallers = const [],
     DependencyContainer Function()? containerFactory,
   }) : serverId = config.id,
        _config = config,
        _installers = installers,
+       _userInstallers = userInstallers,
        _container = _SwappableContainer(
          containerFactory ?? DependencyContainerImpl.new,
        ),
@@ -89,6 +91,23 @@ class ServerContextImpl implements ServerContext {
   final ServerConfig _config;
 
   final List<ServerScopeInstaller> _installers;
+  final List<UserScopeInstaller> _userInstallers;
+
+  /// The user id of the active user-session scope (#135), or null when no
+  /// session scope is active. Mirrored to consumers through the
+  /// [UserSessionScope] adapter this context registers into its container.
+  String? _activeUserId;
+
+  /// Serializes every scope mutation — state transitions AND user-session
+  /// operations (#135) — on one chain: each enqueued operation runs only
+  /// after the previous one settles, so a deactivation issued during a
+  /// background() cannot be skipped or interleaved; it simply runs after
+  /// the transition and observes the settled state. One chain also makes
+  /// deadlock structurally impossible (no operation ever awaits another's
+  /// future from inside the chain). Kept settled — errors are delivered to
+  /// the operation's own caller, never left on the chain — so [dispose]
+  /// can await it unconditionally.
+  Future<void> _scopeOps = Future<void>.value();
 
   @override
   DependencyContainer get container => _container;
@@ -133,11 +152,20 @@ class ServerContextImpl implements ServerContext {
           for (final installer in _installers) {
             await installer.install(_container, _config);
           }
+          // The per-user session lifecycle seam (#135). Registered into the
+          // per-server (base) scope on every fresh installation so the
+          // shell can resolve it like any other per-server service; the
+          // adapter delegates to this context's activateUserSession /
+          // deactivateUserSession.
+          _container.registerSingleton<UserSessionScope>(
+            _ContextUserSessionScope(this),
+          );
         } catch (_) {
           // Discard partial registrations so a retry starts from a clean
           // scope; _transition's catch rolls the state back and rethrows.
           // The reset is guarded so a throwing dispose callback (GetIt does
           // not shield them) cannot mask the real installer error.
+          _activeUserId = null;
           try {
             await _container.replaceInner();
           } catch (teardownError) {
@@ -169,8 +197,18 @@ class ServerContextImpl implements ServerContext {
     }
 
     await _transition(() async {
-      // Resources remain open during backgrounding — no-op here.
-      // The orchestrator owns the backgrounding timer.
+      // Per-server resources remain open during backgrounding — the DB,
+      // clients, and their registrations are retained for a cheap
+      // re-activation. The orchestrator owns the backgrounding timer.
+      //
+      // The user-session scope (#135) is the exception: leaving the
+      // active state ends the session. A server switch never emits an
+      // auth transition for the departing server (its AuthBloc is simply
+      // disposed by the shell's keyed provider), so nothing else would
+      // pop the scope — without this, the prior server's per-user
+      // repositories and their live queries would survive until suspend.
+      // The next sign-in state emission after re-activation rebuilds it.
+      await _teardownUserScope();
       _setState(ServerContextState.backgrounding);
     });
   }
@@ -201,6 +239,11 @@ class ServerContextImpl implements ServerContext {
       // monitoring, matching dispose()'s guarded teardown. replaceInner
       // still installs a fresh inner container even when the old one's
       // disposal throws.
+      // The user-session scope (#135) was already torn down on
+      // background(); if one somehow survived, replaceInner disposes the
+      // user scope first, then the base scope. Reset the bookkeeping so a
+      // post-resume activateUserSession starts clean.
+      _activeUserId = null;
       try {
         await _container.replaceInner();
       } catch (e) {
@@ -235,6 +278,14 @@ class ServerContextImpl implements ServerContext {
     }
     if (_state == ServerContextState.disposed) return;
 
+    // Let any queued scope operation settle too (#135) — a user installer
+    // mid-registration must not race the container teardown. The chain is
+    // kept settled, so this await cannot throw. (An operation enqueued
+    // after this point observes the disposed state itself.)
+    await _scopeOps;
+    if (_state == ServerContextState.disposed) return;
+
+    _activeUserId = null;
     _setState(ServerContextState.disposed);
     try {
       await _container.dispose();
@@ -270,6 +321,122 @@ class ServerContextImpl implements ServerContext {
     await Future<void>(() {});
   }
 
+  // ── User-session scope (#135) ────────────────────────────────────────
+
+  /// The user id of the active user-session scope, or null when none is
+  /// active. Exposed to consumers via the [UserSessionScope] adapter.
+  String? get activeUserId => _activeUserId;
+
+  /// Builds the per-user child scope for [userId]: pushes a fresh user
+  /// scope onto the container and runs every [UserScopeInstaller], in
+  /// order, against a view whose registrations land in the user scope
+  /// while resolution falls through to the per-server scope.
+  ///
+  /// - No-op when [userId] is already the active session user.
+  /// - A *different* active user is torn down first — a missed
+  ///   deactivation can't leak the prior user's services.
+  /// - Runs only after any in-flight transition or scope operation
+  ///   settles (one serialized chain), then requires the context to be
+  ///   [ServerContextState.active]; anything else is a wiring bug and
+  ///   throws [StateError] (auth UI only exists for the active server).
+  /// - On installer failure the partial user scope is discarded (the
+  ///   per-server scope is untouched) and the error propagates; a later
+  ///   call retries from a clean scope.
+  ///
+  /// Serialized with [deactivateUserSession] and every state transition
+  /// through [_scopeOps].
+  Future<void> activateUserSession(String userId) {
+    return _enqueueScopeOp(() async {
+      _assertNotDisposed();
+      if (_state != ServerContextState.active) {
+        throw StateError(
+          'Cannot activate a user session for $serverId in state $_state. '
+          'User sessions are only valid on an active context.',
+        );
+      }
+      if (_activeUserId == userId) return;
+
+      // Defensive: a different user's scope without an intervening
+      // deactivation. Tear it down before building the new one.
+      await _teardownUserScope();
+
+      final view = _container.beginUserScope();
+      try {
+        for (final installer in _userInstallers) {
+          await installer.install(view, _config, userId);
+        }
+      } catch (_) {
+        // Discard the partial user scope so a retry starts clean; the
+        // per-server scope is untouched. Guarded so a throwing dispose
+        // callback cannot mask the real installer error.
+        try {
+          await _container.endUserScope();
+        } catch (teardownError) {
+          assert(() {
+            debugPrint(
+              'ServerContext($serverId): user-scope reset after a failed '
+              'session activation threw (suppressed in favor of the '
+              'original installer error): $teardownError',
+            );
+            return true;
+          }());
+        }
+        rethrow;
+      }
+      _activeUserId = userId;
+    });
+  }
+
+  /// Tears the active user-session scope down, disposing every service its
+  /// installers registered (their `dispose:` callbacks run — the seam
+  /// through which per-user repositories close their vended streams).
+  ///
+  /// Best-effort and idempotent: a no-op when the context is disposed or
+  /// no user scope is active. Never skipped: the shared [_scopeOps] chain
+  /// queues it behind any in-flight transition, after which it observes
+  /// the settled state — post-suspend/dispose the scope already died with
+  /// the container (no-op); post-background the scope was torn down by
+  /// [background] itself (no-op). A live scope found here is disposed
+  /// regardless of state, so a sign-out can never be silently dropped.
+  Future<void> deactivateUserSession() {
+    return _enqueueScopeOp(() async {
+      if (_state == ServerContextState.disposed) {
+        _activeUserId = null;
+        return;
+      }
+      await _teardownUserScope();
+    });
+  }
+
+  /// Chains [op] onto [_scopeOps] and keeps the chain settled.
+  Future<void> _enqueueScopeOp(Future<void> Function() op) {
+    final result = _scopeOps.then((_) => op());
+    _scopeOps = result.then<void>(
+      (_) {},
+      onError: (Object _) {}, // the caller of [op] receives the error
+    );
+    return result;
+  }
+
+  /// Disposes the current user scope, if any, mirroring [suspend]'s guarded
+  /// teardown: a throwing dispose callback is logged, never rethrown, so
+  /// the session still ends and the next activation starts clean.
+  Future<void> _teardownUserScope() async {
+    _activeUserId = null;
+    if (!_container.hasUserScope) return;
+    try {
+      await _container.endUserScope();
+    } catch (e) {
+      assert(() {
+        debugPrint(
+          'ServerContext($serverId): user-scope disposal threw during '
+          'session deactivation: $e',
+        );
+        return true;
+      }());
+    }
+  }
+
   @override
   Stream<ServerContextState> watchState() {
     // Stream.multi runs the callback synchronously on each listen(),
@@ -302,7 +469,7 @@ class ServerContextImpl implements ServerContext {
     }
 
     _transitioning = true;
-    final future = _runTransition(body);
+    final future = _enqueueScopeOp(() => _runTransition(body));
     _inFlightTransition = future;
     try {
       await future;
@@ -363,6 +530,15 @@ class _SwappableContainer implements DependencyContainer {
   /// activation follow the identical code path.
   DependencyContainer? _inner;
 
+  /// The per-user child scope (#135), or null when no user session is
+  /// active. Resolution through this facade checks the user scope first,
+  /// then falls through to the base scope, so per-user registrations are
+  /// visible through the one stable `context.container` handle without any
+  /// change to the [DependencyContainer] interface. Registrations made
+  /// *through the facade* still land in the base scope — the user scope is
+  /// only written via the view [beginUserScope] hands to user installers.
+  DependencyContainer? _userScope;
+
   bool _disposed = false;
 
   DependencyContainer get _current {
@@ -374,16 +550,81 @@ class _SwappableContainer implements DependencyContainer {
     return _inner ??= _factory();
   }
 
+  /// Whether a user-session scope is currently active (#135).
+  bool get hasUserScope => _userScope != null;
+
+  /// Opens the per-user child scope and returns the container **view** to
+  /// hand to user installers: registrations land in the user scope while
+  /// resolution falls through to the base scope (#135).
+  ///
+  /// Throws [StateError] if a user scope is already open (the context
+  /// tears the previous one down first) or the facade is disposed.
+  DependencyContainer beginUserScope() {
+    if (_disposed) {
+      throw StateError(
+        'DependencyContainer has been disposed and cannot be used.',
+      );
+    }
+    if (_userScope != null) {
+      throw StateError(
+        'A user-session scope is already active; deactivate it before '
+        'activating another.',
+      );
+    }
+    final child = _factory();
+    _userScope = child;
+    return _UserScopeView(user: child, base: () => _current);
+  }
+
+  /// Disposes the current user scope (running every registration's dispose
+  /// callback) and detaches it. No-op when none is active (#135).
+  Future<void> endUserScope() async {
+    final user = _userScope;
+    _userScope = null;
+    if (user != null) await user.dispose();
+  }
+
   /// Disposes the current inner container (running every registration's
-  /// dispose callback) and prepares a fresh one for subsequent use.
+  /// dispose callback) and prepares a fresh one for subsequent use. The
+  /// user-session scope, being a child of the inner container's lifetime,
+  /// is torn down first (#135) — per-user services may hold resources from
+  /// the base scope (the per-server DB), so they must release before it.
+  /// Both disposals always run; the first error, if any, is rethrown.
   Future<void> replaceInner() async {
+    final user = _userScope;
+    _userScope = null;
     final old = _inner;
     _inner = null;
-    if (old != null) await old.dispose();
+
+    Object? firstError;
+    StackTrace? firstStackTrace;
+    if (user != null) {
+      try {
+        await user.dispose();
+      } catch (e, s) {
+        firstError = e;
+        firstStackTrace = s;
+      }
+    }
+    if (old != null) {
+      try {
+        await old.dispose();
+      } catch (e, s) {
+        firstError ??= e;
+        firstStackTrace ??= s;
+      }
+    }
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError, firstStackTrace!);
+    }
   }
 
   @override
-  T get<T extends Object>() => _current.get<T>();
+  T get<T extends Object>() {
+    final user = _userScope;
+    if (user != null && user.isRegistered<T>()) return user.get<T>();
+    return _current.get<T>();
+  }
 
   @override
   void registerSingleton<T extends Object>(
@@ -402,18 +643,115 @@ class _SwappableContainer implements DependencyContainer {
       _current.registerFactory<T>(factory);
 
   @override
-  bool isRegistered<T extends Object>() => _current.isRegistered<T>();
+  bool isRegistered<T extends Object>() =>
+      (_userScope?.isRegistered<T>() ?? false) || _current.isRegistered<T>();
 
   @override
   Future<void> dispose() async {
     // Terminal and idempotent. If no inner container was ever created there
     // is nothing to dispose — and none is constructed just to be torn down.
+    // The user scope, if any, goes first for the same reason as
+    // [replaceInner]; both disposals always run.
     if (_disposed) return;
     _disposed = true;
+    final user = _userScope;
+    _userScope = null;
     final old = _inner;
     _inner = null;
-    if (old != null) await old.dispose();
+
+    Object? firstError;
+    StackTrace? firstStackTrace;
+    if (user != null) {
+      try {
+        await user.dispose();
+      } catch (e, s) {
+        firstError = e;
+        firstStackTrace = s;
+      }
+    }
+    if (old != null) {
+      try {
+        await old.dispose();
+      } catch (e, s) {
+        firstError ??= e;
+        firstStackTrace ??= s;
+      }
+    }
+    if (firstError != null) {
+      Error.throwWithStackTrace(firstError, firstStackTrace!);
+    }
   }
+}
+
+/// The container view handed to [UserScopeInstaller]s (#135): registrations
+/// land in the user-session scope; resolution checks the user scope first,
+/// then falls through to the base (per-server) scope, so an installer can
+/// resolve server-lifetime resources and services a preceding user
+/// installer registered through one handle.
+///
+/// Lifecycle is owned by the context — the view exposes no teardown.
+class _UserScopeView implements DependencyContainer {
+  _UserScopeView({
+    required DependencyContainer user,
+    required DependencyContainer Function() base,
+  }) : _user = user,
+       _base = base;
+
+  final DependencyContainer _user;
+
+  /// Getter rather than a captured reference: the base is the swappable
+  /// inner container, resolved at call time.
+  final DependencyContainer Function() _base;
+
+  @override
+  T get<T extends Object>() =>
+      _user.isRegistered<T>() ? _user.get<T>() : _base().get<T>();
+
+  @override
+  bool isRegistered<T extends Object>() =>
+      _user.isRegistered<T>() || _base().isRegistered<T>();
+
+  @override
+  void registerSingleton<T extends Object>(
+    T instance, {
+    FutureOr<void> Function(T instance)? dispose,
+  }) => _user.registerSingleton<T>(instance, dispose: dispose);
+
+  @override
+  void registerLazySingleton<T extends Object>(
+    T Function() factory, {
+    FutureOr<void> Function(T instance)? dispose,
+  }) => _user.registerLazySingleton<T>(factory, dispose: dispose);
+
+  @override
+  void registerFactory<T extends Object>(T Function() factory) =>
+      _user.registerFactory<T>(factory);
+
+  @override
+  Future<void> dispose() {
+    throw UnsupportedError(
+      'The user-scope view must not be disposed by installers; the '
+      'user-session scope lifecycle is owned by the ServerContext (#135).',
+    );
+  }
+}
+
+/// Container-resolvable [UserSessionScope] adapter (#135): the seam the
+/// shell drives on auth transitions, delegating to the owning
+/// [ServerContextImpl]'s user-session lifecycle.
+class _ContextUserSessionScope implements UserSessionScope {
+  _ContextUserSessionScope(this._context);
+
+  final ServerContextImpl _context;
+
+  @override
+  String? get activeUserId => _context.activeUserId;
+
+  @override
+  Future<void> activate(String userId) => _context.activateUserSession(userId);
+
+  @override
+  Future<void> deactivate() => _context.deactivateUserSession();
 }
 
 /// Factory function type for creating [ServerContext] instances.

--- a/packages/core/di/test/server_context_user_session_test.dart
+++ b/packages/core/di/test/server_context_user_session_test.dart
@@ -1,0 +1,470 @@
+import 'package:di/di.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:interfaces/orchestration.dart';
+import 'package:models/domain.dart';
+
+/// Probe registered into the user-session scope by [RecordingUserInstaller];
+/// its dispose callback flips [disposed] so tests can observe scope
+/// teardown (#135).
+class UserProbe {
+  UserProbe(this.userId);
+  final String userId;
+  bool disposed = false;
+}
+
+/// Probe registered into the *base* (per-server) scope so tests can prove
+/// user-session teardown leaves the per-server scope untouched.
+class BaseProbe {
+  bool disposed = false;
+}
+
+/// [ServerScopeInstaller] registering one [BaseProbe] into the per-server
+/// scope.
+class BaseInstaller implements ServerScopeInstaller {
+  final probes = <BaseProbe>[];
+
+  @override
+  Future<void> install(
+    DependencyContainer container,
+    ServerConfig config,
+  ) async {
+    final probe = BaseProbe();
+    probes.add(probe);
+    container.registerSingleton<BaseProbe>(
+      probe,
+      dispose: (p) => p.disposed = true,
+    );
+  }
+}
+
+/// [UserScopeInstaller] that records every install call and registers a
+/// fresh [UserProbe] with a teardown callback.
+class RecordingUserInstaller implements UserScopeInstaller {
+  final installs = <(ServerConfig, String)>[];
+  final probes = <UserProbe>[];
+
+  @override
+  Future<void> install(
+    DependencyContainer container,
+    ServerConfig config,
+    String userId,
+  ) async {
+    installs.add((config, userId));
+    final probe = UserProbe(userId);
+    probes.add(probe);
+    container.registerSingleton<UserProbe>(
+      probe,
+      dispose: (p) => p.disposed = true,
+    );
+  }
+}
+
+/// User installer that resolves a base-scope service before registering —
+/// proving the installer view falls through to the per-server scope.
+class BaseResolvingUserInstaller implements UserScopeInstaller {
+  BaseProbe? resolvedBase;
+
+  @override
+  Future<void> install(
+    DependencyContainer container,
+    ServerConfig config,
+    String userId,
+  ) async {
+    resolvedBase = container.get<BaseProbe>();
+    container.registerSingleton<UserProbe>(UserProbe(userId));
+  }
+}
+
+/// User installer that always throws, for activation-failure paths.
+class FailingUserInstaller implements UserScopeInstaller {
+  var calls = 0;
+
+  @override
+  Future<void> install(
+    DependencyContainer container,
+    ServerConfig config,
+    String userId,
+  ) async {
+    calls++;
+    throw StateError('user installer boom');
+  }
+}
+
+ServerConfig _makeConfig({String id = 'server-local-1'}) => ServerConfig(
+  id: id,
+  displayName: 'Test Server',
+  serverUrl: 'https://api.example.com',
+  connectionState: ConnectionState.disconnected,
+  bgeServerId: '550e8400-e29b-41d4-a716-446655440000',
+  cachedIdentity: ServerIdentity(
+    serverId: '550e8400-e29b-41d4-a716-446655440000',
+    issuer: 'https://api.example.com',
+    wellKnownSchemaVersion: 1,
+    name: 'Test BGE Server',
+    deviceAuthorizationEndpoint: '/api/auth/device',
+    authBasePath: '/api/auth',
+    sessionEndpoint: '/api/auth/get-session',
+    signOutEndpoint: '/api/auth/sign-out',
+    passkeySupported: true,
+    twoFactorSupported: true,
+    anonymousAuthSupported: true,
+  ),
+  lastIdentityFetchedAt: DateTime.now().toUtc(),
+);
+
+void main() {
+  group('UserSessionScope registration', () {
+    test('activation registers a resolvable UserSessionScope seam', () async {
+      final context = ServerContextImpl(config: _makeConfig());
+      addTearDown(context.dispose);
+
+      await context.activate();
+
+      expect(context.container.isRegistered<UserSessionScope>(), isTrue);
+      final scope = context.container.get<UserSessionScope>();
+      expect(scope.activeUserId, isNull);
+    });
+
+    test('the seam is re-registered on a fresh post-suspend scope', () async {
+      final context = ServerContextImpl(config: _makeConfig());
+      addTearDown(context.dispose);
+
+      await context.activate();
+      await context.background();
+      await context.suspend();
+      await context.activate();
+
+      expect(context.container.isRegistered<UserSessionScope>(), isTrue);
+    });
+  });
+
+  group('activateUserSession', () {
+    test('runs user installers with the config and user id, and the '
+        'registered services resolve through context.container', () async {
+      final installer = RecordingUserInstaller();
+      final config = _makeConfig();
+      final context = ServerContextImpl(
+        config: config,
+        userInstallers: [installer],
+      );
+      addTearDown(context.dispose);
+      await context.activate();
+
+      await context.activateUserSession('user-a');
+
+      expect(installer.installs, [(config, 'user-a')]);
+      expect(context.activeUserId, 'user-a');
+      expect(context.container.get<UserSessionScope>().activeUserId, 'user-a');
+      expect(context.container.isRegistered<UserProbe>(), isTrue);
+      expect(context.container.get<UserProbe>().userId, 'user-a');
+    });
+
+    test('the installer view falls through to the per-server scope', () async {
+      final base = BaseInstaller();
+      final userInstaller = BaseResolvingUserInstaller();
+      final context = ServerContextImpl(
+        config: _makeConfig(),
+        installers: [base],
+        userInstallers: [userInstaller],
+      );
+      addTearDown(context.dispose);
+      await context.activate();
+
+      await context.activateUserSession('user-a');
+
+      expect(userInstaller.resolvedBase, same(base.probes.single));
+    });
+
+    test('is idempotent for the already-active user', () async {
+      final installer = RecordingUserInstaller();
+      final context = ServerContextImpl(
+        config: _makeConfig(),
+        userInstallers: [installer],
+      );
+      addTearDown(context.dispose);
+      await context.activate();
+
+      await context.activateUserSession('user-a');
+      await context.activateUserSession('user-a');
+
+      expect(installer.installs, hasLength(1));
+      expect(installer.probes.single.disposed, isFalse);
+    });
+
+    test('a different user replaces the scope: the prior user\'s services '
+        'are disposed and per-user singleton identity differs', () async {
+      final installer = RecordingUserInstaller();
+      final context = ServerContextImpl(
+        config: _makeConfig(),
+        userInstallers: [installer],
+      );
+      addTearDown(context.dispose);
+      await context.activate();
+
+      await context.activateUserSession('user-a');
+      final probeA = context.container.get<UserProbe>();
+
+      await context.activateUserSession('user-b');
+      final probeB = context.container.get<UserProbe>();
+
+      expect(probeA.disposed, isTrue, reason: 'user-a scope must be popped');
+      expect(identical(probeA, probeB), isFalse);
+      expect(probeB.userId, 'user-b');
+      expect(context.activeUserId, 'user-b');
+    });
+
+    test('throws StateError when the context is not active', () async {
+      final context = ServerContextImpl(config: _makeConfig());
+      addTearDown(context.dispose);
+
+      // Never activated: initializing.
+      await expectLater(
+        context.activateUserSession('user-a'),
+        throwsA(isA<StateError>()),
+      );
+
+      await context.activate();
+      await context.background();
+      // Backgrounding is not a session-hosting state either.
+      await expectLater(
+        context.activateUserSession('user-a'),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test('an installer failure discards the partial user scope, leaves the '
+        'base scope intact, and a retry starts clean', () async {
+      final base = BaseInstaller();
+      final failing = FailingUserInstaller();
+      final context = ServerContextImpl(
+        config: _makeConfig(),
+        installers: [base],
+        userInstallers: [failing],
+      );
+      addTearDown(context.dispose);
+      await context.activate();
+
+      await expectLater(
+        context.activateUserSession('user-a'),
+        throwsA(isA<StateError>()),
+      );
+
+      expect(context.activeUserId, isNull);
+      expect(
+        base.probes.single.disposed,
+        isFalse,
+        reason: 'per-server scope must be untouched',
+      );
+      expect(context.container.get<BaseProbe>(), same(base.probes.single));
+      expect(context.state, ServerContextState.active);
+
+      // Retry hits a clean scope (would throw "already active" otherwise).
+      await expectLater(
+        context.activateUserSession('user-a'),
+        throwsA(isA<StateError>()),
+      );
+      expect(failing.calls, 2);
+    });
+  });
+
+  group('deactivateUserSession', () {
+    test('disposes the user scope; per-server services survive', () async {
+      final base = BaseInstaller();
+      final installer = RecordingUserInstaller();
+      final context = ServerContextImpl(
+        config: _makeConfig(),
+        installers: [base],
+        userInstallers: [installer],
+      );
+      addTearDown(context.dispose);
+      await context.activate();
+      await context.activateUserSession('user-a');
+
+      await context.deactivateUserSession();
+
+      expect(installer.probes.single.disposed, isTrue);
+      expect(context.container.isRegistered<UserProbe>(), isFalse);
+      expect(context.activeUserId, isNull);
+      expect(base.probes.single.disposed, isFalse);
+      expect(context.container.get<BaseProbe>(), same(base.probes.single));
+    });
+
+    test('is a no-op without an active session and is idempotent', () async {
+      final context = ServerContextImpl(config: _makeConfig());
+      addTearDown(context.dispose);
+      await context.activate();
+
+      await context.deactivateUserSession();
+      await context.deactivateUserSession();
+
+      expect(context.activeUserId, isNull);
+    });
+
+    test('is a no-op on a disposed context', () async {
+      final context = ServerContextImpl(config: _makeConfig());
+      await context.activate();
+      await context.dispose();
+
+      await expectLater(context.deactivateUserSession(), completes);
+    });
+  });
+
+  group('lifecycle interactions', () {
+    test('background tears the user-session scope down — a server switch '
+        'never emits an auth transition for the departing server, so the '
+        'context must end the session itself (#135 review)', () async {
+      final installer = RecordingUserInstaller();
+      final context = ServerContextImpl(
+        config: _makeConfig(),
+        userInstallers: [installer],
+      );
+      addTearDown(context.dispose);
+      await context.activate();
+      await context.activateUserSession('user-a');
+
+      await context.background();
+
+      expect(
+        installer.probes.single.disposed,
+        isTrue,
+        reason: 'leaving the active state must end the user session',
+      );
+      expect(context.activeUserId, isNull);
+      expect(context.container.isRegistered<UserProbe>(), isFalse);
+
+      // Cheap re-activation (container retained), then the next sign-in
+      // emission rebuilds the session from clean state.
+      await context.activate();
+      await context.activateUserSession('user-a');
+      expect(installer.installs, hasLength(2));
+      expect(context.container.get<UserProbe>().disposed, isFalse);
+    });
+
+    test('deactivateUserSession after background is a harmless no-op — '
+        'the scope already died with the foreground', () async {
+      final installer = RecordingUserInstaller();
+      final context = ServerContextImpl(
+        config: _makeConfig(),
+        userInstallers: [installer],
+      );
+      addTearDown(context.dispose);
+      await context.activate();
+      await context.activateUserSession('user-a');
+
+      await context.background();
+      await expectLater(context.deactivateUserSession(), completes);
+
+      expect(context.activeUserId, isNull);
+    });
+
+    test('a deactivation issued concurrently with a transition is queued, '
+        'never skipped: the caller\'s future completes with the scope '
+        'gone (#135 review)', () async {
+      final installer = RecordingUserInstaller();
+      final context = ServerContextImpl(
+        config: _makeConfig(),
+        userInstallers: [installer],
+      );
+      addTearDown(context.dispose);
+      await context.activate();
+      await context.activateUserSession('user-a');
+
+      // Fire the transition and the deactivation without awaiting in
+      // between — the shared scope-op chain serializes them.
+      final transition = context.background();
+      final deactivation = context.deactivateUserSession();
+      await Future.wait([transition, deactivation]);
+
+      expect(installer.probes.single.disposed, isTrue);
+      expect(
+        context.activeUserId,
+        isNull,
+        reason:
+            'a silently skipped deactivation would leave the '
+            'bookkeeping set and a same-user re-sign-in would reuse a '
+            'stale scope',
+      );
+    });
+
+    test('suspend tears the user-session scope down with the server scope; '
+        'a fresh session can be activated after resume', () async {
+      final installer = RecordingUserInstaller();
+      final context = ServerContextImpl(
+        config: _makeConfig(),
+        userInstallers: [installer],
+      );
+      addTearDown(context.dispose);
+      await context.activate();
+      await context.activateUserSession('user-a');
+
+      await context.background();
+      await context.suspend();
+
+      expect(installer.probes.single.disposed, isTrue);
+      expect(context.activeUserId, isNull);
+
+      await context.activate();
+      await context.activateUserSession('user-a');
+
+      expect(
+        installer.installs,
+        hasLength(2),
+        reason:
+            'post-resume same-user activation must reinstall — the '
+            'prior scope died when the context left the active state',
+      );
+      expect(context.container.get<UserProbe>().disposed, isFalse);
+    });
+
+    test('context.dispose disposes an active user-session scope', () async {
+      final installer = RecordingUserInstaller();
+      final context = ServerContextImpl(
+        config: _makeConfig(),
+        userInstallers: [installer],
+      );
+      await context.activate();
+      await context.activateUserSession('user-a');
+
+      await context.dispose();
+
+      expect(installer.probes.single.disposed, isTrue);
+      expect(context.activeUserId, isNull);
+    });
+
+    test('user-scope registrations shadow a base registration of the same '
+        'type and the base instance resurfaces after deactivation', () async {
+      final shared = UserProbe('base');
+      final context = ServerContextImpl(
+        config: _makeConfig(),
+        installers: [
+          _InlineBaseInstaller((c) => c.registerSingleton<UserProbe>(shared)),
+        ],
+        userInstallers: [RecordingUserInstaller()],
+      );
+      addTearDown(context.dispose);
+      await context.activate();
+
+      expect(context.container.get<UserProbe>(), same(shared));
+
+      await context.activateUserSession('user-a');
+      expect(context.container.get<UserProbe>().userId, 'user-a');
+
+      await context.deactivateUserSession();
+      expect(context.container.get<UserProbe>(), same(shared));
+    });
+  });
+}
+
+/// Adapts a closure into a [ServerScopeInstaller] for one-off base wiring.
+class _InlineBaseInstaller implements ServerScopeInstaller {
+  _InlineBaseInstaller(this._body);
+  final void Function(DependencyContainer container) _body;
+
+  @override
+  Future<void> install(
+    DependencyContainer container,
+    ServerConfig config,
+  ) async {
+    _body(container);
+  }
+}

--- a/packages/core/interfaces/lib/orchestration.dart
+++ b/packages/core/interfaces/lib/orchestration.dart
@@ -6,3 +6,5 @@ export 'src/orchestration/server_context_state.dart';
 export 'src/orchestration/server_context.dart';
 export 'src/orchestration/server_orchestrator.dart';
 export 'src/orchestration/server_scope_installer.dart';
+export 'src/orchestration/user_scope_installer.dart';
+export 'src/orchestration/user_session_scope.dart';

--- a/packages/core/interfaces/lib/src/orchestration/user_scope_installer.dart
+++ b/packages/core/interfaces/lib/src/orchestration/user_scope_installer.dart
@@ -1,0 +1,53 @@
+import 'package:models/domain.dart';
+
+import 'dependency_container.dart';
+
+/// Installs one slice of per-user services into a server's **user-session
+/// scope** during `UserSessionScope.activate()` (#135).
+///
+/// The user-session scope is a child of the per-server scope, keyed by the
+/// (server, user-id-on-that-server) pair: it is pushed when a user
+/// authenticates on that server and popped on any transition out of the
+/// authenticated state (explicit sign-out or a mid-session authentication
+/// loss). Per-user singletons registered here — repositories whose queries
+/// are keyed to the current user, their sync-queue collaborators — are
+/// therefore rebuilt for every user change, so a live query can never keep
+/// serving the previous user's data.
+///
+/// User identity is per-server: the same person signed into two servers has
+/// two independent user-session scopes with distinct [userId]s. Nothing
+/// registered here is shared across server scopes.
+///
+/// This mirrors [ServerScopeInstaller]'s seam role: implementations live
+/// beside the concretes they wire (e.g. `HouseholdScopeInstaller` in
+/// `drift_storage`), and the platform app composes the list it hands to
+/// `ServerContextImpl` — the `di` package stays free of storage and network
+/// dependencies.
+///
+/// ## Contract
+///
+/// - [install] runs against a container **view** whose registrations land in
+///   the user-session scope while resolution falls through to the per-server
+///   scope — so an installer freely resolves server-lifetime resources (the
+///   per-server database, `ClockService`, `AuthRepository`) and registers
+///   per-user services beside them.
+/// - Installers run in list order; an installer may resolve services a
+///   predecessor registered.
+/// - Teardown is expressed at registration time via the container's
+///   `dispose:` callbacks, never through a matching "uninstall" — scope
+///   deactivation disposes the whole user-session scope. Services vending
+///   streams must close them from their dispose path so live subscriptions
+///   stop delivering the departing user's data.
+/// - Throwing from [install] aborts activation: the partial user-session
+///   scope is discarded (the per-server scope is untouched) and the error
+///   propagates to the caller. Installers therefore don't need to clean up
+///   their own partial registrations.
+abstract interface class UserScopeInstaller {
+  /// Wires this installer's per-user services for [userId] on the server
+  /// described by [config] into [container].
+  Future<void> install(
+    DependencyContainer container,
+    ServerConfig config,
+    String userId,
+  );
+}

--- a/packages/core/interfaces/lib/src/orchestration/user_session_scope.dart
+++ b/packages/core/interfaces/lib/src/orchestration/user_session_scope.dart
@@ -1,0 +1,71 @@
+/// Lifecycle seam for a server's per-user dependency scope (#135).
+///
+/// Per-server scopes activate at boot, before sign-in (#128), so any
+/// singleton whose state is keyed to the current user must not live for the
+/// scope's whole life: a live `watch*` subscription that outlived a
+/// same-server sign-out → sign-in would keep serving the previous user's
+/// rows. This seam scopes those services to the *user session* instead — a
+/// child scope of the per-server scope, activated when a user authenticates
+/// and deactivated when that authentication ends.
+///
+/// ## Where it lives
+///
+/// Resolved from the active server's `DependencyContainer`, like any other
+/// per-server service:
+///
+/// ```dart
+/// final scope = active.container.get<UserSessionScope>();
+/// await scope.activate(session.user.id);
+/// ```
+///
+/// - **Native**: registered by `ServerContextImpl` during context
+///   activation; [activate] pushes the user scope and runs the composed
+///   `UserScopeInstaller`s, [deactivate] disposes it.
+/// - **Web** (#137): the web composition root registers its own backing over
+///   the single origin-scoped container. Until it does, the shell treats an
+///   unregistered [UserSessionScope] as "no per-user services on this
+///   platform" and skips the scope step.
+///
+/// The shell's auth listener is the single intended caller: it activates on
+/// any transition into the authenticated state and deactivates on any
+/// transition out of it — explicit sign-out *and* mid-session
+/// authentication loss (token expiry) both end the session scope.
+///
+/// ## Scoping semantics
+///
+/// User identity is per-server. [userId] is the id the *current server*
+/// assigned; the same person on two servers holds two independent session
+/// scopes with distinct ids, and nothing in one is visible to the other.
+///
+/// ## Contract
+///
+/// - [activate] with the [userId] already active is a no-op. [activate]
+///   with a *different* user id first deactivates the existing session
+///   scope, then builds the new one — a missed deactivation can't leak the
+///   prior user's services.
+/// - [activate] throws [StateError] when the backing server scope cannot
+///   host a session (e.g. the native context is not in its active state);
+///   this signals a wiring bug, not a user-facing state.
+/// - If building the scope fails, the partial scope is discarded, the
+///   per-server scope is untouched, and the error propagates; a later
+///   [activate] retries from clean state.
+/// - [deactivate] is idempotent and never throws for "nothing to do";
+///   disposing the scope runs every `dispose:` callback its installers
+///   registered, which must close vended streams (**close**, not error — the
+///   locked #135 contract) so live subscriptions stop delivering the
+///   departing user's data without injecting errors into UI being unmounted.
+/// - Implementations serialize [activate]/[deactivate]; overlapping calls
+///   cannot interleave scope mutations.
+abstract interface class UserSessionScope {
+  /// The user id of the currently active session scope, or null when none
+  /// is active.
+  String? get activeUserId;
+
+  /// Builds the per-user scope for [userId], replacing any existing session
+  /// scope for a different user.
+  Future<void> activate(String userId);
+
+  /// Tears the current per-user scope down, disposing every service
+  /// registered in it. A no-op when no session scope is active.
+  Future<void> deactivate();
+}

--- a/packages/storage/drift_storage/lib/src/composition/household_scope_installer.dart
+++ b/packages/storage/drift_storage/lib/src/composition/household_scope_installer.dart
@@ -7,44 +7,50 @@ import '../databases/server_database.dart';
 import '../repositories/household_repository_impl.dart';
 import '../repositories/sync_queue_repository_impl.dart';
 
-/// [ServerScopeInstaller] for the household write slice (#39).
+/// [UserScopeInstaller] for the household write slice (#39, #135).
 ///
-/// Registers the per-server [SyncQueueRepository] and [HouseholdRepository]
-/// into the scope. Both depend on resources other installers register — the
+/// Registers the per-user [SyncQueueRepository] and [HouseholdRepository]
+/// into the **user-session scope** — the per-user child of the per-server
+/// scope, pushed on sign-in and popped on any transition out of the
+/// authenticated state (#135). Both repositories are keyed to the current
+/// user, so scoping them to the session guarantees a live query can never
+/// outlive a user change: popping the scope disposes them, and the
+/// household repository closes every vended `watch*` stream from its
+/// dispose path.
+///
+/// Both depend on resources the per-server installers register — the
 /// [ServerDatabase] (`StorageScopeInstaller`) and the [ClockService] +
-/// [AuthRepository] (`registerServerNetwork`) — so this installer must run
-/// **after** those: it must be placed **last** in the per-server installer
-/// list, where every dependency it resolves from the container is already
-/// present.
+/// [AuthRepository] (`registerServerNetwork`) — which the user-scope
+/// container view resolves by falling through to the per-server scope, so
+/// this installer has no ordering constraint against them (per-server
+/// scopes install fully before any user session can activate).
 ///
-/// ### User id is resolved lazily (#128)
+/// ### User id resolution stays lazy (#128), now scope-checked (#135)
 ///
-/// Per-server scopes activate during `ServerOrchestrator.initialize()` —
-/// **before** sign-in. The current user id is therefore unknown at
-/// activation and must not be read here. Instead the installer hands
-/// [HouseholdRepositoryImpl] a *provider* ([_resolveUserId]) that reads the
-/// live [AuthRepository.currentAuthState] each time a household action runs.
-/// All household actions sit behind the auth gate, so by the time the
-/// provider is invoked a session exists; if it is ever invoked without one
-/// that is a programmer error and it throws a [StateError] (rather than
-/// silently keying off an empty id).
-///
-/// This replaces the previous eager `getCachedSession()` read that assumed
-/// activation only happened for a signed-in user — false, since activation
-/// runs at boot — and aborted bootstrap when it didn't (#128).
+/// The session's user id is known at install time, but the repository still
+/// receives a *provider* that reads the live [AuthRepository.currentAuthState]
+/// on every household action: in the window between an authentication loss
+/// and the scope pop that follows it, a lazy read fails loudly (a
+/// [StateError]) instead of quietly serving data under a stale identity.
+/// The provider additionally verifies the resolved id matches the id this
+/// scope was built for — a *different* authenticated user under a live
+/// user scope means the scope pop was missed, which must surface as a
+/// wiring bug rather than as cross-user data.
 ///
 /// The `HouseholdRemoteDataSource` the create coordinator also needs is
 /// **not** registered here — it shares the per-server Dio and is registered
 /// in `registerServerNetwork`, beside the resource it depends on. Wiring
-/// this installer into the platform boot list, the create route, and the
-/// `HouseholdLocalizations` delegate happens together in #129.
-class HouseholdScopeInstaller implements ServerScopeInstaller {
+/// this installer into the platform boot's user-installer list, the create
+/// route, and the `HouseholdLocalizations` delegate happens together in
+/// #129.
+class HouseholdScopeInstaller implements UserScopeInstaller {
   const HouseholdScopeInstaller();
 
   @override
   Future<void> install(
     DependencyContainer container,
     ServerConfig config,
+    String userId,
   ) async {
     final db = container.get<ServerDatabase>();
     final clock = container.get<ClockService>();
@@ -53,28 +59,48 @@ class HouseholdScopeInstaller implements ServerScopeInstaller {
     final syncQueue = SyncQueueRepositoryImpl(db, clock);
     container.registerSingleton<SyncQueueRepository>(syncQueue);
 
+    final households = HouseholdRepositoryImpl(
+      db: db,
+      currentUserId: () => _resolveUserId(authRepository, config, userId),
+      syncQueue: syncQueue,
+      clock: clock,
+    );
     container.registerSingleton<HouseholdRepository>(
-      HouseholdRepositoryImpl(
-        db: db,
-        currentUserId: () => _resolveUserId(authRepository, config),
-        syncQueue: syncQueue,
-        clock: clock,
-      ),
+      households,
+      // Close-on-teardown (#135): scope deactivation disposes the
+      // repository, which closes every vended watch stream — live
+      // subscriptions stop delivering the departing user's data without
+      // depending on the UI cancelling them.
+      dispose: (_) => households.onDispose(),
     );
   }
 
-  /// Reads the authenticated user id from [authRepository] at call time.
+  /// Reads the authenticated user id from [authRepository] at call time
+  /// (#128) and verifies it is still [scopeUserId] (#135).
   ///
-  /// Throws a [StateError] if invoked while unauthenticated — unreachable in
-  /// normal use (household actions are gated behind sign-in), so a throw
-  /// here signals a wiring bug, not a user-facing state.
+  /// Throws a [StateError] if invoked while unauthenticated, or if the
+  /// authenticated user is no longer the one this session scope was built
+  /// for. Both are unreachable in normal use — household actions are gated
+  /// behind sign-in and the shell pops the scope on every authentication
+  /// transition — so a throw here signals a wiring bug, not a user-facing
+  /// state.
   static String _resolveUserId(
     AuthRepository authRepository,
     ServerConfig config,
+    String scopeUserId,
   ) {
     final state = authRepository.currentAuthState;
     if (state is AuthStateAuthenticated) {
-      return state.session.user.id;
+      final id = state.session.user.id;
+      if (id != scopeUserId) {
+        throw StateError(
+          'A household action ran for server "${config.bgeServerId}" under '
+          'a user-session scope built for "$scopeUserId", but the '
+          'authenticated user is now "$id". The scope must be deactivated '
+          'on every authentication transition (#135).',
+        );
+      }
+      return id;
     }
     throw StateError(
       'A household action ran for server "${config.bgeServerId}" without an '

--- a/packages/storage/drift_storage/lib/src/repositories/household_repository_impl.dart
+++ b/packages/storage/drift_storage/lib/src/repositories/household_repository_impl.dart
@@ -1,5 +1,8 @@
+import 'dart:async';
+
 import 'package:cuid2/cuid2.dart';
 import 'package:drift/drift.dart';
+import 'package:interfaces/orchestration.dart';
 import 'package:interfaces/repositories.dart';
 import 'package:interfaces/services.dart';
 import 'package:models/domain.dart';
@@ -18,8 +21,13 @@ import '../databases/server_database.dart';
 /// resolve it once when the subscription begins — surfacing an
 /// unauthenticated state as a *stream* error, not a synchronous throw —
 /// and do not re-resolve if the authenticated user changes under a live
-/// subscription; tearing per-user state down on sign-out is a separate,
-/// scope-lifecycle concern (#135). Every read path that
+/// subscription. That is safe because the repository lives in the
+/// per-user session scope (#135): every authentication transition pops
+/// the scope, which disposes this repository ([Disposable]), and disposal
+/// **closes** every vended `watch*` stream — so a subscription can never
+/// keep serving the previous user's rows. After disposal all methods
+/// throw [StateError] and fresh `watch*` calls return already-closed
+/// streams. Every read path that
 /// returns household data — list, single-by-id, watch, member list,
 /// member watch — gates on the current user being a member of the
 /// household in question AND on the household itself being live
@@ -93,7 +101,7 @@ import '../databases/server_database.dart';
 /// Until then the conservative "members-only" rule applies, matching
 /// the auth contract the server-side `HouseholdsService` enforces
 /// today.
-class HouseholdRepositoryImpl implements HouseholdRepository {
+class HouseholdRepositoryImpl implements HouseholdRepository, Disposable {
   /// [syncQueue] MUST be backed by the same [db] instance for [create]'s
   /// "one transaction" guarantee to hold: the enqueue runs inside
   /// `db.transaction(...)` and only joins that transaction when it writes to
@@ -128,8 +136,96 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
   /// server.
   final ClockService _clock;
 
+  /// Set once by [onDispose]; guards every public method (#135).
+  bool _disposed = false;
+
+  /// Live source (Drift) subscriptions behind vended watch streams,
+  /// tracked so [onDispose] can cancel them and *await* the cancellation
+  /// (#135): the suspend path closes the [ServerDatabase] right after this
+  /// repository's dispose callback returns, so Drift teardown must have
+  /// fully completed by then, not merely started.
+  final Set<StreamSubscription<dynamic>> _watchSubscriptions = {};
+
+  /// The outer controllers paired with [_watchSubscriptions], closed on
+  /// [onDispose] so every vended stream ends with a done event — the
+  /// locked close-not-error contract.
+  final Set<MultiStreamController<dynamic>> _watchControllers = {};
+
+  /// Tears this repository down when its user-session scope pops (#135):
+  /// wired by `HouseholdScopeInstaller` as the registration's `dispose:`
+  /// callback. Cancels every live source subscription (awaiting Drift's
+  /// teardown before returning — the per-server DB may close immediately
+  /// after), closes every vended `watch*` stream, and fails all later
+  /// calls loudly. Idempotent.
+  @override
+  Future<void> onDispose() async {
+    if (_disposed) return;
+    _disposed = true;
+
+    final subscriptions = List.of(_watchSubscriptions);
+    _watchSubscriptions.clear();
+    await Future.wait(subscriptions.map((sub) => sub.cancel()));
+
+    final controllers = List.of(_watchControllers);
+    _watchControllers.clear();
+    for (final controller in controllers) {
+      controller.close();
+    }
+  }
+
+  void _checkNotDisposed() {
+    if (_disposed) {
+      throw StateError(
+        'HouseholdRepository has been disposed — its user-session scope '
+        'was torn down (#135). Resolve a fresh instance from the active '
+        'user session.',
+      );
+    }
+  }
+
+  /// Wraps a `watch*` [source] so the returned stream **closes** when this
+  /// repository is disposed (#135), regardless of whether the subscriber
+  /// ever cancels. Drift streams are tied to the database — which is
+  /// per-server and outlives the user session — so without this wrapper a
+  /// subscription taken under one user would keep emitting after the scope
+  /// pop. [source] is invoked lazily per listener, preserving the async*
+  /// bodies' contract of delivering an unauthenticated user id as a
+  /// stream error rather than a synchronous throw.
+  ///
+  /// Each listener's source subscription and outer controller are tracked
+  /// for [onDispose]; both deregister on their own done/cancel so the
+  /// tracking sets only ever hold live entries. `onCancel` returns the
+  /// source cancellation future so a subscriber's `cancel()` also awaits
+  /// Drift teardown.
+  Stream<T> _untilDisposed<T>(Stream<T> Function() source) {
+    return Stream<T>.multi((controller) {
+      if (_disposed) {
+        controller.close();
+        return;
+      }
+      late final StreamSubscription<T> sub;
+      sub = source().listen(
+        controller.add,
+        onError: controller.addError,
+        onDone: () {
+          _watchSubscriptions.remove(sub);
+          _watchControllers.remove(controller);
+          controller.close();
+        },
+      );
+      _watchSubscriptions.add(sub);
+      _watchControllers.add(controller);
+      controller.onCancel = () {
+        _watchSubscriptions.remove(sub);
+        _watchControllers.remove(controller);
+        return sub.cancel();
+      };
+    });
+  }
+
   @override
   Future<List<Household>> getHouseholds() async {
+    _checkNotDisposed();
     final rows = await _householdsQuery(_currentUserId()).get();
     return rows
         .map((r) => _mapHousehold(r.readTable(_db.householdsTable)))
@@ -138,6 +234,7 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
 
   @override
   Future<Household?> getHousehold(String householdId) async {
+    _checkNotDisposed();
     final query =
         _db.select(_db.householdsTable).join([
           innerJoin(
@@ -160,6 +257,7 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
 
   @override
   Future<List<HouseholdMember>> getMembers(String householdId) async {
+    _checkNotDisposed();
     final rows = await _membersQuery(householdId, _currentUserId()).get();
     return rows
         .map((r) => _mapMember(r.readTable(_db.householdMembersTable)))
@@ -168,6 +266,7 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
 
   @override
   Future<HouseholdMember?> getCurrentUserMember(String householdId) async {
+    _checkNotDisposed();
     final userId = _currentUserId();
     final row =
         await (_db.select(_db.householdMembersTable)..where(
@@ -180,6 +279,7 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
 
   @override
   Future<void> cacheHousehold(Household household) async {
+    _checkNotDisposed();
     await _db
         .into(_db.householdsTable)
         .insertOnConflictUpdate(
@@ -199,6 +299,7 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
 
   @override
   Future<void> cacheMember(HouseholdMember member) async {
+    _checkNotDisposed();
     await _db
         .into(_db.householdMembersTable)
         .insertOnConflictUpdate(_memberToCompanion(member));
@@ -206,6 +307,7 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
 
   @override
   Future<void> cacheMembers(List<HouseholdMember> members) async {
+    _checkNotDisposed();
     await _db.batch((b) {
       for (final m in members) {
         b.insert(
@@ -227,6 +329,7 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
     String? language,
     String? visibility,
   }) async {
+    _checkNotDisposed();
     // Validate BEFORE opening the transaction so the cache and the sync
     // queue stay untouched on bad input.
     final trimmedName = name.trim();
@@ -301,6 +404,7 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
     required String localId,
     String? completedSyncQueueId,
   }) async {
+    _checkNotDisposed();
     return _db.transaction(() async {
       // 1. Upsert the server-confirmed household (canonical id, flags
       //    cleared). Done first so the members FK target exists before
@@ -335,7 +439,10 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
   }
 
   @override
-  Stream<List<Household>> watchHouseholds() async* {
+  Stream<List<Household>> watchHouseholds() =>
+      _untilDisposed(_watchHouseholdsSource);
+
+  Stream<List<Household>> _watchHouseholdsSource() async* {
     // Resolve inside the async* body: an unauthenticated [_currentUserId]
     // throw surfaces as a stream error the caller can observe (StreamBuilder,
     // handleError, bloc onError), not a synchronous throw at subscribe time.
@@ -348,9 +455,13 @@ class HouseholdRepositoryImpl implements HouseholdRepository {
   }
 
   @override
-  Stream<List<HouseholdMember>> watchMembers(String householdId) async* {
-    // See [watchHouseholds]: resolve inside the body so an unauthenticated
-    // throw is delivered as a stream error, not synchronously at subscribe.
+  Stream<List<HouseholdMember>> watchMembers(String householdId) =>
+      _untilDisposed(() => _watchMembersSource(householdId));
+
+  Stream<List<HouseholdMember>> _watchMembersSource(String householdId) async* {
+    // See [_watchHouseholdsSource]: resolve inside the body so an
+    // unauthenticated throw is delivered as a stream error, not
+    // synchronously at subscribe.
     final userId = _currentUserId();
     yield* _membersQuery(householdId, userId).watch().map(
       (rows) => rows

--- a/packages/storage/drift_storage/test/composition/household_scope_installer_test.dart
+++ b/packages/storage/drift_storage/test/composition/household_scope_installer_test.dart
@@ -57,10 +57,10 @@ class _FakeAuthRepository implements AuthRepository {
   Stream<AuthState> watchAuthState() => throw UnimplementedError();
 }
 
-AuthResponse _session() => AuthResponse(
+AuthResponse _session({String userId = _kUserId}) => AuthResponse(
   token: 'tok',
   user: AuthUser(
-    id: _kUserId,
+    id: userId,
     username: 'tester',
     email: 'tester@example.com',
     emailVerified: true,
@@ -104,7 +104,8 @@ ServerConfig _config() => ServerConfig(
 /// Builds a scope container carrying the three resources the installer
 /// resolves — the [ServerDatabase], the [ClockService] and the
 /// [AuthRepository] — mirroring what `StorageScopeInstaller` /
-/// `registerServerNetwork` register ahead of this installer in production.
+/// `registerServerNetwork` register in the per-server scope, which the
+/// user-scope view falls through to in production (#135).
 DependencyContainer _scopeContainer(AuthRepository auth) {
   final db = ServerDatabase.memory();
   return DependencyContainerImpl()
@@ -118,22 +119,20 @@ DependencyContainer _scopeContainer(AuthRepository auth) {
 void main() {
   const installer = HouseholdScopeInstaller();
 
-  test(
-    'installs without a session — activation runs before sign-in (#128)',
-    () async {
-      final container = _scopeContainer(
-        _FakeAuthRepository(const AuthStateUnknown()),
-      );
-      addTearDown(container.dispose);
+  test('install never reads the auth state itself — resolution stays lazy '
+      '(#128), so it succeeds under an unknown state', () async {
+    final container = _scopeContainer(
+      _FakeAuthRepository(const AuthStateUnknown()),
+    );
+    addTearDown(container.dispose);
 
-      // The eager getCachedSession() read this replaces would have thrown
-      // here; the lazy provider defers resolution, so install succeeds.
-      await installer.install(container, _config());
+    // An eager session read would throw here; the lazy provider defers
+    // resolution, so install succeeds regardless of the live auth state.
+    await installer.install(container, _config(), _kUserId);
 
-      expect(container.isRegistered<HouseholdRepository>(), isTrue);
-      expect(container.isRegistered<SyncQueueRepository>(), isTrue);
-    },
-  );
+    expect(container.isRegistered<HouseholdRepository>(), isTrue);
+    expect(container.isRegistered<SyncQueueRepository>(), isTrue);
+  });
 
   test(
     'the registered repository resolves the live user id at call time',
@@ -142,7 +141,7 @@ void main() {
         _FakeAuthRepository(AuthStateAuthenticated(session: _session())),
       );
       addTearDown(container.dispose);
-      await installer.install(container, _config());
+      await installer.install(container, _config(), _kUserId);
 
       final repo = container.get<HouseholdRepository>();
 
@@ -159,7 +158,7 @@ void main() {
         _FakeAuthRepository(const AuthStateUnauthenticated()),
       );
       addTearDown(container.dispose);
-      await installer.install(container, _config());
+      await installer.install(container, _config(), _kUserId);
 
       final repo = container.get<HouseholdRepository>();
 
@@ -173,7 +172,7 @@ void main() {
     );
     final container = _scopeContainer(auth);
     addTearDown(container.dispose);
-    await installer.install(container, _config());
+    await installer.install(container, _config(), _kUserId);
     final repo = container.get<HouseholdRepository>();
 
     await expectLater(repo.getHouseholds(), completion(isEmpty));
@@ -186,13 +185,35 @@ void main() {
   });
 
   test(
+    'an authenticated user who is not the scope user throws — a missed '
+    'scope pop must fail loudly, never serve cross-user data (#135)',
+    () async {
+      final auth = _FakeAuthRepository(
+        AuthStateAuthenticated(session: _session()),
+      );
+      final container = _scopeContainer(auth);
+      addTearDown(container.dispose);
+      await installer.install(container, _config(), _kUserId);
+      final repo = container.get<HouseholdRepository>();
+
+      // A different user authenticates while the old user scope is somehow
+      // still live (the shell failed to pop it).
+      auth.authState = AuthStateAuthenticated(
+        session: _session(userId: 'user-someone-else'),
+      );
+
+      await expectLater(repo.getHouseholds(), throwsA(isA<StateError>()));
+    },
+  );
+
+  test(
     'watch* deliver an unauthenticated id as a stream error, not a throw',
     () async {
       final container = _scopeContainer(
         _FakeAuthRepository(const AuthStateUnauthenticated()),
       );
       addTearDown(container.dispose);
-      await installer.install(container, _config());
+      await installer.install(container, _config(), _kUserId);
       final repo = container.get<HouseholdRepository>();
 
       // Invoking the watch methods must not throw synchronously; the
@@ -205,4 +226,27 @@ void main() {
       );
     },
   );
+
+  test('disposing the container closes a live watch stream — the dispose '
+      'wiring behind close-on-scope-pop (#135)', () async {
+    final container = _scopeContainer(
+      _FakeAuthRepository(AuthStateAuthenticated(session: _session())),
+    );
+    await installer.install(container, _config(), _kUserId);
+    final repo = container.get<HouseholdRepository>();
+
+    var done = false;
+    final sub = repo.watchHouseholds().listen(
+      (_) {},
+      onDone: () => done = true,
+    );
+    addTearDown(sub.cancel);
+    await pumpEventQueue();
+    expect(done, isFalse);
+
+    await container.dispose();
+    await pumpEventQueue();
+
+    expect(done, isTrue);
+  });
 }

--- a/packages/storage/drift_storage/test/composition/household_user_session_acceptance_test.dart
+++ b/packages/storage/drift_storage/test/composition/household_user_session_acceptance_test.dart
@@ -1,0 +1,258 @@
+import 'dart:async';
+
+import 'package:di/di.dart';
+import 'package:drift_storage/drift_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:interfaces/orchestration.dart';
+import 'package:interfaces/repositories.dart';
+import 'package:interfaces/services.dart';
+import 'package:models/domain.dart';
+import 'package:models/dto.dart';
+
+import '../support/fixed_clock.dart';
+
+/// #135 acceptance, full-stack over the real context + installer + Drift DB:
+///
+/// 1. A live `watchHouseholds()` subscription across a same-server
+///    sign-out → sign-in stops emitting the prior user's data (the stream
+///    **closes** when the user-session scope pops — the locked contract).
+/// 2. Per-user singletons are rebuilt after a user change: the repository
+///    resolved under user B is a different instance, and user A's
+///    households are invisible to it.
+
+const _kUserA = 'user-a';
+const _kUserB = 'user-b';
+const _kServerId = 'server-uuid-1';
+const _kAuthBase = '/api/auth';
+
+class _FakeAuthRepository implements AuthRepository {
+  _FakeAuthRepository(this._state);
+
+  AuthState _state;
+
+  set authState(AuthState next) => _state = next;
+
+  @override
+  AuthState get currentAuthState => _state;
+
+  @override
+  Future<AuthResponse?> getSession() => throw UnimplementedError();
+
+  @override
+  Future<AuthResponse?> getCachedSession() => throw UnimplementedError();
+
+  @override
+  Future<void> signOut() => throw UnimplementedError();
+
+  @override
+  Future<AuthResponse> signIn({
+    required String email,
+    required String password,
+  }) => throw UnimplementedError();
+
+  @override
+  Future<AuthResponse> signUp({
+    required String email,
+    required String password,
+    required String username,
+    String? firstName,
+    String? lastName,
+  }) => throw UnimplementedError();
+
+  @override
+  Stream<AuthState> watchAuthState() => throw UnimplementedError();
+}
+
+AuthResponse _session(String userId) => AuthResponse(
+  token: 'tok-$userId',
+  user: AuthUser(
+    id: userId,
+    username: 'tester-$userId',
+    email: '$userId@example.com',
+    emailVerified: true,
+    createdAt: DateTime.utc(2024),
+    updatedAt: DateTime.utc(2024),
+  ),
+  expiresAt: DateTime.utc(2099),
+);
+
+AuthState _authenticated(String userId) =>
+    AuthStateAuthenticated(session: _session(userId));
+
+ServerIdentity _identity() => ServerIdentity(
+  serverId: _kServerId,
+  issuer: 'https://api.example.com',
+  wellKnownSchemaVersion: 1,
+  name: 'Test BGE Server',
+  deviceAuthorizationEndpoint: '$_kAuthBase/device',
+  authBasePath: _kAuthBase,
+  sessionEndpoint: '$_kAuthBase/get-session',
+  signOutEndpoint: '$_kAuthBase/sign-out',
+  passkeySupported: false,
+  twoFactorSupported: false,
+  anonymousAuthSupported: false,
+  strategies: const [
+    EmailAndPasswordStrategy(
+      signUpDisabled: false,
+      signInEndpoint: '$_kAuthBase/sign-in/email',
+      signUpEndpoint: '$_kAuthBase/sign-up/email',
+    ),
+  ],
+);
+
+ServerConfig _config() => ServerConfig(
+  id: 'local-1',
+  displayName: 'My Server',
+  serverUrl: 'https://api.example.com',
+  connectionState: ConnectionState.active,
+  bgeServerId: _kServerId,
+  cachedIdentity: _identity(),
+  lastIdentityFetchedAt: DateTime.utc(2024),
+);
+
+/// Registers the three per-server resources the household installer
+/// resolves, mirroring what `StorageScopeInstaller` / `registerServerNetwork`
+/// register ahead of any user session in production.
+class _BaseFixtureInstaller implements ServerScopeInstaller {
+  _BaseFixtureInstaller(this._auth);
+  final AuthRepository _auth;
+
+  @override
+  Future<void> install(
+    DependencyContainer container,
+    ServerConfig config,
+  ) async {
+    container.registerSingleton<ServerDatabase>(
+      ServerDatabase.memory(),
+      dispose: (db) => db.close(),
+    );
+    container.registerSingleton<ClockService>(
+      FixedClockService(DateTime.utc(2024, 1, 15, 10, 30)),
+    );
+    container.registerSingleton<AuthRepository>(_auth);
+  }
+}
+
+void main() {
+  late _FakeAuthRepository auth;
+  late ServerContextImpl context;
+  late UserSessionScope session;
+
+  setUp(() async {
+    auth = _FakeAuthRepository(const AuthStateUnknown());
+    context = ServerContextImpl(
+      config: _config(),
+      installers: [_BaseFixtureInstaller(auth)],
+      userInstallers: const [HouseholdScopeInstaller()],
+    );
+    await context.activate();
+    session = context.container.get<UserSessionScope>();
+  });
+
+  tearDown(() => context.dispose());
+
+  Future<void> signIn(String userId) async {
+    auth.authState = _authenticated(userId);
+    await session.activate(userId);
+  }
+
+  Future<void> signOut() async {
+    auth.authState = const AuthStateUnauthenticated();
+    await session.deactivate();
+  }
+
+  test('a live watchHouseholds subscription closes on sign-out and the '
+      'rebuilt scope serves only the new user\'s data', () async {
+    await signIn(_kUserA);
+    final repoA = context.container.get<HouseholdRepository>();
+    await repoA.create(name: 'Alpha Household');
+
+    final emissions = <List<Household>>[];
+    final errors = <Object>[];
+    var done = false;
+    final sub = repoA.watchHouseholds().listen(
+      emissions.add,
+      onError: errors.add,
+      onDone: () => done = true,
+    );
+    addTearDown(sub.cancel);
+
+    await pumpEventQueue();
+    expect(emissions, isNotEmpty);
+    expect(emissions.last.single.name, 'Alpha Household');
+    final countBeforeSignOut = emissions.length;
+
+    // Same-server sign-out: the scope pop must CLOSE the live stream
+    // (not error it) — acceptance criterion 1.
+    await signOut();
+    await pumpEventQueue();
+
+    expect(done, isTrue, reason: 'scope pop must close vended streams');
+    expect(errors, isEmpty, reason: 'close-on-pop, never error-on-pop');
+    expect(
+      emissions.length,
+      countBeforeSignOut,
+      reason: 'no further data after the pop',
+    );
+
+    // Same-server sign-in as a different user: per-user singletons are
+    // rebuilt — acceptance criterion 2.
+    await signIn(_kUserB);
+    final repoB = context.container.get<HouseholdRepository>();
+    expect(identical(repoA, repoB), isFalse);
+
+    // The shared per-server DB still holds user A's rows, but the
+    // membership read gate hides them from user B.
+    await expectLater(repoB.watchHouseholds().first, completion(isEmpty));
+    await expectLater(repoB.getHouseholds(), completion(isEmpty));
+  });
+
+  test('the disposed repository fails loudly instead of serving the '
+      'departed user', () async {
+    await signIn(_kUserA);
+    final repoA = context.container.get<HouseholdRepository>();
+    await repoA.create(name: 'Alpha Household');
+
+    await signOut();
+
+    await expectLater(repoA.getHouseholds(), throwsA(isA<StateError>()));
+    await expectLater(
+      repoA.create(name: 'Too Late'),
+      throwsA(isA<StateError>()),
+    );
+    // A fresh watch on the disposed instance closes immediately.
+    await expectLater(repoA.watchHouseholds(), emitsDone);
+  });
+
+  test('watchMembers subscriptions close on sign-out too', () async {
+    await signIn(_kUserA);
+    final repoA = context.container.get<HouseholdRepository>();
+    final created = await repoA.create(name: 'Alpha Household');
+
+    var done = false;
+    final sub = repoA
+        .watchMembers(created.household.id)
+        .listen((_) {}, onDone: () => done = true);
+    addTearDown(sub.cancel);
+    await pumpEventQueue();
+
+    await signOut();
+    await pumpEventQueue();
+
+    expect(done, isTrue);
+  });
+
+  test('per-server services survive the session pop', () async {
+    await signIn(_kUserA);
+    await signOut();
+
+    // The base scope is untouched: the DB and the session seam remain
+    // registered and usable for the next sign-in.
+    expect(context.container.isRegistered<ServerDatabase>(), isTrue);
+    expect(context.container.isRegistered<UserSessionScope>(), isTrue);
+    expect(context.container.isRegistered<HouseholdRepository>(), isFalse);
+
+    await signIn(_kUserB);
+    expect(context.container.isRegistered<HouseholdRepository>(), isTrue);
+  });
+}


### PR DESCRIPTION
Introduces UserSessionScope/UserScopeInstaller (core/interfaces) and wires them through ServerContextImpl's _SwappableContainer as a child scope: registrations land in the user scope, resolution falls through to the per-server scope, so per-user singletons rebuild on every sign-in and are disposed on any transition out of authenticated state.

- ServerContextImpl: activateUserSession/deactivateUserSession, serialized with state transitions on one chain; background() ends the session (a server switch never emits an auth transition for the departing server); suspend/dispose tear it down with the container.
- HouseholdScopeInstaller moves from the per-server to the user tier; HouseholdRepositoryImpl implements Disposable, closing (not erroring) every vended watch* stream on scope pop, and awaits source subscription cancellation before onDispose() returns.
- Shell: _AuthScope drives the scope from the auth listener. Sign-in activates before the gate advances, and a failed activation signs the user out rather than stranding a session without services. Sign-out routes home away first, then pops the scope, so no live widget can dispatch into a disposed repository.

Tests: ServerContextImpl user-session lifecycle (core/di), full-stack sign-out/sign-in acceptance over a real Drift DB (drift_storage), and shell wiring including failure and ordering cases (app_shell).

Web parity deferred to #137; wiring the household installer into the production user-installer list is deferred to #129 (heads-up posted there). Sync-queue user-awareness gap filed as #138.

Refs #135, #137, #129, #138

## Summary by Sourcery

Introduce a per-user session dependency scope nested under the per-server scope and drive its lifecycle from authentication transitions so user-scoped services are rebuilt on sign-in and torn down on sign-out or server background/suspend.

New Features:
- Add UserSessionScope and UserScopeInstaller abstractions to support per-user dependency scopes on top of per-server contexts.
- Expose user-session lifecycle controls on ServerContextImpl and a container facade that supports a child user scope with fall-through resolution to the base scope.

Enhancements:
- Move household storage wiring from the per-server scope into the per-user session scope and make HouseholdRepositoryImpl disposable, closing live streams and guarding operations after teardown.
- Serialize all server state transitions and user-session operations on a single chain to avoid races between auth-driven scope changes and context lifecycle events.
- Update the shell auth listener to activate the user-session scope before routing into authenticated UI and to deactivate it after routing away on sign-out, with robust handling of missing seams and activation/deactivation failures.

Tests:
- Add server_context_user_session_test to cover user-session lifecycle, scope interaction with context state changes, and container scoping semantics.
- Add bge_app_user_session_wiring_test to validate shell wiring of the UserSessionScope across various auth flows, including failure and ordering behavior.
- Add household_user_session_acceptance_test to exercise full-stack behavior of household repositories across sign-out/sign-in cycles over a real Drift database.
- Extend household_scope_installer tests to cover the new per-user installer contract, lazy and scope-checked user-id resolution, and stream-closing behavior on disposal.